### PR TITLE
Add function to walk headlines of current file

### DIFF
--- a/README.org
+++ b/README.org
@@ -59,7 +59,7 @@ This package might evolve into a multi-.el project.
     =:PUBLISHDATE:= property exists.
   - [ ] Ability to set/toggle =:DRAFT: true= in property drawer. Of
     course that should translate to hugo post fm.
-- [ ] Function to re-export the whole org file to subtree-specific
+- [X] Function to re-export the whole org file to subtree-specific
   markdown files
 - [ ] Use =org-capture= to generate new posts in a pre-defined "blog
   posts org file". That step should also auto-insert the meta-data

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -272,6 +272,26 @@ Return output file's name."
     (org-export-to-file 'hugo outfile async subtreep visible-only)))
 
 ;;;###autoload
+(defun org-hugo-walk-headlines ()
+  "Publish each 1st-level headline to hugo-mode"
+  (interactive)
+  (org-map-entries
+   '(lambda ()
+      (let* ((entry (org-element-at-point))
+             (level (org-element-property :level (org-element-at-point)))
+             (commentedp (org-element-property :commentedp headline))
+             (tags (org-element-property :tags headline))))
+      (if (and  (eq 1 level)
+                (member "noexport" tags)
+                (not commentedp))
+          (org-hugo-export-to-md nil t))))
+  ;; (org-publish-subtrees-to
+  ;;  (quote hugo) (buffer-file-name)
+  ;;  md nil
+  ;;  (concat (file-name-as-directory hugo-content-dir) hugo-section))
+  )
+
+;;;###autoload
 (defun org-hugo-publish-to-md (plist filename pub-dir)
   "Publish an org file to Markdown.
 


### PR DESCRIPTION
- add org-hugo-walk-headlines
- exports each 1st-level headline to a hugo entry.
- primitive with no error testing or finer controls
- should definitely be improved!!