### PR TITLE
Escape any double quote already in value when wrapping it in quotes

### DIFF
--- a/example-site/content-org/all-posts.org
+++ b/example-site/content-org/all-posts.org
@@ -132,6 +132,14 @@ Something 2.1
 ** Foo ( Bar ) Baz
 ** (Foo)Bar.Baz&Zoo
 ** Hey! I have a link [[https://example.org][here]] (Awesome!)
+* Awesome title with "quoted text"
+:PROPERTIES:
+:EXPORT_FILE_NAME: post-title-quotes
+:EXPORT_DATE: 2017-07-22T13:46:33-04:00
+:END:
+
+Testing a post with quotes in the title
+
 * Excluded post                                                    :noexport:
 :PROPERTIES:
 :EXPORT_FILE_NAME: excluded-post

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -609,7 +609,7 @@ string with just alphanumeric characters."
          (string-match-p "\\`[a-zA-Z0-9]+\\'" val))
     val)
    (t
-    (concat "\"" val "\""))))
+    (concat "\"" (replace-regexp-in-string "\"" "\\\\\""  val) "\""))))
 
 (defun org-hugo--parse-menu-prop-to-alist (str)
   "Return an alist converted from a string STR of Hugo menu properties.


### PR DESCRIPTION
Toml front matter is unparseable when a post title has a " in it.  This PR fixes that.