### PR TITLE
Use org-map-entries for index computation of a post

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -896,19 +896,12 @@ If the point is not in a valid Hugo post subtree, nil is returned."
                         subtree
                       (org-hugo--get-valid-subtree)))
              (level (org-element-property :level entry))
-             (index 0))
+             (index 0)
+             (current-pos (point)))
         (when level
-          (let ((curr-line (line-number-at-pos))
-                prev-line)
-            (catch 'break
-              (while :infinite
-                (if (and prev-line
-                         (= curr-line prev-line))
-                    (throw 'break nil)
-                  (setq prev-line curr-line)
-                  (org-backward-heading-same-level 1)
-                  (setq curr-line (line-number-at-pos))
-                  (setq index (1+ index))))))
+          (org-map-entries
+           (lambda () (when (< (point) current-pos)
+                        (setq index (1+ index)))) "EXPORT_FILE_NAME<>\"\"")
           (cons level index))))))
 
 ;;; Interactive functions


### PR DESCRIPTION
The index computation of a post can be really slow in a big blog for a
subtree at the bottom of the tree.  This commit implements the index
computation using `org-map-entries` making it much faster for the
average case for a large-ish blog, but slightly slower for the initial
few posts in the blog.

For instance, I have a blog with about 350 posts (17k lines long all-posts.org)
- Exporting the last subtree in this file takes about 20s !
- Exporting the first post is pretty quick (under 1s and pretty quick)

With this change every post exports in about the same time - somewhere between 1 - 2s (again didn't time it precisely). For another perspective to look at this, post `#40` (2.7k lines from the top) takes about the same time to export with both these implementations. 