### PR TITLE
scope org-hugo-export-subtree-to-md to ignore commented trees

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1606,7 +1606,7 @@ nil."
                                ;; Export only the subtrees where
                                ;; EXPORT_FILE_NAME property is not
                                ;; empty.
-                               "EXPORT_FILE_NAME<>\"\"")
+                                "EXPORT_FILE_NAME<>\"\"" nil "comment")
               (message "[ox-hugo] Exported %d subtrees" org-hugo--subtree-count)
               nil)
           ;; Publish only the current subtree


### PR DESCRIPTION
Hi, I'm back and man does ox-hugo look fabulous! Still exploring, but finally getting to use it a bit.

This is a one-line fix to ignore commented trees when exporting all
subtrees. I'd also like to ignore org-export-exclude-tags but I'm not
sure how to scope org-map-entries properly.