### PR TITLE
Updated cf-learn.info URL to https

### DIFF
--- a/doc/data/users.toml
+++ b/doc/data/users.toml
@@ -113,7 +113,7 @@
   source = "https://github.com/zzamboni/cf-learn.info"
   branch = "master"
   org_dir = "content-org"
-  site = "http://cf-learn.info/"
+  site = "https://cf-learn.info/"
 
 [xianmin]
   author = "Xianmin Chen"


### PR DESCRIPTION
I have migrated my https://cf-learn.info/ website to Netlify as well, and now it enforces SSL connections.