### PR TITLE
Add org-hugo-suppress-lastmod-period

### DIFF
--- a/doc/data/users.toml
+++ b/doc/data/users.toml
@@ -323,6 +323,20 @@
   site = "https://infotics.es"
   hosting = "gitea"
 
+[emacscast]
+  author = "Rakhim Davletkaliyev"
+  source = "https://github.com/freetonik/emacscast.org"
+  branch = "master"
+  org_dir = "content-org"
+  site = "https://emacscast.org/"
+  
+[rakhim]
+  author = "Rakhim Davletkaliyev"
+  source = "https://github.com/freetonik/rakhim.org"
+  branch = "master"
+  org_dir = "content-org"
+  site = "https://rakhim.org/"
+
 # []
 #   author = ""
 #   source = ""

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -985,6 +985,29 @@ Examples of RFC3339-compatible values for this variable:
 
 Do =C-h v org-hugo-date-format= for more information (within Emacs,
 once the =ox-hugo= package is loaded).
+
+***** =org-hugo-suppress-lastmod-period==
+ - Default value :: =0.0=
+
+A suppressing period not to write the =lastmod= item in the front matter.
+
+This variable is used to control the duration of the suppressing
+period. If the value is 86400.0, the =lastmod= item will not be added to
+the front matter within 24 hours from the initial exporting.
+
+=lastmod= would be exported when you initially change the Org TODO
+state to =DONE= by saving the file automatically with the following
+conditions. Some users may not prefer this behavior.
+
+| Variable                         | Value |
+|----------------------------------+-------|
+| org-hugo-auto-set-lastmod        | t     |
+| org-hugo-auto-export-on-save     | t     |
+| org-log-done                     | time  |
+
+In such case, you can suppress =lastmod= in the front matter if you set
+=org-hugo-suppress-lastmod-period= to =60.0= or other appropriate value.
+
 **** File-based Exports
 :PROPERTIES:
 :CUSTOM_ID: dates-file-based-exports

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -1008,6 +1008,9 @@ conditions. Some users may not prefer this behavior.
 In such case, you can suppress =lastmod= in the front matter if you set
 =org-hugo-suppress-lastmod-period= to =60.0= or other appropriate value.
 
+Note that to enable this feature, set =org-hugo-auto-set-lastmod= or
+=EXPORT_HUGO_AUTO_SET_LASTMOD= to non-nil.
+
 **** File-based Exports
 :PROPERTIES:
 :CUSTOM_ID: dates-file-based-exports

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -986,7 +986,7 @@ Examples of RFC3339-compatible values for this variable:
 Do =C-h v org-hugo-date-format= for more information (within Emacs,
 once the =ox-hugo= package is loaded).
 
-***** =org-hugo-suppress-lastmod-period==
+***** =org-hugo-suppress-lastmod-period=
  - Default value :: =0.0=
 
 A suppressing period not to write the =lastmod= item in the front matter.

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -1,4 +1,4 @@
-;; Time-stamp: <2018-09-05 09:10:50 kmodi>
+;; Time-stamp: <2018-09-05 09:35:49 kmodi>
 
 ;; Setup to export Org files to Hugo-compatible Markdown using
 ;; `ox-hugo' in an "emacs -Q" environment.
@@ -205,6 +205,10 @@ Fake current time: 2100/12/21 00:00:00 (arbitrary)."
   (encode-time 0 0 0 21 12 2100))
 (advice-add 'current-time :override #'ox-hugo-test/current-time-override)
 ;; (advice-remove 'current-time #'ox-hugo-test/current-time-override)
+
+;; Override the default `org-hugo-export-creator-string' so that this
+;; string is consistent in all ox-hugo tests.
+(setq org-hugo-export-creator-string "Emacs + Org mode + ox-hugo")
 
 (with-eval-after-load 'org
   ;; Allow multiple line Org emphasis markup

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -5130,7 +5130,7 @@ it is disabled using =:EXPORT_OPTIONS: title:nil=.
 This post will be exported without =author= in the front-matter because
 it is disabled using =:EXPORT_OPTIONS: author:nil=.
 ** Creator                                             :creator:front_matter:
-*** Default Creator                            :dont_export_during_make_test:
+*** Default Creator
 :PROPERTIES:
 :EXPORT_DATE: 2017-12-01
 :EXPORT_OPTIONS: creator:t

--- a/test/site/content-org/screenshot-subtree-export-example.org
+++ b/test/site/content-org/screenshot-subtree-export-example.org
@@ -4,6 +4,8 @@
 #+hugo_weight: auto
 #+hugo_auto_set_lastmod: t
 
+#+author: Kaushal Modi
+
 * Emacs                                                              :@emacs:
 All posts in here will have the category set to /emacs/.
 ** TODO Writing Hugo blog in Org                                   :hugo:org:

--- a/test/site/content-org/single-posts/suppress-lastmod.org
+++ b/test/site/content-org/single-posts/suppress-lastmod.org
@@ -1,0 +1,22 @@
+#+title: Single Post with suppressed lastmod
+#+hugo_base_dir: ../../
+#+hugo_section: singles
+#+date: [2018-09-01 Sat 05:08]
+#+hugo_lastmod: 2018-09-02
+#+macro: doc [[https://ox-hugo.scripter.co/doc/$1][$2]]
+
+This post will not export =lastmod= because
+=org-hugo-suppress-lastmod-period= is greater than the time
+differences between =[2018-09-01 Sat 05:08]= and
+=2018-09-02= specified in =#+hugo_lastmod=. =[2018-09-01 Sat 05:08]=
+will be converted to =2018-09-01T05:08:00+00:00=, and =2018-09-02=
+will be handled as =2018-09-02T00:00:00+00:00=.
+
+In batch mode, the local variable could not be applied. So =lastmod=
+will be exported in {{{doc(suppress-lastmod,Single Post with suppressed lastmod)}}}.
+
+* Local Variables :ARCHIVE:
+# Local Variables:
+# org-hugo-suppress-lastmod-period: 86400.0
+# End:
+

--- a/test/site/content-org/single-posts/suppress-lastmod.org
+++ b/test/site/content-org/single-posts/suppress-lastmod.org
@@ -1,22 +1,18 @@
 #+title: Single Post with suppressed lastmod
 #+hugo_base_dir: ../../
 #+hugo_section: singles
-#+date: [2018-09-01 Sat 05:08]
-#+hugo_lastmod: 2018-09-02
+#+date: [2118-09-01 Sat 05:08]
 #+macro: doc [[https://ox-hugo.scripter.co/doc/$1][$2]]
+#+hugo_auto_set_lastmod: t
 
 This post will not export =lastmod= because
 =org-hugo-suppress-lastmod-period= is greater than the time
-differences between =[2018-09-01 Sat 05:08]= and
-=2018-09-02= specified in =#+hugo_lastmod=. =[2018-09-01 Sat 05:08]=
-will be converted to =2018-09-01T05:08:00+00:00=, and =2018-09-02=
-will be handled as =2018-09-02T00:00:00+00:00=.
-
-In batch mode, the local variable could not be applied. So =lastmod=
-will be exported in {{{doc(suppress-lastmod,Single Post with suppressed lastmod)}}}.
+difference between =[2118-09-01 Sat 05:08]= and the current
+date.
 
 * Local Variables :ARCHIVE:
 # Local Variables:
-# org-hugo-suppress-lastmod-period: 86400.0
+# org-hugo-auto-set-lastmod: nil
+# org-hugo-suppress-lastmod-period: 0.0
 # End:
 

--- a/test/site/content-org/single-posts/unsuppress-lastmod.org
+++ b/test/site/content-org/single-posts/unsuppress-lastmod.org
@@ -1,19 +1,16 @@
 #+title: Single Post with unsuppressed lastmod
 #+hugo_base_dir: ../../
 #+hugo_section: singles
-#+date: [2018-09-01 Sat 05:11]
-#+hugo_lastmod: 2018-09-02T05:55:00
+#+date: [1999-09-01 Sat 05:11]
+#+hugo_auto_set_lastmod: t
 
 This post will export =lastmod= because
-=org-hugo-suppress-lastmod-period= is less than the time differences
-between =[2018-09-01 Sat 05:11]= and
-=2018-09-02T05:55:00= specified in
-=#+hugo_lastmod=. =[2018-09-01 Sat 05:11]= will be converted to
-=2018-09-01T05:11:00+00:00=, and =2018-09-02T05:55:00= will be
-handled as =2018-09-02T05:55:00+00:00=.
+=org-hugo-suppress-lastmod-period= is less than the time difference
+between =[1999-09-01 Sat 05:11]= and the current date.
 
 * Local Variables :ARCHIVE:
 # Local Variables:
-# org-hugo-suppress-lastmod-period: 86400.0
+# org-hugo-auto-set-lastmod: nil
+# org-hugo-suppress-lastmod-period: 0.0
 # End:
 

--- a/test/site/content-org/single-posts/unsuppress-lastmod.org
+++ b/test/site/content-org/single-posts/unsuppress-lastmod.org
@@ -1,0 +1,19 @@
+#+title: Single Post with unsuppressed lastmod
+#+hugo_base_dir: ../../
+#+hugo_section: singles
+#+date: [2018-09-01 Sat 05:11]
+#+hugo_lastmod: 2018-09-02T05:55:00
+
+This post will export =lastmod= because
+=org-hugo-suppress-lastmod-period= is less than the time differences
+between =[2018-09-01 Sat 05:11]= and
+=2018-09-02T05:55:00= specified in
+=#+hugo_lastmod=. =[2018-09-01 Sat 05:11]= will be converted to
+=2018-09-01T05:11:00+00:00=, and =2018-09-02T05:55:00= will be
+handled as =2018-09-02T05:55:00+00:00=.
+
+* Local Variables :ARCHIVE:
+# Local Variables:
+# org-hugo-suppress-lastmod-period: 86400.0
+# End:
+

--- a/test/site/content-org/suppress-lastmod.org
+++ b/test/site/content-org/suppress-lastmod.org
@@ -1,0 +1,64 @@
+#+hugo_base_dir: ../
+#+macro: doc [[https://ox-hugo.scripter.co/doc/$1][$2]]
+
+* org-hugo-suppress-lastmod-period
+** DONE suppress lastmod with auto-set-lastmod
+   CLOSED: [2018-09-01 Sat 08:35]
+:PROPERTIES:
+:EXPORT_FILE_NAME: suppress-lastmod-in-subtree-with-auto-lastmod
+:END:
+
+This post will never export =lastmod= when you initially change the
+Org TODO state to =DONE= by saving the file automatically because
+=org-hugo-suppress-lastmod-period= is always greater than the time
+differences between =date= and =lastmod= in the following condition.
+
+| Variable                         | Value |
+|----------------------------------+-------|
+| org-hugo-suppress-lastmod-period | 60.0  |
+| org-hugo-auto-set-lastmod        | t     |
+| org-hugo-auto-export-on-save     | t     |
+| org-log-done                     | time  |
+
+For instance, auto generated =date= would be =2018-09-01T08:35:00+00:00=
+and =lastmod= could be =2018-09-01T08:35:59+00:00=. But if you change
+something in this post after the initial exporting, the =lastmod= will
+be exported because the time differences will exceed
+=org-hugo-suppress-lastmod-period=.
+
+** DONE suppress lastmod
+   CLOSED: [2018-09-01 Sat 02:57]
+:PROPERTIES:
+:EXPORT_FILE_NAME: suppress-lastmod-in-subtree
+:EXPORT_HUGO_LASTMOD: 2018-09-01T02:57:59
+:END:
+
+This post will not export =lastmod= because
+=org-hugo-suppress-lastmod-period= is greater than the time
+differences between =[2018-09-01 Sat 02:57]= and
+=2018-09-01T02:57:59= described in =EXPORT_HUGO_LASTMOD=. The =date=
+will be converted to =2018-09-01T02:57:00+00:00=, and the =lastmod=
+will be converted to =2018-09-01T02:57:59+00:00=.
+
+In batch mode, the local variable could not be applied. So =lastmod=
+will be actually exported in
+{{{doc(suppress-lastmod-in-subtree,suppress lastmod)}}}.
+
+** DONE unsuppress lastmod
+   CLOSED: [2018-09-01 Sat 02:57]
+:PROPERTIES:
+:EXPORT_FILE_NAME: unsuppress-lastmod-in-subtree
+:EXPORT_HUGO_LASTMOD: 2018-09-01T03:00:00
+:END:
+
+This post will export =lastmod= because
+=org-hugo-suppress-lastmod-period= is less than the time differences
+between =[2018-09-01 Sat 02:57]= and =2018-09-01T03:00:00= described
+in =EXPORT_HUGO_LASTMOD=. the =date= will be converted to
+=2018-09-01T02:57:00+00:00=.
+
+* Local Variables :ARCHIVE:
+# Local Variables:
+# org-hugo-suppress-lastmod-period: 60.0
+# org-hugo-auto-set-lastmod: t
+# End:

--- a/test/site/content-org/suppress-lastmod.org
+++ b/test/site/content-org/suppress-lastmod.org
@@ -1,17 +1,17 @@
 #+hugo_base_dir: ../
-#+macro: doc [[https://ox-hugo.scripter.co/doc/$1][$2]]
 
 * org-hugo-suppress-lastmod-period
 ** DONE suppress lastmod with auto-set-lastmod
-   CLOSED: [2018-09-01 Sat 08:35]
+   CLOSED: [2118-09-01 Wed 08:35]
 :PROPERTIES:
 :EXPORT_FILE_NAME: suppress-lastmod-in-subtree-with-auto-lastmod
+:EXPORT_HUGO_AUTO_SET_LASTMOD: t
 :END:
 
 This post will never export =lastmod= when you initially change the
-Org TODO state to =DONE= by saving the file automatically because
+Org TODO state to =DONE= by saving the file because
 =org-hugo-suppress-lastmod-period= is always greater than the time
-differences between =date= and =lastmod= in the following condition.
+difference between =date= and =lastmod= in the following condition.
 
 | Variable                         | Value |
 |----------------------------------+-------|
@@ -20,45 +20,39 @@ differences between =date= and =lastmod= in the following condition.
 | org-hugo-auto-export-on-save     | t     |
 | org-log-done                     | time  |
 
-For instance, auto generated =date= would be =2018-09-01T08:35:00+00:00=
-and =lastmod= could be =2018-09-01T08:35:59+00:00=. But if you change
-something in this post after the initial exporting, the =lastmod= will
-be exported because the time differences will exceed
+For instance, auto generated =date= would be =2018-09-01T08:00:00+00:00=
+and =lastmod= could be =2018-09-01T08:00:59+00:00=. The time
+difference is less than =org-hugo-suppress-lastmod-period= so
+=lastmod= filed will not be exported. But if you change something in
+this post after the initial exporting, the =lastmod= will be exported
+because the time difference will exceed
 =org-hugo-suppress-lastmod-period=.
 
-** DONE suppress lastmod
-   CLOSED: [2018-09-01 Sat 02:57]
-:PROPERTIES:
-:EXPORT_FILE_NAME: suppress-lastmod-in-subtree
-:EXPORT_HUGO_LASTMOD: 2018-09-01T02:57:59
-:END:
-
-This post will not export =lastmod= because
-=org-hugo-suppress-lastmod-period= is greater than the time
-differences between =[2018-09-01 Sat 02:57]= and
-=2018-09-01T02:57:59= described in =EXPORT_HUGO_LASTMOD=. The =date=
-will be converted to =2018-09-01T02:57:00+00:00=, and the =lastmod=
-will be converted to =2018-09-01T02:57:59+00:00=.
-
-In batch mode, the local variable could not be applied. So =lastmod=
-will be actually exported in
-{{{doc(suppress-lastmod-in-subtree,suppress lastmod)}}}.
-
 ** DONE unsuppress lastmod
-   CLOSED: [2018-09-01 Sat 02:57]
+   CLOSED: [1999-09-01 Sat 02:57]
 :PROPERTIES:
 :EXPORT_FILE_NAME: unsuppress-lastmod-in-subtree
-:EXPORT_HUGO_LASTMOD: 2018-09-01T03:00:00
+:EXPORT_HUGO_AUTO_SET_LASTMOD: t
 :END:
 
 This post will export =lastmod= because
-=org-hugo-suppress-lastmod-period= is less than the time differences
-between =[2018-09-01 Sat 02:57]= and =2018-09-01T03:00:00= described
-in =EXPORT_HUGO_LASTMOD=. the =date= will be converted to
-=2018-09-01T02:57:00+00:00=.
+=org-hugo-suppress-lastmod-period= is less than the time difference
+between =[1999-09-01 Sat 02:57]= and the current date.
+
+** DONE ignore suppress lastmod
+   CLOSED: [2018-09-05 Wed 14:19]
+:PROPERTIES:
+:EXPORT_FILE_NAME: ignore-suppress-lastmod-in-subtree
+:EXPORT_HUGO_LASTMOD: 1999-09-05
+:EXPORT_HUGO_AUTO_SET_LASTMOD: nil
+:END:
+
+This post will export =lastmod= because =EXPORT_HUGO_LASTMOD= is
+provided even if =org-hugo-suppress-lastmod-period= is less than the
+time difference between =[2018-09-05 Wed 14:19]= and =1999-09-05=.
 
 * Local Variables :ARCHIVE:
 # Local Variables:
-# org-hugo-suppress-lastmod-period: 60.0
-# org-hugo-auto-set-lastmod: t
+# org-hugo-auto-set-lastmod: nil
+# org-hugo-suppress-lastmod-period: 0.0
 # End:

--- a/test/site/content-org/writing-hugo-blog-in-org-file-export.org
+++ b/test/site/content-org/writing-hugo-blog-in-org-file-export.org
@@ -7,6 +7,8 @@
 #+title: Writing Hugo blog in Org (File Export)
 
 #+date: 2017-09-10
+#+author: Kaushal Modi
+
 #+hugo_tags: hugo org
 #+hugo_categories: emacs
 #+hugo_menu: :menu "main" :weight 2001

--- a/test/site/content/posts/default-creator.md
+++ b/test/site/content/posts/default-creator.md
@@ -1,9 +1,9 @@
 +++
 title = "Default Creator"
 date = 2017-12-01
-tags = ["export-option", "creator", "front-matter", "dont-export-during-make-test"]
+tags = ["export-option", "creator", "front-matter"]
 draft = false
-creator = "Emacs 26.0.90 (Org mode 9.1.3 + ox-hugo)"
+creator = "Emacs + Org mode + ox-hugo"
 +++
 
 The front-matter for this post contains the default Creator string.

--- a/test/site/content/posts/ignore-suppress-lastmod-in-subtree.md
+++ b/test/site/content/posts/ignore-suppress-lastmod-in-subtree.md
@@ -1,0 +1,11 @@
++++
+title = "ignore suppress lastmod"
+author = ["Takaaki ISHIKAWA"]
+date = 2018-09-05T14:19:00+00:00
+lastmod = 1999-09-05
+draft = false
++++
+
+This post will export `lastmod` because `EXPORT_HUGO_LASTMOD` is
+provided even if `org-hugo-suppress-lastmod-period` is less than the
+time difference between `[2018-09-05 Wed 14:19]` and `1999-09-05`.

--- a/test/site/content/posts/suppress-lastmod-in-subtree-with-auto-lastmod.md
+++ b/test/site/content/posts/suppress-lastmod-in-subtree-with-auto-lastmod.md
@@ -1,0 +1,26 @@
++++
+title = "suppress lastmod with auto-set-lastmod"
+author = ["Takaaki ISHIKAWA"]
+date = 2118-09-01T08:35:00+00:00
+draft = false
++++
+
+This post will never export `lastmod` when you initially change the
+Org TODO state to `DONE` by saving the file because
+`org-hugo-suppress-lastmod-period` is always greater than the time
+difference between `date` and `lastmod` in the following condition.
+
+| Variable                         | Value |
+|----------------------------------|-------|
+| org-hugo-suppress-lastmod-period | 60.0  |
+| org-hugo-auto-set-lastmod        | t     |
+| org-hugo-auto-export-on-save     | t     |
+| org-log-done                     | time  |
+
+For instance, auto generated `date` would be `2018-09-01T08:00:00+00:00`
+and `lastmod` could be `2018-09-01T08:00:59+00:00`. The time
+difference is less than `org-hugo-suppress-lastmod-period` so
+`lastmod` filed will not be exported. But if you change something in
+this post after the initial exporting, the `lastmod` will be exported
+because the time difference will exceed
+`org-hugo-suppress-lastmod-period`.

--- a/test/site/content/posts/unsuppress-lastmod-in-subtree.md
+++ b/test/site/content/posts/unsuppress-lastmod-in-subtree.md
@@ -1,0 +1,11 @@
++++
+title = "unsuppress lastmod"
+author = ["Takaaki ISHIKAWA"]
+date = 1999-09-01T02:57:00+00:00
+lastmod = 2100-12-21T00:00:00+00:00
+draft = false
++++
+
+This post will export `lastmod` because
+`org-hugo-suppress-lastmod-period` is less than the time difference
+between `[1999-09-01 Sat 02:57]` and the current date.

--- a/test/site/content/singles/suppress-lastmod.md
+++ b/test/site/content/singles/suppress-lastmod.md
@@ -1,0 +1,14 @@
++++
+title = "Single Post with suppressed lastmod"
+author = ["Takaaki ISHIKAWA"]
+date = 2118-09-01T05:08:00+00:00
+draft = false
++++
+
+This post will not export `lastmod` because
+`org-hugo-suppress-lastmod-period` is greater than the time
+difference between `[2118-09-01 Sat 05:08]` and the current
+date.
+
+
+## Local Variables {#local-variables}

--- a/test/site/content/singles/unsuppress-lastmod.md
+++ b/test/site/content/singles/unsuppress-lastmod.md
@@ -1,0 +1,14 @@
++++
+title = "Single Post with unsuppressed lastmod"
+author = ["Takaaki ISHIKAWA"]
+date = 1999-09-01T05:11:00+00:00
+lastmod = 2100-12-21T00:00:00+00:00
+draft = false
++++
+
+This post will export `lastmod` because
+`org-hugo-suppress-lastmod-period` is less than the time difference
+between `[1999-09-01 Sat 05:11]` and the current date.
+
+
+## Local Variables {#local-variables}


### PR DESCRIPTION
Hi.

When I use `ox-hugo` with the following condition, `lastmod` is generated unexpectedly when I initially change the Org state to `DONE`. This user action is not actually modification of a post, it's just a creation of new post.

- org-hugo-auto-set-lastmod = t
- org-hugo-auto-export-on-save = t
- org-log-done = time
- using auto-save-buffers.el

So, I introduced `org-hugo-suppress-lastmod-period` variable to precisely control the period between the initial creation of an entry and actual modification of it.

For instance, when you change the Org state to `DONE` from `TODO` in an entry, the `date` is exported as `2018-09-02T02:01:00+09:00` derived from `CLOSED: [2018-09-02 Sun 02:01]`. This means the initial creation time is set to `02:01:00` but right after that the `lastmod` could be exported as `2018-09-02T02:01:14+09:00` based on the value of `(org-current-time)` at the moment of saving the file. So tiny time difference could be naturally occurred between changing Org state and file saving but this combined action is not actually modification of the entry.

If you set `org-hugo-suppress-lastmod-period` to `60.0` or other appropriate value, it can be avoided. Moreover, if you set it to `86400.0`, this means the modification to the entry will not create `lastmod` value in front matter until the next day of the initially change of Org state. This is also useful because some Hugo themes only show year, month, and day.

What I did:
- Added a new variable
- Added two functions
- Updated ox-hugo-manual
- Added 5 testcases in 3 files
- `-j1` applied to build doc as `make -j1 doc`

Unresolved:
- Applying local-variables in org files when building test
- Checking the changes from "TODO" to "DONE" when building test in batch-mode

Best regards,
Takaaki