### PR TITLE
Set the EMACS variable correctly when inside emacs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,13 @@
 
 MAKE_ := $(MAKE) -j1 --no-print-directory
 
-EMACS ?= emacs
-EMACS_exists := $(shell command -v $(EMACS) 2> /dev/null)
+ifdef INSIDE_EMACS
+  EMACS := $(shell which emacs)
+else
+  EMACS ?= emacs
+endif
+
+EMACS_exists := "$(shell command -v "$(EMACS)" 2> /dev/null)"
 ifeq ("$(EMACS_exists)","")
 	EMACS := /tmp/emacs/bin/emacs
 endif


### PR DESCRIPTION
When running from a shell inside of emacs the EMACS variable is set to
a literal string with the format:

emacs-version (term: term-protocol-version)

The variable INSIDE_EMACS will be defined and set to the same value
when running inside of emacs. This is documented in the emacs manual
38.2 Interactive Subshell. By checking if INSIDE_EMACS is defined the
EMACS variable may be set to the path returned by the which shell
command. Otherwise, the EMACS variable may be set using the
conditional variable assignment operator.