### PR TITLE
remove ox-hugo-autoloads.el silently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ clean: ctemp
 	@rm -rf $(OX_HUGO_ELPA)
 	@rm -rf ./doc/public
 	@rm -rf /tmp/hugo/bin
-	@rm ox-hugo-autoloads.el
+	@rm -f ox-hugo-autoloads.el
 
 # Set a make variable during rule execution
 # https://stackoverflow.com/a/1909390/1219634


### PR DESCRIPTION
Added the -f flag to silence rm when ox-hugo-autoloads.el does not
exist during clean.