### PR TITLE
Exported table does not have a preceding if the Org table has only #+name 

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -1017,7 +1017,7 @@ contextual information."
          (no-header (= (length rows) 1)) ;No header if table has just 1 row
          (table-ref (org-blackfriday--get-reference table))
          (table-anchor (if table-ref
-                           (format "<a id=\"%s\"></a>\n" table-ref)
+                           (format "<a id=\"%s\"></a>\n\n" table-ref)
                          ""))
          (caption (org-export-get-caption table))
          table-num

--- a/test/site/content/dir-locals-test/dir-locals-test.md
+++ b/test/site/content/dir-locals-test/dir-locals-test.md
@@ -29,6 +29,7 @@ creator: "Dummy creator string"
 ## <span class="section-num">1</span> Variables set in <kbd>.dir-locals.el</kbd> {#variables-set-in-dot-dir-locals-dot-el}
 
 <a id="table--vars-dir-locals"></a>
+
 <div class="table-caption">
   <span class="table-number"><a href="#table--vars-dir-locals">Table 1</a></span>:
   Variables set using <code>.dir-locals.el</code>

--- a/test/site/content/posts/links-to-tables.md
+++ b/test/site/content/posts/links-to-tables.md
@@ -33,6 +33,7 @@ will output below (_lorem-ipsum_ added to increase page content so
 that the link jump is evident):
 
 <a id="table--simple1"></a>
+
 <div class="table-caption">
   <span class="table-number"><a href="#table--simple1">Table 1</a></span>:
   Simple table 1
@@ -99,6 +100,7 @@ blandit in.
 Here's another table:
 
 <a id="table--simple2"></a>
+
 <div class="table-caption">
   <span class="table-number"><a href="#table--simple2">Table 2</a></span>:
   Simple table 2

--- a/test/site/content/singles/links-to-org-elements.md
+++ b/test/site/content/singles/links-to-org-elements.md
@@ -165,6 +165,7 @@ will output below (_lorem-ipsum_ added to increase page content so
 that the link jump is evident):
 
 <a id="table--simple1"></a>
+
 <div class="table-caption">
   <span class="table-number"><a href="#table--simple1">Tabelle 1</a></span>:
   Simple table 1
@@ -231,6 +232,7 @@ blandit in.
 Here's another table:
 
 <a id="table--simple2"></a>
+
 <div class="table-caption">
   <span class="table-number"><a href="#table--simple2">Tabelle 2</a></span>:
   Simple table 2


### PR DESCRIPTION
if a table is identified by `#+NAME: name`, then ox-blackfriday will add an `<a>` tag before the table. However, unless this tag is separated from the table by an empty line, the parser will not attempt to parse the table, and so the table text will be interpreted as plain text, becoming illegible in the browser.  The extra `\n` fixes the issue. 