### PR TITLE
citations: Update RegExp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 HUGO_BIN_SOURCE ?= https://gitlab.com/kaushalmodi/unofficial-hugo-dev-builds.git
 HUGO_VERSION ?= DEV
 
-PANDOC_BIN_VERSION ?= 2.6
+PANDOC_BIN_VERSION ?= 2.9.2
 PANDOC_ARCHIVE_NAME ?= pandoc-$(PANDOC_BIN_VERSION)-linux.tar.gz
 PANDOC_BIN_SOURCE ?= https://github.com/jgm/pandoc/releases/download/$(PANDOC_BIN_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ endif
 HUGO_BIN_SOURCE ?= https://gitlab.com/kaushalmodi/unofficial-hugo-dev-builds.git
 HUGO_VERSION ?= DEV
 
-PANDOC_BIN_VERSION ?= 2.9.2
-PANDOC_ARCHIVE_NAME ?= pandoc-$(PANDOC_BIN_VERSION)-linux.tar.gz
+PANDOC_BIN_VERSION ?= 2.9.2.1
+PANDOC_ARCHIVE_NAME ?= pandoc-$(PANDOC_BIN_VERSION)-linux-amd64.tar.gz
 PANDOC_BIN_SOURCE ?= https://github.com/jgm/pandoc/releases/download/$(PANDOC_BIN_VERSION)
 
 # baseURL value set via environment variable HUGO_BASEURL

--- a/ox-hugo-pandoc-cite.el
+++ b/ox-hugo-pandoc-cite.el
@@ -17,6 +17,7 @@
     "-t" ,(concat "markdown-citations"
                   "-simple_tables"
                   "+pipe_tables"
+                  "-raw_attribute"
                   "-fenced_divs"
                   "-fenced_code_attributes"
                   "-bracketed_spans")

--- a/ox-hugo-pandoc-cite.el
+++ b/ox-hugo-pandoc-cite.el
@@ -63,7 +63,7 @@ arguments.")
   "Buffer to contain the `pandoc' run output and errors.")
 
 (defvar org-hugo-pandoc-cite--references-header-regexp
-  "^<div id=\"refs\" class=\"references\">$"
+  "^<div id=\"refs\" class=\"references hanging-indent\">$"
   "Regexp to match the Pandoc-inserted references header string.
 
 This string is present only if Pandoc has resolved one or more

--- a/ox-hugo-pandoc-cite.el
+++ b/ox-hugo-pandoc-cite.el
@@ -63,7 +63,7 @@ arguments.")
   "Buffer to contain the `pandoc' run output and errors.")
 
 (defvar org-hugo-pandoc-cite--references-header-regexp
-  "^<div id=\"refs\" class=\"references hanging-indent\">$"
+  "^<div id=\"refs\" .*>$"
   "Regexp to match the Pandoc-inserted references header string.
 
 This string is present only if Pandoc has resolved one or more


### PR DESCRIPTION
Evidently, the default styles have changed, this fixes the citation generation.