### PR TITLE
Respect org-src-lang modes

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -885,6 +885,7 @@ This function is adapted from `org-html-special-block'."
 
 INFO is a plist used as a communication channel."
   (let* ((lang (org-element-property :language src-block))
+         (lang (or (cdr (assoc lang org-src-lang-modes)) lang))
          (code (org-export-format-code-default src-block info))
          (parent-element (org-export-get-parent src-block))
          (parent-type (car parent-element))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2581,6 +2581,7 @@ Hugo \"highlight\" shortcode features:
 CONTENTS is nil.  INFO is a plist used as a communication
 channel."
   (let* ((lang (org-element-property :language src-block))
+         (lang (or (cdr (assoc lang org-src-lang-modes)) lang))
          (parameters-str (org-element-property :parameters src-block))
          (parameters (org-babel-parse-header-arguments parameters-str))
          (is-fm-extra (cdr (assoc :front_matter_extra parameters)))


### PR DESCRIPTION
First of all, thanks for your great package! It's wonderful to use. 

I am sorry for the drive by commit. Perhaps I should have made an issue to discuss first. 

This PR scratches a minor itch of mine. 
It makes sure that source blocks such as a jupyter-python
source block are syntax highlighted as a python source block.

This is normally ensured by the `org-src-lang` variable, which maps src_block source language to emacs mode. For most languages this is an improvement. 

For OCaml users, this might not be an improvement, since the default mode is `tuareg-mode`. I am not sure how to fix that reliably. 

As to copyright assignment, I waive my copyright. Feel free to copy and paste the changes without merging the PR. 

I hope this PR can be integrated in some form or another as is. If not, I am willing to make changes to satisfy any needs. 

