### PR TITLE
Fix incorrect org-content link - robinwils.gitlab.io

### DIFF
--- a/doc/data/users.toml
+++ b/doc/data/users.toml
@@ -390,8 +390,8 @@
 
 [RobinWils]
   author = "Robin Wils"
-  source = "https://codeberg.org/RobinWils/hugo-source-pages"
-  site = "https://robinwils.gitlab.io"
+  source = "https://gitlab.com/RobinWils/robinwils.com"
+  site = "https://robinwils.com"
   org_dir = "content-org"
 
 [mikeyobrien]

--- a/doc/data/users.toml
+++ b/doc/data/users.toml
@@ -390,7 +390,7 @@
 
 [RobinWils]
   author = "Robin Wils"
-  source = "https://gitlab.com/RobinWils/robinwils.gitlab.io"
+  source = "https://codeberg.org/RobinWils/hugo-source-pages"
   site = "https://robinwils.gitlab.io"
   org_dir = "content-org"
 


### PR DESCRIPTION
I often move my site from one platform to another lately, but I just found out that my content-org wasn't correct anymore, so I fixed it.