### PR TITLE
:sparkles: Add option to preserve URL as-is

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -408,13 +408,15 @@ style tag."
     ret))
 
 ;;;; Sanitize URL
-(defun org-blackfriday--url-sanitize (url)
+(defun org-blackfriday--url-sanitize (url org-hugo-link-url-asis)
   "Sanitize the URL by replace certain characters with their hex encoding.
 
 Replaces \"_\" with \"%5F\".
 
 Workaround for Blackfriday bug https://github.com/russross/blackfriday/issues/278."
-  (replace-regexp-in-string "_" "%5F" url))
+  (if (not org-hugo-link-url-asis)
+      (replace-regexp-in-string "_" "%5F" url)
+    url))
 
 ;;;; Blackfriday Issue 239 Workaround
 (defun org-blackfriday--issue-239-workaround (code parent-type)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -701,6 +701,11 @@ specified for them):
   :group 'org-export-hugo
   :type 'boolean)
 ;;;###autoload (put 'org-hugo-link-desc-insert-type 'safe-local-variable 'booleanp)
+(defcustom org-hugo-link-url-asis nil
+  "Export url link as-is to avoid 404 error
+ caused by the sanitizing of underscore by \"%5F\""
+  :group 'org-export-hugo
+  :type 'boolean)
 
 (defcustom org-hugo-langs-no-descr-in-code-fences '()
   "List of languages whose descriptors should not be exported to Markdown.
@@ -2047,7 +2052,8 @@ and rewrite link paths to make blogging more seamless."
     (when (and (stringp raw-path)
                link-is-url)
       (setq raw-path (org-blackfriday--url-sanitize
-                      (url-encode-url raw-path))))
+                      (url-encode-url raw-path)
+                      org-hugo-link-url-asis)))
     ;; (message "[ox-hugo-link DBG] link: %S" link)
     ;; (message "[ox-hugo-link DBG] link path: %s" (org-element-property :path link))
     ;; (message "[ox-hugo-link DBG] link filename: %s" (expand-file-name (plist-get (car (cdr link)) :path)))

--- a/test/issue-236-url-underscore-asis.el
+++ b/test/issue-236-url-underscore-asis.el
@@ -1,0 +1,14 @@
+(require 'ert)
+(ert-deftest org-hugo-link/url-underscore-asis ()
+  "Expect org-hugo-link can export sanitized/asis
+by toggling 'org-hugo-link-url-asis'"
+  (let ((url (url-encode-url "https://a_b.com")))
+    (progn
+      (let ((org-hugo-link-url-asis t))
+        (should (equal (org-blackfriday--url-sanitize url t)
+                       url)))
+      (let ((org-hugo-link-url-asis nil))
+        (should (equal (org-blackfriday--url-sanitize url nil)
+                       "https://a%5Fb.com"))))))
+
+


### PR DESCRIPTION
Thank you for developing great tool!!
I cannot think of my blogging without `ox-hugo` anymore!

Sometimes I have trouble with linking URL with underscore because it is sanitized by `org-blackfriday--url-sanitize` and cause 404 error.
To avoid this, I added a boolean variable `org-hugo-link-url-asis`.
If set to `t`, the variable preserve URL as-is for non-blackberry users.
The modification does not affect users do not concern this problem because the default value of the variable is `nil`.

Please let me know if you find a problem with my modification.

Thank you,
