### PR TITLE
adapt pandoc argument list for pandoc v2.11 (citeproc, atx-headings)

### DIFF
--- a/ox-hugo-pandoc-cite.el
+++ b/ox-hugo-pandoc-cite.el
@@ -21,8 +21,9 @@
                   "-fenced_divs"
                   "-fenced_code_attributes"
                   "-bracketed_spans")
-    "--atx-headers"
-    "--id-prefix=fn:")
+    "--markdown-headings=atx"
+    "--id-prefix=fn:"
+    "--citeproc")
   "Pandoc arguments used in `org-hugo-pandoc-cite--run-pandoc'.
 
 -f markdown : Convert *from* Markdown


### PR DESCRIPTION
I have tried ox-hugo with recent pandoc (2.11), which has moved away from a separate pandoc-citeproc filter to a internal citation processing. I think the new `--citeproc` option is now required even when supplying a bibliography.

The new syntax for ATX headers is `--markdown-headers=atx`.