### PR TITLE
do not hardcode References title (more flexibility)

### DIFF
--- a/ox-hugo-pandoc-cite.el
+++ b/ox-hugo-pandoc-cite.el
@@ -175,9 +175,7 @@ Required fixes:
         ;; There should be at max only one replacement needed for
         ;; this.
         (when (re-search-forward org-hugo-pandoc-cite--references-header-regexp nil :noerror)
-          (replace-match (concat level-mark
-                                 " References {#references}\n\n"
-                                 "\\&\n  <div></div>\n")))) ;See footnote 1
+          (replace-match "\n\n\\&\n  <div></div>\n"))) ;See footnote 1
 
       ;; Add the Blackfriday required hack to Pandoc ref divs.
       (save-excursion


### PR DESCRIPTION
I am not sure there is a need to hardcode a ‘References’ heading, as it is possible to either add a particular heading at the end of the org source file or to use the pandoc `reference-section-title` variable in the front matter. I stumbled across this as I was trying to change the language of my references heading. Possibly I am upsetting some other logic with this change, but it resolved my problem (short of checking for translations in CSL locales or so).