### PR TITLE
Update users.toml - add "www." before URL

### DIFF
--- a/doc/data/users.toml
+++ b/doc/data/users.toml
@@ -385,7 +385,7 @@
 [RobinWils]
   author = "Robin Wils"
   source = "https://gitlab.com/RobinWils/robinwils.com"
-  site = "https://robinwils.com"
+  site = "https://www.robinwils.com"
   org_dir = "content-org"
 
 [mikeyobrien]


### PR DESCRIPTION
My website had a padlock icon next to it. 
I think that this fixes it and otherwise, it isn't the biggest problem.