### PR TITLE
Handle backslash escapes according to CommonMark Spec

### DIFF
--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -3357,7 +3357,7 @@ Test to check that the backslashes are correctly escaped.
 $$
 C(w,b) = \frac{1}{2n} \sum_x{{\|y(x)-a\|}^2}
 $$
-*** =\\= at EOL → =\\\\\\=
+*** =\\= at EOL → =\\\\=
 \begin{align}
 a^1  &= x \\
 a^2  &=  σ(W^2a^1 + b^2) \\
@@ -3401,6 +3401,23 @@ link!
 \begin{equation}
 \mathcal{L}\left[ e^{at} \right](z) = \frac{1}{z-a}
 \end{equation}
+
+*** Backslashes within a LaTeX equation
+{{{oxhugoissue(458)}}}
+
+Double backslashes (~\\~) should be escaped:
+\[\sum_{\substack{0<i<m\\0<j<n}}\]
+
+A backslash before any ASCII punctuation character should be escaped,
+for example, ~\,~, ~\;~, ~\:~, ~\!~ are used to control the width of
+spacing:
+  \[ab\]
+  \[a\ b\]
+  \[a\,b\]
+  \[a\;b\]
+  \[a\:b\]
+  \[a\!b\]
+
 * Lists                                                               :lists:
 ** List following a list
 :PROPERTIES:

--- a/test/site/content/posts/equations-bf-escaping.md
+++ b/test/site/content/posts/equations-bf-escaping.md
@@ -16,14 +16,14 @@ C(w,b) = \frac{1}{2n} \sum\_x{{\\|y(x)-a\\|}^2}
 \\]
 
 
-## `\\` at EOL → `\\\\\\` {#at-eol}
+## `\\` at EOL → `\\\\` {#at-eol}
 
 \begin{align}
-a^1  &= x \\\\\\
-a^2  &=  σ(W^2a^1 + b^2) \\\\\\
-a^3  &=  σ(W^3a^2 + b^3) \\\\\\
-⋯ \\\\\\
-a^L  &= σ(W^La^{L-1} + b^L) \\\\\\
+a^1  &= x \\\\
+a^2  &=  σ(W^2a^1 + b^2) \\\\
+a^3  &=  σ(W^3a^2 + b^3) \\\\
+⋯ \\\\
+a^L  &= σ(W^La^{L-1} + b^L) \\\\
 y  &= a^L
 \end{align}
 
@@ -31,11 +31,11 @@ y  &= a^L
 ### Same as above, but without space before the `\\` at EOL {#same-as-above-but-without-space-before-the-at-eol}
 
 \begin{align}
-a^1  &= x\\\\\\
-a^2  &=  σ(W^2a^1 + b^2)\\\\\\
-a^3  &=  σ(W^3a^2 + b^3)\\\\\\
-⋯\\\\\\
-a^L  &= σ(W^La^{L-1} + b^L)\\\\\\
+a^1  &= x\\\\
+a^2  &=  σ(W^2a^1 + b^2)\\\\
+a^3  &=  σ(W^3a^2 + b^3)\\\\
+⋯\\\\
+a^L  &= σ(W^La^{L-1} + b^L)\\\\
 y  &= a^L
 \end{align}
 
@@ -55,8 +55,8 @@ y  &= a^L
 
 \begin{equation}
 \begin{cases}
-u\_t = ku\_{xx} \\\\\\
-u(x,0) = T\_1 , & x <0 \\\\\\
+u\_t = ku\_{xx} \\\\
+u(x,0) = T\_1 , & x <0 \\\\
 u(x,0) = T\_2 , & x > 0
 \end{cases}
 \end{equation}
@@ -73,3 +73,21 @@ link!
 \begin{equation}
 \mathcal{L}\left[ e^{at} \right\]\(z) = \frac{1}{z-a}
 \end{equation}
+
+
+## Backslashes within a LaTeX equation {#backslashes-within-a-latex-equation}
+
+`ox-hugo` Issue #[458](https://github.com/kaushalmodi/ox-hugo/issues/458)
+
+Double backslashes (`\\`) should be escaped:
+\\[\sum\_{\substack{0<i<m\\\0<j<n}}\\]
+
+A backslash before any ASCII punctuation character should be escaped,
+for example, `\,`, `\;`, `\:`, `\!` are used to control the width of
+spacing:
+  \\[ab\\]
+  \\[a\ b\\]
+  \\[a\\,b\\]
+  \\[a\\;b\\]
+  \\[a\\:b\\]
+  \\[a\\!b\\]

--- a/test/site/content/real-examples/nn-intro.md
+++ b/test/site/content/real-examples/nn-intro.md
@@ -44,9 +44,9 @@ Disclaimer
 a
 = \sigma(
     \left[ \begin{matrix}
-        w\_{1} & ⋯  & w\_{n} \\\\\\
+        w\_{1} & ⋯  & w\_{n} \\\\
     \end{matrix}\right]  ·
-    \left[ \begin{array}{x} x\_1 \\ ⋮ \\ ⋮ \\ x\_n \end{array}\right] +
+    \left[ \begin{array}{x} x\_1 \\\ ⋮ \\\ ⋮ \\\ x\_n \end{array}\right] +
     b
 )
 \\]
@@ -83,15 +83,15 @@ a
 ##### 激活函数向量表达式 {#激活函数向量表达式}
 
 \\[
-\left[ \begin{array}{a} a\_1 \\ ⋮ \\ a\_s \end{array}\right]
+\left[ \begin{array}{a} a\_1 \\\ ⋮ \\\ a\_s \end{array}\right]
 = \sigma(
     \left[ \begin{matrix}
-        w\_{1,1} & ⋯  & w\_{1,n} \\\\\\
-        ⋮ & ⋱  & ⋮  \\\\\\
-        w\_{s,1} & ⋯  & w\_{s,n} \\\\\\
+        w\_{1,1} & ⋯  & w\_{1,n} \\\\
+        ⋮ & ⋱  & ⋮  \\\\
+        w\_{s,1} & ⋯  & w\_{s,n} \\\\
     \end{matrix}\right]  ·
-    \left[ \begin{array}{x} x\_1 \\ ⋮ \\ ⋮ \\ x\_n \end{array}\right] +
-    \left[ \begin{array}{b} b\_1 \\ ⋮ \\ b\_s \end{array}\right]
+    \left[ \begin{array}{x} x\_1 \\\ ⋮ \\\ ⋮ \\\ x\_n \end{array}\right] +
+    \left[ \begin{array}{b} b\_1 \\\ ⋮ \\\ b\_s \end{array}\right]
 )
 \\]
 
@@ -121,15 +121,15 @@ a
 ##### 激活函数矩阵表达式 {#激活函数矩阵表达式}
 
 \\[
-\left[ \begin{array}{a} a^l\_1 \\ ⋮ \\ a^l\_{d\_l} \end{array}\right]
+\left[ \begin{array}{a} a^l\_1 \\\ ⋮ \\\ a^l\_{d\_l} \end{array}\right]
 = \sigma(
     \left[ \begin{matrix}
-        w^l\_{1,1} & ⋯  & w^l\_{1,d\_{l-1}} \\\\\\
-        ⋮ & ⋱  & ⋮  \\\\\\
-        w^l\_{d\_l,1} & ⋯  & w^l\_{d\_l,d\_{l-1}} \\\\\\
+        w^l\_{1,1} & ⋯  & w^l\_{1,d\_{l-1}} \\\\
+        ⋮ & ⋱  & ⋮  \\\\
+        w^l\_{d\_l,1} & ⋯  & w^l\_{d\_l,d\_{l-1}} \\\\
     \end{matrix}\right]  ·
-    \left[ \begin{array}{x} a^{l-1}\_1 \\ ⋮ \\ ⋮ \\ a^{l-1}\_{d\_{l-1}} \end{array}\right] +
-    \left[ \begin{array}{b} b^l\_1 \\ ⋮ \\ b^l\_{d\_l} \end{array}\right])
+    \left[ \begin{array}{x} a^{l-1}\_1 \\\ ⋮ \\\ ⋮ \\\ a^{l-1}\_{d\_{l-1}} \end{array}\right] +
+    \left[ \begin{array}{b} b^l\_1 \\\ ⋮ \\\ b^l\_{d\_l} \end{array}\right])
 \\]
 
 
@@ -159,12 +159,12 @@ a
 计算过程如下：
 
 \begin{align}
-a^1  &= x \\\\\\
-a^2  &=  σ(W^2a^1 + b^2) \\\\\\
-a^3  &=  σ(W^3a^2 + b^3) \\\\\\
-⋯ \\\\\\
-a^L  &= σ(W^La^{L-1} + b^L) \\\\\\
-y  &= a^L \\\\\\
+a^1  &= x \\\\
+a^2  &=  σ(W^2a^1 + b^2) \\\\
+a^3  &=  σ(W^3a^2 + b^3) \\\\
+⋯ \\\\
+a^L  &= σ(W^La^{L-1} + b^L) \\\\
+y  &= a^L \\\\
 \end{align}
 
 推断实际上就是一系列矩阵乘法与向量运算，一个训练好的神经网络可以高效地使用各种语言实现。神经网络的功能是通过推断而体现的。推断实现起来很简单，但如何 **训练神经网络** 才是真正的难点。
@@ -228,9 +228,9 @@ MSE，而不是诸如"正确分类图像个数"的指标，是因为只有一个
 ΔC ≈ \frac{∂C}{∂v\_1} Δv\_1 + \frac{∂C}{∂v\_2} Δv\_2
 \\]
 
-这里 \\(Δv\\) 是向量： \\(Δv = \left[ \begin{array}{v} Δv\_1 \\ Δv\_2
+这里 \\(Δv\\) 是向量： \\(Δv = \left[ \begin{array}{v} Δv\_1 \\\ Δv\_2
 \end{array}\right]\\) ， \\(∇C\\)  是梯度向量 \\(\left[ \begin{array}{C}
-\frac{∂C}{∂v\_1} \\ \frac{∂C}{∂v\_2} \end{array} \right]\\) ，于是上式可重写为
+\frac{∂C}{∂v\_1} \\\ \frac{∂C}{∂v\_2} \end{array} \right]\\) ，于是上式可重写为
 
 \\[
 ΔC ≈ ∇C·Δv
@@ -246,7 +246,7 @@ MSE，而不是诸如"正确分类图像个数"的指标，是因为只有一个
  \\(w,b\\) 数目非常巨大
 
 \\[
-w →w' = w-η\frac{∂C}{∂w} \\\\\\
+w →w' = w-η\frac{∂C}{∂w} \\\\
 b → b' = b-η\frac{∂C}{∂b}
 \\]
 
@@ -373,10 +373,10 @@ z^{l+1}\_k = W^{l+1}\_{k,\*} ·a^l + b^{l+1}\_{k}  =   W^{l+1}\_{k,\*} · σ(z^{
 回代则有：
 
 \begin{align}
-δ^l\_j & = \sum\_{k=1}^{d\_{l+1}}  (δ^{l+1}\_k  \frac{∂z^{l+1}\_k}{∂z^{l}\_j})  \\\\\\
-& = σ'(z^l)   \sum\_{k=1}^{d\_{l+1}}     (δ^{l+1}\_k  w^{l+1}\_{kj}) \\\\\\
-& = σ'(z^l) ⊙  [(δ^{l+1}) · W^{l+1}\_{\*.j}] \\\\\\
-& = σ'(z^l) ⊙ [(W^{l+1})^T\_{j,\*} ·  (δ^{l+1}) ]\\\\\\
+δ^l\_j & = \sum\_{k=1}^{d\_{l+1}}  (δ^{l+1}\_k  \frac{∂z^{l+1}\_k}{∂z^{l}\_j})  \\\\
+& = σ'(z^l)   \sum\_{k=1}^{d\_{l+1}}     (δ^{l+1}\_k  w^{l+1}\_{kj}) \\\\
+& = σ'(z^l) ⊙  [(δ^{l+1}) · W^{l+1}\_{\*.j}] \\\\
+& = σ'(z^l) ⊙ [(W^{l+1})^T\_{j,\*} ·  (δ^{l+1}) ]\\\\
 \end{align}
 
 这里，对后一层所有神经元的误差权值之积求和，可以改写为两个向量的点积：


### PR DESCRIPTION
Hi, I refactored function `org-blackfriday-escape-chars-in-equation` according to the [specification of CommonMark](https://spec.commonmark.org/0.30/#backslash-escapes). Now it should be able to handle backslashes properly.

Also, according to the spec, backslashes before any ASCII punctuation character are escaped. This is useful in Latex, for example, `\,` means "thin space", and `\;` means "thick space".

This should fix #458

One issue is that this commit may break the support of Blackfriday (I didn't test it). But considering that most people are using Goldmark now, I think this should be OK.