### PR TITLE
make sure the extension is string before downcase

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2171,9 +2171,9 @@ and rewrite link paths to make blogging more seamless."
                                 " "     ;" </span>"
                                 ;; Escape the double-quotes, if any.
                                 (replace-regexp-in-string "\"" "\\\\\"" caption))))
-             (extension (downcase (file-name-extension raw-path)))
+             (extension (file-name-extension raw-path))
              (inlined-svg (and (stringp extension)
-                               (string= "svg" extension)
+                               (string= "svg" (downcase extension))
                                (plist-get attr :inlined))))
         ;; (message "[ox-hugo-link DBG] Inline image: %s, extension: %s" raw-path extension)
         ;; (message "[ox-hugo-link DBG] inlined svg? %S" inlined-svg)


### PR DESCRIPTION
`file-name-extension` returns nil for some links, e.g. http://example.com/test.jpg?imageView/1, and error `(wrong-type-argument char-or-string-p nil)` will be issued by `downcase` when exporting buffers containing such links. 