### PR TITLE
Breaking: Replace lt gt signs with html entities

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -782,8 +782,16 @@ matches with \"\\\" as needed."
   (when (plist-get info :with-smart-quotes)
     (setq text (org-export-activate-smart-quotes text :html info)))
   ;; The below series of replacements in `text' is order sensitive.
-  ;; Protect `, *, _, and \
+  ;; Protect `, *, _ and \
   (setq text (replace-regexp-in-string "[`*_\\]" "\\\\\\&" text))
+  ;; Encode `<' as `&lt;' except when it's present as part of a Hugo
+  ;; shortcode (`{{< .. >}}').
+  ;;              ^^
+  (setq text (replace-regexp-in-string "\\([^{]\\)\\(<\\)" "\\1&lt;" text))
+  ;; Encode `>' as `&gt;' except when it's present as part of a Hugo
+  ;; shortcode (`{{< .. >}}').
+  ;;                    ^^
+  (setq text (replace-regexp-in-string "\\(>\\)\\([^}]\\)" "&gt;\\2" text))
   ;; Protect ambiguous #.  This will protect # at the beginning of
   ;; a line, but not at the beginning of a paragraph.  See
   ;; `org-md-paragraph'.
@@ -1167,7 +1175,7 @@ contextual information."
          ;; Org removes all the leading whitespace only from the first
          ;; line.  So the trick is to use the ">" character before any
          ;; intended indentation on the first non-blank line.
-         (ret (replace-regexp-in-string "\\`\\([[:blank:]\n\r]*?\\)[[:blank:]]*>" "\\1" ret))
+         (ret (replace-regexp-in-string "\\`\\([[:blank:]\n\r]*?\\)[[:blank:]]*&gt;" "\\1" ret))
          (br (org-html-close-tag "br" nil info))
          (re (format "\\(?:%s\\)?[ \t]*\n" (regexp-quote br)))
          ;; Replace each newline character with line break.  Also

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -784,14 +784,12 @@ matches with \"\\\" as needed."
   ;; The below series of replacements in `text' is order sensitive.
   ;; Protect `, *, _ and \
   (setq text (replace-regexp-in-string "[`*_\\]" "\\\\\\&" text))
-  ;; Encode `<' as `&lt;' except when it's present as part of a Hugo
-  ;; shortcode (`{{< .. >}}').
-  ;;              ^^
-  (setq text (replace-regexp-in-string "\\([^{]\\)\\(<\\)" "\\1&lt;" text))
-  ;; Encode `>' as `&gt;' except when it's present as part of a Hugo
-  ;; shortcode (`{{< .. >}}').
-  ;;                    ^^
-  (setq text (replace-regexp-in-string "\\(>\\)\\([^}]\\)" "&gt;\\2" text))
+  ;; Protect the characters in `org-html-protect-char-alist' (`<',
+  ;; `>', `&').
+  (setq text (org-html-encode-plain-text text))
+  ;; Protect braces when verbatim shortcode mentions are detected.
+  (setq text (replace-regexp-in-string "{{%" "{&lbrace;%" text))
+  (setq text (replace-regexp-in-string "%}}" "%&rbrace;}" text))
   ;; Protect ambiguous #.  This will protect # at the beginning of
   ;; a line, but not at the beginning of a paragraph.  See
   ;; `org-md-paragraph'.

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -1722,8 +1722,8 @@ there.
 The =figure= shortcodes in the two Markdown source code blocks below
 should *not* be expanded.. they should be visible verbatim.
 
-- {&lbrace;< .. >}&rbrace; --- [[https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown][Shortcodes without Markdown]]
-- {&lbrace;% .. %}&rbrace; --- [[https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown][Shortcodes with Markdown]]
+- {{< .. >}} --- [[https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown][Shortcodes without Markdown]]
+- {{% .. %}} --- [[https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown][Shortcodes with Markdown]]
 **** Code block using code fences
 #+begin_src md
 {{< figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" >}}
@@ -1737,16 +1737,27 @@ auto-enable[fn:4] using the =highlight= shortcode.
 {{% figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" %}}
 #+end_src
 *** Shortcodes *not* escaped
-The =figure= shortcodes in the below example block *should* be
-expanded.. you should be seeing little unicorns below.
+The =figure= shortcode in the below example block *should* be
+expanded.. you should be seeing a little unicorn below.
 #+begin_example
 {{< figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" >}}
-{{% figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" %}}
 #+end_example
+
 Above a =#+begin_example= .. =#+end_example= block is chosen
 arbitrarily. The Hugo shortcodes will remain unescaped in *any*
 source/example block except for _Markdown source blocks_ (annotated
 with =md= language).
+
+Below, the same ~figure~ shortcode is called with the ~%~ syntax.
+
+- Note :: If you are using Hugo 0.55.0 or newer, you will just see the
+  raw HTML from this shortcode (unrendered HTML) because the behavior
+  of {{% .. %}} shortcodes [[https://gohugo.io/news/0.55.0-relnotes/#shortcodes-revised][changed in Hugo v0.55.0]].
+
+#+begin_example
+{{% figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" %}}
+#+end_example
+
 -----
 *It is necessary to set the Hugo site config variable
 =pygmentsCodeFences= to =true= for syntax highlighting to work for
@@ -3314,14 +3325,13 @@ $$ a=+\sqrt{2} $$ or \[ a=-\sqrt{2} \]
 :EXPORT_FILE_NAME: equations-with-r-c
 :END:
 #+begin_description
-Test to check that &reg;, &copy; and &trade; don't get interpreted
-within equations.
+Test to check that \reg, \copy and \trade don't get interpreted within equations.
 #+end_description
 {{{oxhugoissue(104)}}}
 
-Below, =(r)= or =(R)= should not get converted to &reg;, =(c)= or
-=(C)= should not get converted to &copy;, and =(tm)= or =(TM)= should
-not get converted to &trade;:
+Below, =(r)= or =(R)= should not get converted to \reg, =(c)= or =(C)=
+should not get converted to \copy, and =(tm)= or =(TM)= should not get
+converted to \trade:
 
 - $(r)$ $(R)$
 - $(c)$ $(C)$
@@ -3988,6 +3998,16 @@ removed when translating to Markdown.
   >				Text indented by 4 tab characters
   #+end_verse
 *** Corner cases
+#+begin_src org -n 0
+,#+begin_verse
+
+>Line 1 above was empty. So the first =>= seen on this line is removed.
+Line 3 had no =>= char.
+> ← See that this =>= on line 4 is retained even at the beginning of the line.
+Line 5 has this > charcter in-between and is retained.
+,#+end_verse
+#+end_src
+
 Only the *first* =>= character immediately following spaces and empty
 lines will be removed:
 #+begin_verse
@@ -4002,6 +4022,17 @@ If someone really wants to have =>= as the first non-blank character
 in the final output, they can use =>>= instead.. *only for that first
 instance*. The below Verse block is same as above except that the
 first =>= is retained in the final output.
+
+#+begin_src org -n 0
+,#+begin_verse
+
+>>Line 1 above was empty. So *only* the first =>= seen on this line is removed.
+Line 3 had no =>= char.
+> ← See that this =>= on line 4 is retained even at the beginning of the line.
+Line 5 has this > charcter in-between and is retained.
+,#+end_verse
+#+end_src
+
 #+begin_verse
 
 >>Line 1 above was empty. So *only* the first =>= seen on this line is removed.

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2390,7 +2390,7 @@ matter of the post because HTML does not allow markup in the =<title>=
 section.
 
 So the title of this post should read as "ndash and mdash".
-** Escaping hashes and exclamations correctly in body
+** Escaping hashes and exclamations correctly in body              :escaping:
 :PROPERTIES:
 :EXPORT_FILE_NAME: escaping-hashes-and-exclamations-in-body
 :END:
@@ -2419,6 +2419,30 @@ Hash char at beginning of a continued line
 Markdown]
 
 This ! does not need to be escaped as there is no ambiguity.
+** Escaping angle brackets                          :escaping:angle_brackets:
+:PROPERTIES:
+:EXPORT_FILE_NAME: escaping-angle-brackets
+:END:
+#+begin_description
+Test the escaping of angle brackets because they are used in HTML tags.
+#+end_description
+- some <text>
+- some < /italic text/ > (spaces are required between the italics
+  formatting chars and ~<~ / ~>~)
+
+If you really need to put verbatim HTML in Org source, use
+~#+begin_export html~ block:
+
+#+begin_export html
+<ul>
+  <li><b>This is in bold</b></li>
+  <li><i>This is in italics</i></li>
+</ul>
+#+end_export
+
+This also works if you /desperately need/ to inline HTML within your
+Org source: @@html:<b>This is bold</b>@@ .. But why@@html:<span
+style="color:red;">‽</span>@@.
 ** Force line break / Center align                         :force:line_break:
 *** Force line break
 :PROPERTIES:
@@ -4348,35 +4372,61 @@ Here's a warning!
 :EXPORT_FILE_NAME: paired-shortcodes-special-blocks-no-arguments
 :EXPORT_HUGO_PAIRED_SHORTCODES: %mdshortcode myshortcode
 :END:
+#+begin_description
+Tests for paired shortcodes with no arguments.
+#+end_description
 Test case for feature requested in {{{oxhugoissue(119)}}}.
 **** Paired markdown shortcode
+#+begin_src org
+,#+begin_mdshortcode
+Content *with* /emphasis/ characters is rendered.
+,#+end_mdshortcode
+#+end_src
+
+Above will export as:
+
+#+begin_src md
+{{% mdshortcode %}}
+Content *with* /emphasis/ characters is rendered.
+{{% /mdshortcode %}}
+#+end_src
+
+and render as:
+
 #+begin_mdshortcode
 Content *with* /emphasis/ characters is rendered.
-
-The HTML <b>markup</b> will also get rendered.
 #+end_mdshortcode
-
-This will export as:
-
-#+begin_src md
-{{% mdshortcode %}} Content rendered as Markdown {{% /mdshortcode %}}
-#+end_src
 **** Paired non-markdown (default) shortcode
-#+begin_myshortcode
-Content is rendered <b>like HTML</b>. The Markdown /emphasis/
-characters are !! NOT !! rendered.
+Markdown is !! NOT !! rendered in non-markdown shortcodes.
+
+#+begin_src org
+,#+begin_myshortcode
+The Markdown /emphasis/ characters are !! NOT !! rendered.
 
 So a blank line before this sentence in the Markdown source will
-<b>not</b> result in a new paragraph in HTML. <p>But this will be a
-new paragraph as it is wrapped in HTML <code>&lt;p&gt;</code>
-tags.</p>
-#+end_myshortcode
+not result in a new paragraph in HTML.
+,#+end_myshortcode
+#+end_src
 
-This will export as:
+Above will export as:
 
 #+begin_src md
-{{< myshortcode >}} Content NOT rendered as Markdown {{< /myshortcode >}}
+{{< myshortcode >}}
+The Markdown /emphasis/ characters are !! NOT !! rendered.
+
+So a blank line before this sentence in the Markdown source will
+not result in a new paragraph in HTML.
+{{< /myshortcode >}}
 #+end_src
+
+and render as:
+
+#+begin_myshortcode
+The Markdown /emphasis/ characters are !! NOT !! rendered.
+
+So a blank line before this sentence in the Markdown source will
+not result in a new paragraph in HTML.
+#+end_myshortcode
 **** Not a recognized paired shortcode
 #+begin_foo
 Content *with* Markdown /emphasis/ characters is rendered fine in the
@@ -4390,6 +4440,10 @@ tags or HTML5-recognized tags.
 :EXPORT_FILE_NAME: paired-shortcodes-special-blocks-positional-arguments
 :EXPORT_HUGO_PAIRED_SHORTCODES: %alert myshortcode-pos
 :END:
+#+begin_description
+Tests for paired shortcodes with positional arguments.
+#+end_description
+
 Test case for feature requested in {{{oxhugoissue(119)}}}.
 **** Paired markdown shortcode
 The =alert= shortcode takes 1 positional argument.
@@ -4400,8 +4454,6 @@ The =alert= shortcode takes 1 positional argument.
 #+attr_shortcode: note
 #+begin_alert
 Content *with* /emphasis/ characters is rendered.
-
-The HTML <b>markup</b> will also get rendered.
 #+end_alert
 
 -----
@@ -4412,8 +4464,6 @@ Below is the about same as above, except that =warning= attribute
 #+attr_shortcode: warning
 #+begin_alert
 Content *with* /emphasis/ characters is rendered.
-
-The HTML <b>markup</b> will also get rendered.
 #+end_alert
 **** Paired non-markdown (default) shortcode
 The =myshortcode-pos= takes 2 positional arguments. In the below
@@ -4422,14 +4472,17 @@ and ="zoo"= will be the /second/.
 
 #+attr_shortcode: "foo bar" zoo
 #+begin_myshortcode-pos
-Content is rendered <b>like HTML</b>. The Markdown /emphasis/
-characters are !! NOT !! rendered.
+The Markdown /emphasis/ characters are !! NOT !! rendered.
 #+end_myshortcode-pos
 *** Paired shortcodes using special blocks (Named Arguments) :arguments:named:
 :PROPERTIES:
 :EXPORT_FILE_NAME: paired-shortcodes-special-blocks-named-arguments
 :EXPORT_HUGO_PAIRED_SHORTCODES: %mdshortcode-named myshortcode-named
 :END:
+#+begin_description
+Tests for paired shortcodes with named arguments.
+#+end_description
+
 Test case for feature requested in {{{oxhugoissue(119)}}}.
 **** Paired markdown shortcode
 In the below example, ="foo bar"= will be the /arg1/ argument, and
@@ -4438,8 +4491,6 @@ In the below example, ="foo bar"= will be the /arg1/ argument, and
 #+attr_shortcode: :arg1 foo bar :arg2 color: red; text-align: center;
 #+begin_mdshortcode-named
 Content *with* /emphasis/ characters is rendered.
-
-The HTML <b>markup</b> will also get rendered.
 #+end_mdshortcode-named
 **** Paired non-markdown (default) shortcode
 In the below example, ="foo"= will be the /arg1/ argument, and
@@ -4447,8 +4498,7 @@ In the below example, ="foo"= will be the /arg1/ argument, and
 
 #+attr_shortcode: :arg1 foo :arg2 color:green;
 #+begin_myshortcode-named
-Content is rendered <b>like HTML</b>. The Markdown /emphasis/
-characters are !! NOT !! rendered.
+The Markdown /emphasis/ characters are !! NOT !! rendered.
 #+end_myshortcode-named
 ** Using Org macros in lieu of Hugo shortcodes
 :PROPERTIES:

--- a/test/site/content-org/single-posts/post_with_underscore_in_name.org
+++ b/test/site/content-org/single-posts/post_with_underscore_in_name.org
@@ -7,6 +7,7 @@
 #+hugo_tags: "cross-link"
 #+description: Test post to test another ox-hugo test.
 
-This test post is created to test [{{< relref
-"italicize-links-with-underscores" >}}]({{< relref
-"italicize-links-with-underscores" >}}).
+#+macro: relref @@md:[$1]({{< relref "$2" >}})@@
+
+This test post is created to test {{{relref(Italicize links with
+underscores,italicize-links-with-underscores)}}}.

--- a/test/site/content/posts/equations-with-r-c.md
+++ b/test/site/content/posts/equations-with-r-c.md
@@ -1,9 +1,6 @@
 +++
 title = "Equations with (r), (c), .."
-description = """
-  Test to check that &reg;, &copy; and &trade; don't get interpreted
-  within equations.
-  """
+description = "Test to check that &reg;, &copy; and &trade; don't get interpreted within equations."
 tags = ["equations", "mathjax"]
 categories = ["upstream"]
 draft = false
@@ -11,9 +8,9 @@ draft = false
 
 `ox-hugo` Issue #[104](https://github.com/kaushalmodi/ox-hugo/issues/104)
 
-Below, `(r)` or `(R)` should not get converted to &reg;, `(c)` or
-`(C)` should not get converted to &copy;, and `(tm)` or `(TM)` should
-not get converted to &trade;:
+Below, `(r)` or `(R)` should not get converted to &reg;, `(c)` or `(C)`
+should not get converted to &copy;, and `(tm)` or `(TM)` should not get
+converted to &trade;:
 
 -   \\(( r)\\) \\(( R)\\)
 -   \\(( c)\\) \\(( C)\\)

--- a/test/site/content/posts/escaping-angle-brackets.md
+++ b/test/site/content/posts/escaping-angle-brackets.md
@@ -1,0 +1,22 @@
++++
+title = "Escaping angle brackets"
+description = "Test the escaping of angle brackets because they are used in HTML tags."
+tags = ["body", "escaping", "angle-brackets"]
+draft = false
++++
+
+-   some &lt;text&gt;
+-   some &lt; _italic text_ &gt; (spaces are required between the italics
+    formatting chars and `<` / `>`)
+
+If you really need to put verbatim HTML in Org source, use
+`#+begin_export html` block:
+
+<ul>
+  <li><b>This is in bold</b></li>
+  <li><i>This is in italics</i></li>
+</ul>
+
+This also works if you _desperately need_ to inline HTML within your
+Org source: <b>This is bold</b> .. But why<span
+style="color:red;">‽</span>.

--- a/test/site/content/posts/escaping-hashes-and-exclamations-in-body.md
+++ b/test/site/content/posts/escaping-hashes-and-exclamations-in-body.md
@@ -1,6 +1,6 @@
 +++
 title = "Escaping hashes and exclamations correctly in body"
-tags = ["body"]
+tags = ["body", "escaping"]
 draft = false
 +++
 

--- a/test/site/content/posts/paired-shortcodes-special-blocks-named-arguments.md
+++ b/test/site/content/posts/paired-shortcodes-special-blocks-named-arguments.md
@@ -1,5 +1,6 @@
 +++
 title = "Paired shortcodes using special blocks (Named Arguments)"
+description = "Tests for paired shortcodes with named arguments."
 tags = ["shortcode", "paired", "special-block", "arguments", "named"]
 draft = false
 +++
@@ -14,8 +15,6 @@ In the below example, `"foo bar"` will be the _arg1_ argument, and
 
 {{% mdshortcode-named arg1="foo bar" arg2="color: red; text-align: center;" %}}
 Content **with** _emphasis_ characters is rendered.
-
-The HTML <b>markup</b> will also get rendered.
 {{% /mdshortcode-named %}}
 
 
@@ -25,6 +24,5 @@ In the below example, `"foo"` will be the _arg1_ argument, and
 `"color:green;"` will be the _arg2_ argument.
 
 {{< myshortcode-named arg1="foo" arg2="color:green;" >}}
-Content is rendered <b>like HTML</b>. The Markdown _emphasis_
-characters are !! NOT !! rendered.
+The Markdown _emphasis_ characters are !! NOT !! rendered.
 {{< /myshortcode-named >}}

--- a/test/site/content/posts/paired-shortcodes-special-blocks-no-arguments.md
+++ b/test/site/content/posts/paired-shortcodes-special-blocks-no-arguments.md
@@ -1,5 +1,6 @@
 +++
 title = "Paired Shortcodes using special blocks (No Arguments)"
+description = "Tests for paired shortcodes with no arguments."
 tags = ["shortcode", "paired", "special-block", "no-arguments"]
 draft = false
 +++
@@ -9,36 +10,59 @@ Test case for feature requested in `ox-hugo` Issue #[119](https://github.com/kau
 
 ## Paired markdown shortcode {#paired-markdown-shortcode}
 
-{{% mdshortcode %}}
-Content **with** _emphasis_ characters is rendered.
+```org
+#+begin_mdshortcode
+Content *with* /emphasis/ characters is rendered.
+#+end_mdshortcode
+```
 
-The HTML <b>markup</b> will also get rendered.
-{{% /mdshortcode %}}
-
-This will export as:
+Above will export as:
 
 ```md
-{{%/* mdshortcode */%}} Content rendered as Markdown {{%/* /mdshortcode */%}}
+{{%/* mdshortcode */%}}
+Content *with* /emphasis/ characters is rendered.
+{{%/* /mdshortcode */%}}
 ```
+
+and render as:
+
+{{% mdshortcode %}}
+Content **with** _emphasis_ characters is rendered.
+{{% /mdshortcode %}}
 
 
 ## Paired non-markdown (default) shortcode {#paired-non-markdown--default--shortcode}
 
-{{< myshortcode >}}
-Content is rendered <b>like HTML</b>. The Markdown _emphasis_
-characters are !! NOT !! rendered.
+Markdown is !! NOT !! rendered in non-markdown shortcodes.
+
+```org
+#+begin_myshortcode
+The Markdown /emphasis/ characters are !! NOT !! rendered.
 
 So a blank line before this sentence in the Markdown source will
-<b>not</b> result in a new paragraph in HTML. <p>But this will be a
-new paragraph as it is wrapped in HTML <code>&lt;p&gt;</code>
-tags.</p>
-{{< /myshortcode >}}
+not result in a new paragraph in HTML.
+#+end_myshortcode
+```
 
-This will export as:
+Above will export as:
 
 ```md
-{{</* myshortcode */>}} Content NOT rendered as Markdown {{</* /myshortcode */>}}
+{{</* myshortcode */>}}
+The Markdown /emphasis/ characters are !! NOT !! rendered.
+
+So a blank line before this sentence in the Markdown source will
+not result in a new paragraph in HTML.
+{{</* /myshortcode */>}}
 ```
+
+and render as:
+
+{{< myshortcode >}}
+The Markdown _emphasis_ characters are !! NOT !! rendered.
+
+So a blank line before this sentence in the Markdown source will
+not result in a new paragraph in HTML.
+{{< /myshortcode >}}
 
 
 ## Not a recognized paired shortcode {#not-a-recognized-paired-shortcode}

--- a/test/site/content/posts/paired-shortcodes-special-blocks-positional-arguments.md
+++ b/test/site/content/posts/paired-shortcodes-special-blocks-positional-arguments.md
@@ -1,5 +1,6 @@
 +++
 title = "Paired shortcodes using special blocks (Positional Arguments)"
+description = "Tests for paired shortcodes with positional arguments."
 tags = ["shortcode", "paired", "special-block", "positional", "arguments"]
 draft = false
 +++
@@ -79,8 +80,6 @@ The `alert` shortcode takes 1 positional argument.
 
 {{% alert note %}}
 Content **with** _emphasis_ characters is rendered.
-
-The HTML <b>markup</b> will also get rendered.
 {{% /alert %}}
 
 ---
@@ -90,8 +89,6 @@ Below is the about same as above, except that `warning` attribute
 
 {{% alert warning %}}
 Content **with** _emphasis_ characters is rendered.
-
-The HTML <b>markup</b> will also get rendered.
 {{% /alert %}}
 
 
@@ -102,6 +99,5 @@ example, the double-quoted `"foo bar"` will be the _first_ argument,
 and `"zoo"` will be the _second_.
 
 {{< myshortcode-pos "foo bar" zoo >}}
-Content is rendered <b>like HTML</b>. The Markdown _emphasis_
-characters are !! NOT !! rendered.
+The Markdown _emphasis_ characters are !! NOT !! rendered.
 {{< /myshortcode-pos >}}

--- a/test/site/content/posts/post-heading-slugs.md
+++ b/test/site/content/posts/post-heading-slugs.md
@@ -10,7 +10,7 @@ draft = false
 ## Foo ( Bar ) Baz {#foo--bar--baz}
 
 
-## (Foo)Bar.Baz&Zoo {#foo--bar-dot-baz-and-zoo}
+## (Foo)Bar.Baz&amp;Zoo {#foo--bar-dot-baz-and-zoo}
 
 -   `.` → `dot`
 -   `&` → `and`

--- a/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
+++ b/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
@@ -9,7 +9,7 @@ draft = false
 The `figure` shortcodes in the two Markdown source code blocks below
 should **not** be expanded.. they should be visible verbatim.
 
--   {&lbrace;< .. >}&rbrace; --- [Shortcodes without Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown)
+-   {&lbrace;&lt; .. >}&rbrace; --- [Shortcodes without Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown)
 -   {&lbrace;% .. %}&rbrace; --- [Shortcodes with Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown)
 
 

--- a/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
+++ b/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
@@ -9,8 +9,8 @@ draft = false
 The `figure` shortcodes in the two Markdown source code blocks below
 should **not** be expanded.. they should be visible verbatim.
 
--   {&lbrace;&lt; .. >}&rbrace; --- [Shortcodes without Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown)
--   {&lbrace;% .. %}&rbrace; --- [Shortcodes with Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown)
+-   {{&lt; .. &gt;}} --- [Shortcodes without Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown)
+-   {&lbrace;% .. %&rbrace;} --- [Shortcodes with Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown)
 
 
 ### Code block using code fences {#code-block-using-code-fences}
@@ -34,18 +34,30 @@ auto-enable[^fn:1] using the `highlight` shortcode.
 
 ## Shortcodes **not** escaped {#shortcodes-not-escaped}
 
-The `figure` shortcodes in the below example block **should** be
-expanded.. you should be seeing little unicorns below.
+The `figure` shortcode in the below example block **should** be
+expanded.. you should be seeing a little unicorn below.
 
 ```text
 {{< figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" >}}
-{{% figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" %}}
 ```
 
 Above a `#+begin_example` .. `#+end_example` block is chosen
 arbitrarily. The Hugo shortcodes will remain unescaped in **any**
 source/example block except for <span class="underline">Markdown source blocks</span> (annotated
 with `md` language).
+
+Below, the same `figure` shortcode is called with the `%` syntax.
+
+Note
+: If you are using Hugo 0.55.0 or newer, you will just see the
+    raw HTML from this shortcode (unrendered HTML) because the behavior
+    of {&lbrace;% .. %&rbrace;} shortcodes [changed in Hugo v0.55.0](https://gohugo.io/news/0.55.0-relnotes/#shortcodes-revised).
+
+<!--listend-->
+
+```text
+{{% figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" %}}
+```
 
 ---
 

--- a/test/site/content/posts/verse-for-indentation.md
+++ b/test/site/content/posts/verse-for-indentation.md
@@ -53,8 +53,8 @@ lines will be removed:
 <br />
 Line 1 above was empty. So the first `>` seen on this line is removed.<br />
 Line 3 had no `>` char.<br />
-> ← See that this `>` on line 4 is retained even at the beginning of the line.<br />
-Line 5 has this > charcter in-between and is retained.<br />
+&gt; ← See that this `>` on line 4 is retained even at the beginning of the line.<br />
+Line 5 has this &gt; charcter in-between and is retained.<br />
 </p>
 
 If someone really wants to have `>` as the first non-blank character
@@ -66,6 +66,6 @@ first `>` is retained in the final output.
 <br />
 >Line 1 above was empty. So **only** the first `>` seen on this line is removed.<br />
 Line 3 had no `>` char.<br />
-> ← See that this `>` on line 4 is retained even at the beginning of the line.<br />
-Line 5 has this > charcter in-between and is retained.<br />
+&gt; ← See that this `>` on line 4 is retained even at the beginning of the line.<br />
+Line 5 has this &gt; charcter in-between and is retained.<br />
 </p>

--- a/test/site/content/posts/verse-for-indentation.md
+++ b/test/site/content/posts/verse-for-indentation.md
@@ -46,6 +46,16 @@ removed when translating to Markdown.
 
 ## Corner cases {#corner-cases}
 
+{{< highlight org "linenos=table, linenostart=0" >}}
+#+begin_verse
+
+>Line 1 above was empty. So the first =>= seen on this line is removed.
+Line 3 had no =>= char.
+> ← See that this =>= on line 4 is retained even at the beginning of the line.
+Line 5 has this > charcter in-between and is retained.
+#+end_verse
+{{< /highlight >}}
+
 Only the **first** `>` character immediately following spaces and empty
 lines will be removed:
 
@@ -62,9 +72,19 @@ in the final output, they can use `>>` instead.. **only for that first
 instance**. The below Verse block is same as above except that the
 first `>` is retained in the final output.
 
+{{< highlight org "linenos=table, linenostart=0" >}}
+#+begin_verse
+
+>>Line 1 above was empty. So *only* the first =>= seen on this line is removed.
+Line 3 had no =>= char.
+> ← See that this =>= on line 4 is retained even at the beginning of the line.
+Line 5 has this > charcter in-between and is retained.
+#+end_verse
+{{< /highlight >}}
+
 <p class="verse">
 <br />
->Line 1 above was empty. So **only** the first `>` seen on this line is removed.<br />
+&gt;Line 1 above was empty. So **only** the first `>` seen on this line is removed.<br />
 Line 3 had no `>` char.<br />
 &gt; ← See that this `>` on line 4 is retained even at the beginning of the line.<br />
 Line 5 has this &gt; charcter in-between and is retained.<br />

--- a/test/site/content/singles/post_with_underscore_in_name.md
+++ b/test/site/content/singles/post_with_underscore_in_name.md
@@ -6,6 +6,4 @@ tags = ["cross-link"]
 draft = false
 +++
 
-This test post is created to test [{{< relref
-"italicize-links-with-underscores" >}}]({{< relref
-"italicize-links-with-underscores" >}}).
+This test post is created to test [Italicize links with underscores]({{< relref "italicize-links-with-underscores" >}}).

--- a/test/site/layouts/shortcodes/mdshortcode-named.html
+++ b/test/site/layouts/shortcodes/mdshortcode-named.html
@@ -1,7 +1,7 @@
+<!-- Interestingly if safeCSS is not used above, the style gets
+     assigned a "ZgotmplZ" value. -- https://stackoverflow.com/a/14796642/1219634
+-->
 <div class="{{ .Get "arg1" }}" style="{{ .Get "arg2" | safeCSS }}">
-    <!-- Interestingly if safeCSS is not used above, the style gets
-         assigned a "ZgotmplZ" value. -- https://stackoverflow.com/a/14796642/1219634
-    -->
     <ul>
         <li><b>arg1:</b> {{ .Get "arg1" }}</li>
         <li><b>arg2:</b> {{ .Get "arg2" }}</li>


### PR DESCRIPTION
- `<`, `>` and `&` in Org source are now protected.
- This wouldn't be a breaking change in general. But users using Hugo shortcodes directly in Org source (which anyways isn't supported in `ox-hugo`) will be affected by this change.
  - But if users really need to use shortcodes in Org source, they can do so using `@@md:..@@`, `begin_export md` .. `#+end_export`, `#+begin_export html` .. `#+end_export` and similar methods already supported in Org.