### PR TITLE
Add `org-blackfriday-syntax-highlighting-langs`

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -69,6 +69,26 @@ Note that this variable is *only* for internal use.")
   :tag "Org Export Blackfriday"
   :group 'org-export)
 
+(defcustom org-blackfriday-syntax-highlighting-langs
+  '(("ipython" . "python")
+    ("jupyter-python" . "python"))
+  "Alist mapping src block languages to their syntax highlighting languages.
+
+The key is the src block language name.  The value is the
+language name to be used in the exported Markdown.  The value
+language name would be one that Hugo's Chroma syntax highlighter
+would understand.
+
+For most src languages, this variable will not need to be
+customized.  But there are some src block \"languages\" like
+`ipython' and `jupyter-python' for which, the exported language
+tag needs to be `python'."
+  :group 'org-export-blackfriday
+  :type '(repeat
+	  (cons
+	   (string "Src Block language")
+	   (string "Syntax highlighting language"))))
+
 
 
 ;;; Define Back-End
@@ -935,6 +955,7 @@ This function is adapted from `org-html-special-block'."
 
 INFO is a plist used as a communication channel."
   (let* ((lang (org-element-property :language src-block))
+         (lang (or (cdr (assoc lang org-blackfriday-syntax-highlighting-langs)) lang))
          (code (org-export-format-code-default src-block info))
          (parent-element (org-export-get-parent src-block))
          (parent-type (car parent-element))

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -1789,6 +1789,17 @@ Some text.
 #+end_src
 
 Some more text.
+** Source blocks with langs that need to be replaced in Markdown :lang:syntax_highlighting:
+:PROPERTIES:
+:EXPORT_FILE_NAME: source-block-replace-langs-in-exported-md
+:END:
+#+begin_src ipython
+(print "hello")
+#+end_src
+
+#+begin_src jupyter-python
+(print "hello")
+#+end_src
 * Formatting                                                     :formatting:
 ** General
 :PROPERTIES:

--- a/test/site/content/issues/424-exporting-results-blocks-from-included-org-files.md
+++ b/test/site/content/issues/424-exporting-results-blocks-from-included-org-files.md
@@ -15,7 +15,7 @@ Note
 
 <!--listend-->
 
-```jupyter-python
+```python
 lm_adam = LinearModel()
 lm_adam.to(device)
 optimizer = Adam(lm_adam.parameters(), weight_decay=0.0001)

--- a/test/site/content/posts/source-block-replace-langs-in-exported-md.md
+++ b/test/site/content/posts/source-block-replace-langs-in-exported-md.md
@@ -1,0 +1,13 @@
++++
+title = "Source blocks with langs that need to be replaced in Markdown"
+tags = ["src-block", "lang", "syntax-highlighting"]
+draft = false
++++
+
+```python
+(print "hello")
+```
+
+```python
+(print "hello")
+```


### PR DESCRIPTION
This allows replacing "langs" like `ipython` and `jupyter-python` with
just `python` when exported to Markdown.

Uses https://github.com/kaushalmodi/ox-hugo/pull/383 as
reference (Thanks @ahendriksen).

Fixes https://github.com/kaushalmodi/ox-hugo/issues/384.

Fixes https://github.com/kaushalmodi/ox-hugo/issues/189.