### PR TITLE
org-id: Add .dir-locals.el to the #500 test + Don't export empty anchors

### DIFF
--- a/test/site/content-org/org-roam/.dir-locals.el
+++ b/test/site/content-org/org-roam/.dir-locals.el
@@ -1,0 +1,4 @@
+((org-mode . ((org-hugo-base-dir . "../../")
+              (org-hugo-section . "org-roam")
+              (org-export-with-author . nil)
+              (eval . (org-hugo-auto-export-mode)))))

--- a/test/site/content-org/org-roam/org-roam-file-A.org
+++ b/test/site/content-org/org-roam/org-roam-file-A.org
@@ -1,9 +1,6 @@
 :PROPERTIES:
 :ID:       1e8ccec9-735d-41d0-b0cf-143d9c3e965d
 :END:
-#+hugo_base_dir: ../
-#+hugo_section: org-roam
-#+author:
 #+title: A
 #+filetags: org-roam @org-id
 

--- a/test/site/content-org/org-roam/org-roam-file-B.org
+++ b/test/site/content-org/org-roam/org-roam-file-B.org
@@ -1,9 +1,6 @@
 :PROPERTIES:
 :ID:       01579e8c-a90b-4c53-af58-e18ff7877d00
 :END:
-#+hugo_base_dir: ../
-#+hugo_section: org-roam
-#+author:
 #+title: B
 #+filetags: org-roam @org-id
 

--- a/test/site/content/org-id-links/org-id-link-parent.md
+++ b/test/site/content/org-id-links/org-id-link-parent.md
@@ -5,7 +5,7 @@ draft = false
 
 This is a parent page that link other page via Org-mode id links:
 
--   Point to a org file [Org-mode id links child]({{<relref "org-id-link-child.md#" >}})
--   Point to a section in org file [Section]({{<relref "org-id-link-child.md#section" >}})
--   Point to a org file that belongs another hugo_section [Org-mode ID links in other section]({{<relref "org-id-link-other-section.md#" >}})
--   Point to a section in org file that belongs another hugo_section [Section]({{<relref "org-id-link-other-section.md#section" >}})
+-   Point to a org file [Org-mode id links child]({{< relref "org-id-link-child.md" >}})
+-   Point to a section in org file [Section]({{< relref "org-id-link-child.md#section" >}})
+-   Point to a org file that belongs another hugo_section [Org-mode ID links in other section]({{< relref "org-id-link-other-section.md" >}})
+-   Point to a section in org file that belongs another hugo_section [Section]({{< relref "org-id-link-other-section.md#section" >}})

--- a/test/site/content/org-roam/org-roam-file-A.md
+++ b/test/site/content/org-roam/org-roam-file-A.md
@@ -7,4 +7,4 @@ draft = false
 
 <https://github.com/kaushalmodi/ox-hugo/issues/500>
 
-[B]({{<relref "org-roam-file-B.md#" >}})
+[B]({{< relref "org-roam-file-B.md" >}})


### PR DESCRIPTION
- Test ref #500 
- Unrelated commit that came up as was helping a user debug their issue.. needed to clean up an inconsistency with `relref` shortcode exports.