### PR TITLE
logbook content parsing

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -862,7 +862,11 @@ set.
 | =tags_weight = 123= (auto-calc)    | =:EXPORT_HUGO_WEIGHT: :tags auto=      | When set to =:FOO auto=, /FOO/ taxonomy weight is auto-calculated          |
 | =weight = 123= (in =[menu.foo]=)   | =:EXPORT_HUGO_MENU: :menu foo=         | Menu weight is auto-calculated unless specified                            |
 |------------------------------------+----------------------------------------+----------------------------------------------------------------------------|
-***** Notes
+Also see the [[*Custom Front-matter Parameters][Custom Front-matter Parameters]] section.
+***** Front-matter Precedence
+:PROPERTIES:
+:CUSTOM_ID: front-matter-precedence
+:END:
 - Precedence for =date= parsing ::
   1. First transition to a /DONE/ state recorded in =:LOGBOOK:= (see
      {{{titleref(Drawers#logbook-dates,Dates parsed from ~:LOGBOOK:~
@@ -871,15 +875,15 @@ set.
   3. =EXPORT_DATE= subtree property
   4. =#+date:= keyword
 - Precedence for =lastmod= parsing ::
-  1. =lastmod= set automatically if =:EXPORT_HUGO_AUTO_SET_LASTMOD: t=
-  2. Last (second or later) transition to a /DONE/ state recorded in
+  1. Last (second or later) transition to a /DONE/ state recorded in
      =:LOGBOOK:= (see {{{titleref(Drawers#logbook-dates,Dates parsed
      from ~:LOGBOOK:~ drawers)}}})
+  2. =lastmod= set automatically if =:EXPORT_HUGO_AUTO_SET_LASTMOD: t=
+     *and* if it's not derived from the =:LOGBOOK:= drawer.
   3. =EXPORT_HUGO_LASTMOD= subtree property or =#+hugo_lastmod:= keyword
-- Precedence for =draft= parsing :: Org TODO state based /draft/ state
-     /more than/ =EXPORT_HUGO_DRAFT= subtree property.
-- Custom front-matter parameters :: See the [[*Custom Front-matter Parameters][Custom Front-matter
-  Parameters]] section.
+- Precedence for =draft= parsing ::
+  1. Org TODO state based /draft/ state
+  2. =EXPORT_HUGO_DRAFT= subtree property
 **** For file-based exports
 #+caption: Hugo front-matter translation for file-based exports
 #+attr_html: :class sane-table
@@ -1089,6 +1093,11 @@ It's normal for one to choose to auto-set the /last modified/ date for
 all the posts. So instead of setting the above property for each post
 individually, it might be more convenient to simply put
 =#+hugo_auto_set_lastmod: t= at the top of the file.
+
+But note that if the =lastmod= date is parsed from the
+{{{titleref(Drawers#logbook-dates,~:LOGBOOK:~ drawer)}}} that value
+will take precedence, and the "auto set lastmod" feature will be
+disabled.
 *** Image Links
 :PROPERTIES:
 :EXPORT_FILE_NAME: image-links
@@ -4405,6 +4414,14 @@ state changed or under the heading where the ~org-add-note~ command
 
   Note that if only one transition to the /DONE/ state was recorded,
   then this front-matter variable remains unset.
+
+#+begin_note
+The ~date~ and ~lastmod~ values parsed from the ~:LOGBOOK:~ drawer
+state transitions will have the highest precedence. See
+{{{titleref(Org meta-data to Hugo
+front-matter#front-matter-precedence,Front-matter Precedence)}}} for
+more info.
+#+end_note
 ***** ~:LOGBOOK:~ Notes
 - Notes added to the ~:LOGBOOK:~ drawer under the post heading will be
   exported to the TOML Table Array ~[[logbook._toplevel.notes]]~ in

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -863,9 +863,19 @@ set.
 | =weight = 123= (in =[menu.foo]=)   | =:EXPORT_HUGO_MENU: :menu foo=         | Menu weight is auto-calculated unless specified                            |
 |------------------------------------+----------------------------------------+----------------------------------------------------------------------------|
 ***** Notes
-- Precedence for =date= parsing :: =CLOSED= subtree property /more
-     than/ =EXPORT_DATE= subtree property /more than/ =#+date:=
-     keyword.
+- Precedence for =date= parsing ::
+  1. First transition to a /DONE/ state recorded in =:LOGBOOK:= (see
+     {{{titleref(Drawers#logbook-dates,Dates parsed from ~:LOGBOOK:~
+     drawers)}}})
+  2. =CLOSED= subtree property
+  3. =EXPORT_DATE= subtree property
+  4. =#+date:= keyword
+- Precedence for =lastmod= parsing ::
+  1. =lastmod= set automatically if =:EXPORT_HUGO_AUTO_SET_LASTMOD: t=
+  2. Last (second or later) transition to a /DONE/ state recorded in
+     =:LOGBOOK:= (see {{{titleref(Drawers#logbook-dates,Dates parsed
+     from ~:LOGBOOK:~ drawers)}}})
+  3. =EXPORT_HUGO_LASTMOD= subtree property or =#+hugo_lastmod:= keyword
 - Precedence for =draft= parsing :: Org TODO state based /draft/ state
      /more than/ =EXPORT_HUGO_DRAFT= subtree property.
 - Custom front-matter parameters :: See the [[*Custom Front-matter Parameters][Custom Front-matter
@@ -4352,33 +4362,49 @@ are based on the ~org-export-dictionary~ variable from ~ox.el~.
 #+begin_description
 How Org Drawers get exported to front-matter.
 #+end_description
+#+begin_note
+This feature will work only if the ~org-hugo-front-matter-format~ is
+left at its default value of ~"toml"~.
+#+end_note
 See [[info:org#Drawers]] to learn more about the Org Drawers feature.
 **** ~:LOGBOOK:~ Drawer
 :PROPERTIES:
 :CUSTOM_ID: logbook-drawer
 :END:
-Ox-hugo natively supports parsing of these two kinds of information in
-the ~:LOGBOOK:~ drawers:
-1. Notes saved to the ~:LOGBOOK:~ drawers.
-2. /TODO/ state changes saved to these drawers.
+Ox-hugo supports parsing of these two kinds of information from the
+~:LOGBOOK:~ drawers:
+1. /TODO/ state changes saved to these drawers.
+2. Notes saved to the ~:LOGBOOK:~ drawers.
 
 #+begin_note
-For now, the ~:LOGBOOK:~ exporting feature works well only if the
-~org-log-note-headings~ is left at its default value.
+The ~:LOGBOOK:~ dates and notes exporting features work only if the
+~org-log-note-headings~ variable is left uncustomized, at its default
+value.
 #+end_note
 
-This feature works only if:
-1. ~org-log-into-drawer~ is set to a non-nil value (or the
-   ~:LOG_INTO_DRAWER:~ subtree property is set to a non-nil
-   value)[fn:13], *and*
-2. Drawer exporting is enabled[fn:14]. For example, enable that using
-   ~#+options: d:t~ keyword or ~:EXPORT_OPTIONS: d:t~ subtree
-   property.
+These features work only if:
+1. ~org-log-into-drawer~ (or the ~:LOG_INTO_DRAWER:~ subtree property)
+   is set to a non-nil value[fn:13], *and*
+2. Drawer exporting is enabled. You can enable that using ~#+options:
+   d:t~ keyword or ~:EXPORT_OPTIONS: d:t~ subtree property[fn:14].
 
-With ~LOG_INTO_DRAWER:~ enabled, the ~:LOGBOOK:~ drawer (default name
+With ~:LOG_INTO_DRAWER:~ enabled, the ~:LOGBOOK:~ drawer (default name
 of this drawer) is created immediately after the Org heading whose
-state changed or under where the ~org-add-note~ (bound by default to
-~C-c C-z~) command was called.
+state changed or under the heading where the ~org-add-note~ command
+(bound by default to ~C-c C-z~) was called.
+***** Dates parsed from ~:LOGBOOK:~ /TODO/ state changes
+:PROPERTIES:
+:CUSTOM_ID: logbook-dates
+:END:
+- ~date~ :: This front-matter variable is updated with the timestamp
+  associated with the *first* TODO state transition to one of the
+  ~org-done-keywords~ values[fn:15] i.e. transition to /DONE/ state.
+- ~lastmod~ :: This front-matter variable is updated with the
+  timestamp associated with the *last* TODO state transition to the
+  /DONE/ state.
+
+  Note that if only one transition to the /DONE/ state was recorded,
+  then this front-matter variable remains unset.
 ***** ~:LOGBOOK:~ Notes
 - Notes added to the ~:LOGBOOK:~ drawer under the post heading will be
   exported to the TOML Table Array ~[[logbook._toplevel.notes]]~ in
@@ -4386,15 +4412,16 @@ state changed or under where the ~org-add-note~ (bound by default to
 
   Here, *_toplevel* is a special/reserved TOML Table name to store
   notes associated with the post's main heading.
-- Notes added to the ~:LOGBOOK:~ drawer under a post's *sub-heading*
+- Notes added to the ~:LOGBOOK:~ drawer under a post's sub-heading
   will be exported to the TOML Table Array ~[[logbook.<sub heading
   title>.notes]]~ in the page front-matter.
 
 By design, Ox-hugo exports the ~:LOGBOOK:~ drawer notes as /data/ to
-the front-matter, and user is given freedom on where and how to render
-that data.
-****** ~logbook~ front-matter Hugo templating example
-Here is one way of rendering that data in Hugo templates:
+the front-matter, and user is given the freedom on where and how to
+render that data.
+***** ~logbook~ front-matter Hugo templating examples
+This section shared just one of the ways to render the ~logbook~
+front-matter data using Hugo templates.
 
 Create ~layouts/partials/logbook_notes.html~ in your Hugo site repo
 with these contents:
@@ -4422,9 +4449,10 @@ with these contents:
 #+end_src
 
 This partial accepts a Hugo *dict* input argument with keys *page* and
-*notes_param*. Here's an example of how one could use that partial in
-the ~single.html~ template:
-******* Example of rendering "_toplevel" notes
+*notes_param*.
+****** Example of rendering "_toplevel" notes
+Here's an example of how one could use that partial in the
+~single.html~ template:
 #+name: code__rendering_toplevel_logbook_notes
 #+caption: Example of using ~logbook_notes.html~ Hugo Partial in ~single.html~ layout file
 #+begin_src go-html-template
@@ -4434,10 +4462,10 @@ the ~single.html~ template:
 #+end_src
 
 Above,
-- The ~page~ key is passed the context of the current page ~$.Page~.
+- The ~page~ key is passed the context of the current page: ~$.Page~.
 - The ~notes_param~ key is passed the hierarchical path to the
   /toplevel/ Logbook notes: ~"logbook._toplevel.notes"~.
-******* Example of rendering notes under sub-headings
+****** Example of rendering notes under sub-headings
 Hugo's [[https://gohugo.io/templates/render-hooks/#heading-link-example][Render Hooks for Headings]] feature can be leveraged for
 rendering notes entered in ~:LOGBOOK:~ drawers under sub-headings in a
 post.
@@ -4455,12 +4483,14 @@ site repo with these contents:
                  "notes_param" (printf "logbook.%s.notes" .PlainText)) }}
 #+end_src
 
-Above, the same ~logbook_notes.html~ partial is used but with
-different value for the ~notes_param~ key. This time, it derives the
+Above, the same ~logbook_notes.html~ partial is used but with the
+~notes_param~ key set differently --- This time, it derives the
 hierarchical path to the ~logbook. .. .notes~ TOML Table Array using
-the ~.PlainText~ variable. For example, if the sub-heading title is
-"Example of rendering notes under sub-headings", the value of
-~.PlainText~ for that heading will be the same.
+the Heading Render Hook's ~.PlainText~ variable.
+
+For example, if the sub-heading title is "Example of rendering notes
+under sub-headings", the value of ~.PlainText~ for that heading will
+be the same.
 ** Meta
 :PROPERTIES:
 :EXPORT_HUGO_MENU: :menu "7.meta"
@@ -4829,10 +4859,8 @@ Categories,)}}}.
   maintaining global variables.
 * Footnotes
 
-
-
-
-
+[fn:15] The default value of the buffer-local variable
+~org-done-keywords~ in any Org buffer is ~("DONE")~.
 
 [fn:14] See the *'d'* option in [[info:org#Export Settings]].
 

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -4345,6 +4345,122 @@ This feature has language support too. If the ~#+language~ keyword is
 set to a language code other than ~en~ (example: ~de~), the
 translations of the element type names get exported. The translations
 are based on the ~org-export-dictionary~ variable from ~ox.el~.
+*** Drawers
+:PROPERTIES:
+:EXPORT_FILE_NAME: drawers
+:END:
+#+begin_description
+How Org Drawers get exported to front-matter.
+#+end_description
+See [[info:org#Drawers]] to learn more about the Org Drawers feature.
+**** ~:LOGBOOK:~ Drawer
+:PROPERTIES:
+:CUSTOM_ID: logbook-drawer
+:END:
+Ox-hugo natively supports parsing of these two kinds of information in
+the ~:LOGBOOK:~ drawers:
+1. Notes saved to the ~:LOGBOOK:~ drawers.
+2. /TODO/ state changes saved to these drawers.
+
+#+begin_note
+For now, the ~:LOGBOOK:~ exporting feature works well only if the
+~org-log-note-headings~ is left at its default value.
+#+end_note
+
+This feature works only if:
+1. ~org-log-into-drawer~ is set to a non-nil value (or the
+   ~:LOG_INTO_DRAWER:~ subtree property is set to a non-nil
+   value)[fn:13], *and*
+2. Drawer exporting is enabled[fn:14]. For example, enable that using
+   ~#+options: d:t~ keyword or ~:EXPORT_OPTIONS: d:t~ subtree
+   property.
+
+With ~LOG_INTO_DRAWER:~ enabled, the ~:LOGBOOK:~ drawer (default name
+of this drawer) is created immediately after the Org heading whose
+state changed or under where the ~org-add-note~ (bound by default to
+~C-c C-z~) command was called.
+***** ~:LOGBOOK:~ Notes
+- Notes added to the ~:LOGBOOK:~ drawer under the post heading will be
+  exported to the TOML Table Array ~[[logbook._toplevel.notes]]~ in
+  the page front-matter.
+
+  Here, *_toplevel* is a special/reserved TOML Table name to store
+  notes associated with the post's main heading.
+- Notes added to the ~:LOGBOOK:~ drawer under a post's *sub-heading*
+  will be exported to the TOML Table Array ~[[logbook.<sub heading
+  title>.notes]]~ in the page front-matter.
+
+By design, Ox-hugo exports the ~:LOGBOOK:~ drawer notes as /data/ to
+the front-matter, and user is given freedom on where and how to render
+that data.
+****** ~logbook~ front-matter Hugo templating example
+Here is one way of rendering that data in Hugo templates:
+
+Create ~layouts/partials/logbook_notes.html~ in your Hugo site repo
+with these contents:
+
+#+name: code__logbook_notes_partial
+#+caption: ~logbook_notes.html~ Hugo Partial
+#+begin_src go-html-template
+{{ with .page.Param .notes_param }}
+    <dl>
+        {{ range . }}
+            <dt>
+                <span class="timestamp-wrapper">
+                    <span class="timestamp">
+                        {{ printf `&lt;%s&gt;` (time.Format "2006-01-02" .timestamp)
+                        | safeHTML }}
+                    </span>
+                </span>
+            </dt>
+            <dd>
+                {{ .note | $.page.RenderString | emojify }}
+            </dd>
+        {{ end }}
+    </dl>
+{{ end }}
+#+end_src
+
+This partial accepts a Hugo *dict* input argument with keys *page* and
+*notes_param*. Here's an example of how one could use that partial in
+the ~single.html~ template:
+******* Example of rendering "_toplevel" notes
+#+name: code__rendering_toplevel_logbook_notes
+#+caption: Example of using ~logbook_notes.html~ Hugo Partial in ~single.html~ layout file
+#+begin_src go-html-template
+{{ partial "logbook_notes.html"
+           (dict "page" $.Page
+                 "notes_param" "logbook._toplevel.notes") }}
+#+end_src
+
+Above,
+- The ~page~ key is passed the context of the current page ~$.Page~.
+- The ~notes_param~ key is passed the hierarchical path to the
+  /toplevel/ Logbook notes: ~"logbook._toplevel.notes"~.
+******* Example of rendering notes under sub-headings
+Hugo's [[https://gohugo.io/templates/render-hooks/#heading-link-example][Render Hooks for Headings]] feature can be leveraged for
+rendering notes entered in ~:LOGBOOK:~ drawers under sub-headings in a
+post.
+
+Create ~layouts/_default/_markup/render-heading.html~ in your Hugo
+site repo with these contents:
+#+name: code__rendering_sub_heading_logbook_notes
+#+caption: Example of using ~logbook_notes.html~ Hugo Partial in ~render-heading.html~
+#+begin_src go-html-template
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}
+  <a href="#{{ .Anchor | safeURL }}"><small>#</small></a>
+</h{{ .Level }}>
+{{ partial "logbook_notes.html"
+           (dict "page" $.Page
+                 "notes_param" (printf "logbook.%s.notes" .PlainText)) }}
+#+end_src
+
+Above, the same ~logbook_notes.html~ partial is used but with
+different value for the ~notes_param~ key. This time, it derives the
+hierarchical path to the ~logbook. .. .notes~ TOML Table Array using
+the ~.PlainText~ variable. For example, if the sub-heading title is
+"Example of rendering notes under sub-headings", the value of
+~.PlainText~ for that heading will be the same.
 ** Meta
 :PROPERTIES:
 :EXPORT_HUGO_MENU: :menu "7.meta"
@@ -4715,6 +4831,13 @@ Categories,)}}}.
 
 
 
+
+
+
+[fn:14] See the *'d'* option in [[info:org#Export Settings]].
+
+[fn:13] See [[info:org#Tracking TODO state changes]] for more
+information.
 
 [fn:3] The ~dvisvgm~ and ~dvipng~ executables ship with TexLive
 distributions.

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -3,7 +3,7 @@
 ;; Author: Kaushal Modi <kaushal.modi@gmail.com>
 ;;         Matt Price <moptop99@gmail.com>
 ;; Version: 0.11.1
-;; Package-Requires: ((emacs "26.3") (tomelr "0.3.0"))
+;; Package-Requires: ((emacs "26.3") (tomelr "0.4.3"))
 ;; Keywords: Org, markdown, docs
 ;; URL: https://ox-hugo.scripter.co
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4137,7 +4137,8 @@ are \"toml\" and \"yaml\"."
                      "BIBLIOGRAPHY"
                      "HUGO_AUTO_SET_LASTMOD"
                      "LANGUAGE"
-                     "AUTHOR")))
+                     "AUTHOR"
+                     "OPTIONS")))
     (mapcar (lambda (str)
               (concat "EXPORT_" str))
             prop-list)))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -3987,7 +3987,8 @@ INFO is a plist used as a communication channel."
                           (cons 'menu menu-alist)
                           (cons 'resources resources)
                           ;; (cons 'logbook-entries (plist-get info :logbook-entries))
-                          (cons 'logbook_notes (plist-get info :logbook-notes)))))
+                          (cons 'logbook (list
+                                          (cons 'notes (plist-get info :logbook-notes)))))))
          ret)
     ;; (message "[get fm DBG] tags: %s" tags)
     ;; (message "dbg: hugo tags: %S" (plist-get info :hugo-tags))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1779,79 +1779,79 @@ holding contextual information."
       ;;    (paragraph
       ;;     <State change text>
       ;;     (timestamp <timestamp> )))))
-      (let* ((logbook-notes (plist-get info :logbook))
-             (logbook-entries
-              (org-element-map drawer 'plain-list
-                (lambda (lst)
-                  (org-element-map lst 'item
-                    (lambda (item)
-                      (org-element-map item 'paragraph
-                        (lambda (para)
-                          ;; (pp para)
-                          (let ((logbook-entry ())
-                                (para-raw-str (org-export-data para info)))
-                            ;; (message "\n[ox-hugo logbook DBG] paragraph raw str : %s" para-raw-str)
+      (let ((logbook-notes (plist-get info :logbook)))
+        (org-element-map drawer 'plain-list
+          (lambda (lst)
+            (org-element-map lst 'item
+              (lambda (item)
+                (org-element-map item 'paragraph
+                  (lambda (para)
+                    ;; (pp para)
+                    (let ((logbook-entry ())
+                          (para-raw-str (org-export-data para info)))
+                      ;; (message "\n[ox-hugo logbook DBG] paragraph raw str : %s" para-raw-str)
 
-                            ;; Parse the logbook entry's timestamp.
-                            (org-element-map para 'timestamp
-                              (lambda (ts)
-                                ;; (pp ts)
-                                (let* ((ts-raw-str (org-element-property :raw-value ts))
-                                       (ts-str (org-hugo--org-date-time-to-rfc3339 ts-raw-str info)))
-                                  ;; (message "[ox-hugo logbook DBG] ts: %s, ts fmtd: %s"
-                                  ;;          ts-raw-str ts-str)
-                                  (push `(timestamp . ,ts-str) logbook-entry))
-                                nil)
-                              nil :first-match) ;Each 'paragraph element will have only one 'timestamp element
+                      ;; Parse the logbook entry's timestamp.
+                      (org-element-map para 'timestamp
+                        (lambda (ts)
+                          ;; (pp ts)
+                          (let* ((ts-raw-str (org-element-property :raw-value ts))
+                                 (ts-str (org-hugo--org-date-time-to-rfc3339 ts-raw-str info)))
+                            ;; (message "[ox-hugo logbook DBG] ts: %s, ts fmtd: %s"
+                            ;;          ts-raw-str ts-str)
+                            (push `(timestamp . ,ts-str) logbook-entry))
+                          nil) ;lambda return for (org-element-map para 'timestamp
+                        nil :first-match) ;Each 'paragraph element will have only one 'timestamp element
 
-                            (save-match-data
-                              (cond
-                               ;; Parse (assq 'state org-log-note-headings)
-                               ((string-match "^State\\s-+\\(?1:\".+?\"\\)*\\s-+from\\s-+\\(?2:\".+?\"\\)*"
-                                              para-raw-str)
-                                (let ((to-state (org-string-nw-p
-                                                 (save-match-data ;Required because `string-trim' changes match data
-                                                   (string-trim
-                                                    (or (match-string-no-properties 1 para-raw-str) "")
-                                                    "\"" "\""))))
-                                      (from-state (org-string-nw-p
-                                                   (save-match-data ;Required because `string-trim' changes match data
-                                                     (string-trim
-                                                      (or (match-string-no-properties 2 para-raw-str) "")
-                                                      "\"" "\"")))))
-                                  ;; (message "[ox-hugo logbook DBG] state change : from %s to %s @ %s"
-                                  ;;          from-state to-state (plist-get logbook-entry :timestamp))
-                                  (when to-state
-                                    (push `(to_state . ,to-state) logbook-entry))
-                                  (when from-state
-                                    (push `(from_state . ,from-state) logbook-entry))))
-                               ;; Parse (assq 'note org-log-note-headings)
-                               ((string-match "^Note taken on .*?\n\\(?1:\\(.\\|\n\\)*\\)" para-raw-str)
-                                (let ((note (string-trim
-                                             (match-string-no-properties 1 para-raw-str))))
-                                  ;; (message "[ox-hugo logbook DBG] note : %s @ %s"
-                                  ;;          note (plist-get logbook-entry :timestamp))
-                                  (push `(note . ,note) logbook-entry)))
-                               (t
-                                (user-error "LOGBOOK drawer entry is neither a state change, nor a note."))))
-                            (when (assoc 'note logbook-entry)
-                              (let ((context-key (or sub-heading "_toplevel")))
-                                (unless (assoc context-key logbook-notes)
-                                  (push (cons context-key (list (cons 'notes (list)))) logbook-notes))
-                                (setcdr (assoc 'notes (assoc context-key logbook-notes))
-                                        (append (cdr (assoc 'notes (assoc context-key logbook-notes)))
-                                                (list (nreverse logbook-entry))))))
-                            ;; (message "[ox-hugo logbook DBG] logbook entry : %S" logbook-entry)
-                            logbook-entry))
-                        nil :first-match) ;Each 'item element will have only one 'paragraph element
-                      )))
-                nil :first-match))) ;The 'logbook element will have only one 'plain-list element
-        ;; (message "[ox-hugo logbook DBG] all logbook entries : %S" logbook-entries)
+                      (save-match-data
+                        (cond
+                         ;; Parse (assq 'state org-log-note-headings)
+                         ((string-match "^State\\s-+\\(?1:\".+?\"\\)*\\s-+from\\s-+\\(?2:\".+?\"\\)*"
+                                        para-raw-str)
+                          (let ((to-state (org-string-nw-p
+                                           (save-match-data ;Required because `string-trim' changes match data
+                                             (string-trim
+                                              (or (match-string-no-properties 1 para-raw-str) "")
+                                              "\"" "\""))))
+                                (from-state (org-string-nw-p
+                                             (save-match-data ;Required because `string-trim' changes match data
+                                               (string-trim
+                                                (or (match-string-no-properties 2 para-raw-str) "")
+                                                "\"" "\"")))))
+                            ;; (message "[ox-hugo logbook DBG] state change : from %s to %s @ %s"
+                            ;;          from-state to-state (plist-get logbook-entry :timestamp))
+                            (when to-state
+                              (push `(to_state . ,to-state) logbook-entry))
+                            (when from-state
+                              (push `(from_state . ,from-state) logbook-entry))))
+                         ;; Parse (assq 'note org-log-note-headings)
+                         ((string-match "^Note taken on .*?\n\\(?1:\\(.\\|\n\\)*\\)" para-raw-str)
+                          (let ((note (string-trim
+                                       (match-string-no-properties 1 para-raw-str))))
+                            ;; (message "[ox-hugo logbook DBG] note : %s @ %s"
+                            ;;          note (plist-get logbook-entry :timestamp))
+                            (push `(note . ,note) logbook-entry)))
+                         (t
+                          (user-error "LOGBOOK drawer entry is neither a state change, nor a note."))))
+
+                      (when (assoc 'note logbook-entry)
+                        (let ((context-key (or sub-heading "_toplevel")))
+                          (unless (assoc context-key logbook-notes)
+                            (push (cons context-key (list (cons 'notes (list)))) logbook-notes))
+                          (setcdr (assoc 'notes (assoc context-key logbook-notes))
+                                  (append (cdr (assoc 'notes (assoc context-key logbook-notes)))
+                                          (list (nreverse logbook-entry))))))
+
+                      ;; (message "[ox-hugo logbook DBG] logbook entry : %S" logbook-entry)
+                      logbook-entry)
+                    nil) ;lambda return for (org-element-map item 'paragraph
+                  nil :first-match) ;Each 'item element will have only one 'paragraph element
+                nil))    ;lambda return for (org-element-map lst 'item
+            nil) ;lambda return for (org-element-map drawer 'plain-list ..
+          nil :first-match) ;The 'logbook element will have only one 'plain-list element
         ;; TODO: Code to save the notes content and date/lastmod
         ;; timestamps to appropriate front-matter.
-        ;; (message "[ox-hugo logbook DBG] state changes : %S" logbook-entries)
         (message "[ox-hugo logbook DBG] logbook-notes : %S" logbook-notes)
-        (plist-put info :logbook-entries logbook-entries) ;Includes notes + state changes
         (plist-put info :logbook logbook-notes)
         "")) ;Nothing from the LOGBOOK gets exported to the Markdown body
      (t

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -709,6 +709,7 @@ bibliography heading auto-injection is not done."
               (org-hugo-export-as-md a s v)))))
 ;;;; translate-alist
   :translate-alist '((code . org-hugo-kbd-tags-maybe)
+                     (drawer . org-hugo-drawer)
                      (example-block . org-hugo-example-block)
                      (export-block . org-hugo-export-block)
                      (export-snippet . org-hugo-export-snippet)
@@ -1720,6 +1721,38 @@ channel."
       (format "<kbd>%s</kbd>" (org-html-encode-plain-text
                                (org-element-property :value verbatim)))
     (org-md-verbatim verbatim nil nil)))
+
+;;;; Drawer (specifically Logbook)
+(defun org-hugo-drawer (drawer contents info)
+  "Transcode a DRAWER element from Org to appropriate Hugo front-matter.
+CONTENTS holds the contents of the block.  INFO is a plist
+holding contextual information."
+  (let ((drawer-name (downcase (org-element-property :drawer-name drawer))))
+    (cond
+     ((string= "logbook" drawer-name)
+      ;; (pp drawer)
+      (message "[ox-hugo logbook] elem type: %s" (org-element-type drawer))
+      (org-element-map drawer 'plain-list
+        (lambda (lst)
+          (org-element-map lst 'item
+            (lambda (item)
+              (org-element-map item 'paragraph
+                (lambda (para)
+                  ;; (pp para)
+                  (message "[ox-hugo logbook] list content: %s"
+                           (org-export-data para info))
+                  (org-element-map para 'timestamp
+                    (lambda (ts)
+                      ;; (pp ts)
+                      (message "[ox-hugo logbook] ts: %s"
+                               (org-element-property :raw-value ts))))))))))
+
+      ;; TODO: Code to save the notes content and date/lastmod
+      ;; timestamps to appropriate front-matter.
+
+      "") ;Nothing from the LOGBOOK gets exported to the Markdown body
+     (t
+      (org-html-drawer drawer contents info)))))
 
 ;;;; Example Block
 (defun org-hugo-example-block (example-block _contents info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1371,8 +1371,11 @@ cannot be formatted in Hugo-compatible format."
                                    (nth 1 err)))
                           nil)))
                       ;; Else (if nil) and user want to auto-set the
-                      ;; lastmod field.
+                      ;; lastmod field. If the lastmod value is
+                      ;; derived from LOGBOOK, disable the
+                      ;; auto-setting of lastmod.
                       ((and (equal date-key :hugo-lastmod)
+                            (null (plist-get info :logbook-lastmod))
                             (org-hugo--plist-get-true-p info :hugo-auto-set-lastmod))
                        (let* ((curr-time (org-current-time))
                               (lastmod-str (org-hugo--org-date-time-to-rfc3339 curr-time info)))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1767,10 +1767,7 @@ holding contextual information."
                              (lambda (ts)
                                ;; (pp ts)
                                (let* ((ts-raw-str (org-element-property :raw-value ts))
-                                      (ts-str (format-time-string
-                                               (plist-get info :hugo-date-format)
-                                               (apply #'encode-time
-                                                      (org-parse-time-string ts-raw-str)))))
+                                      (ts-str (org-hugo--org-date-time-to-rfc3339 ts-raw-str info)))
                                  ;; (message "[ox-hugo logbook DBG] ts: %s, ts fmtd: %s"
                                  ;;          ts-raw-str ts-str)
                                  (setq logbook-entry (plist-put logbook-entry :timestamp ts-str)))
@@ -1816,6 +1813,7 @@ holding contextual information."
         ;; TODO: Code to save the notes content and date/lastmod
         ;; timestamps to appropriate front-matter.
         ;; (message "[ox-hugo logbook DBG] state changes : %S" logbook-entries)
+        (plist-put info :logbook-entries logbook-entries)
         "")) ;Nothing from the LOGBOOK gets exported to the Markdown body
      (t
       (org-html-drawer drawer contents info)))))
@@ -3980,7 +3978,11 @@ INFO is a plist used as a communication channel."
                  (creator . ,creator)
                  (locale . ,locale)
                  (blackfriday . ,blackfriday)))
-         (data `,(append data weight-data custom-fm-data (list (cons 'menu menu-alist) (cons 'resources resources))))
+         (data `,(append data weight-data custom-fm-data
+                         (list
+                          (cons 'menu menu-alist)
+                          (cons 'resources resources)
+                          (cons 'org-logbook (plist-get info :logbook-entries)))))
          ret)
     ;; (message "[get fm DBG] tags: %s" tags)
     ;; (message "dbg: hugo tags: %S" (plist-get info :hugo-tags))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1737,9 +1737,11 @@ channel."
   "Transcode a DRAWER element from Org to appropriate Hugo front-matter.
 CONTENTS holds the contents of the block.  INFO is a plist
 holding contextual information."
-  (let ((drawer-name (downcase (org-element-property :drawer-name drawer))))
+  (let* ((logbook-drawer-name (org-log-into-drawer))
+         (drawer-name (org-element-property :drawer-name drawer)))
+    (message "dbg: %S" logbook-drawer-name)
     (cond
-     ((string= "logbook" drawer-name)
+     ((equal logbook-drawer-name drawer-name)
       ;; (message "[ox-hugo logbook DBG] elem type: %s" (org-element-type drawer))
       ;; (pp drawer)
 
@@ -3985,11 +3987,12 @@ INFO is a plist used as a communication channel."
          (data `,(append data weight-data custom-fm-data
                          (list
                           (cons 'menu menu-alist)
-                          (cons 'resources resources)
-                          ;; (cons 'logbook-entries (plist-get info :logbook-entries))
-                          (cons 'logbook (list
-                                          (cons 'notes (plist-get info :logbook-notes)))))))
+                          (cons 'resources resources))))
          ret)
+
+    (when (plist-get info :logbook-notes)
+      (setq data (append data `((logbook . ((notes . ,(plist-get info :logbook-notes))))))))
+
     ;; (message "[get fm DBG] tags: %s" tags)
     ;; (message "dbg: hugo tags: %S" (plist-get info :hugo-tags))
     ;; (message "[get fm info DBG] %S" info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1771,7 +1771,7 @@ holding contextual information."
                                        (ts-str (org-hugo--org-date-time-to-rfc3339 ts-raw-str info)))
                                   ;; (message "[ox-hugo logbook DBG] ts: %s, ts fmtd: %s"
                                   ;;          ts-raw-str ts-str)
-                                  (setq logbook-entry (plist-put logbook-entry :timestamp ts-str)))
+                                  (push `(timestamp . ,ts-str) logbook-entry))
                                 nil)
                               nil :first-match) ;Each 'paragraph element will have only one 'timestamp element
 
@@ -1793,20 +1793,20 @@ holding contextual information."
                                   ;; (message "[ox-hugo logbook DBG] state change : from %s to %s @ %s"
                                   ;;          from-state to-state (plist-get logbook-entry :timestamp))
                                   (when to-state
-                                    (setq logbook-entry (plist-put logbook-entry :to-state to-state)))
+                                    (push `(to_state . ,to-state) logbook-entry))
                                   (when from-state
-                                    (setq logbook-entry (plist-put logbook-entry :from-state from-state)))))
+                                    (push `(from_state . ,from-state) logbook-entry))))
                                ;; Parse (assq 'note org-log-note-headings)
                                ((string-match "^Note taken on .*?\n\\(?1:\\(.\\|\n\\)*\\)" para-raw-str)
                                 (let ((note (string-trim
                                              (match-string-no-properties 1 para-raw-str))))
                                   ;; (message "[ox-hugo logbook DBG] note : %s @ %s"
                                   ;;          note (plist-get logbook-entry :timestamp))
-                                  (setq logbook-entry (plist-put logbook-entry :note note))))
+                                  (push `(note . ,note) logbook-entry)))
                                (t
                                 (user-error "LOGBOOK drawer entry is neither a state change, nor a note."))))
-                            (when (plist-get logbook-entry :note)
-                              (push logbook-entry logbook-notes))
+                            (when (assoc 'note logbook-entry)
+                              (push (nreverse logbook-entry) logbook-notes))
                             ;; (message "[ox-hugo logbook DBG] logbook entry : %S" logbook-entry)
                             logbook-entry))
                         nil :first-match) ;Each 'item element will have only one 'paragraph element

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7306,6 +7306,9 @@ This test removes the ~foo~ front-matter key from the exported file
 :EXPORT_OPTIONS: d:t
 :END:
 :LOGBOOK:
+- Note taken on [2022-04-08 Fri 14:53] \\
+  This note addition prompt shows up on typing the ~C-c C-z~ binding.
+  See [[info:org#Drawers]].
 - Note taken on [2018-09-06 Thu 11:45] \\
   Another note *bold* /italics/.
 - Note taken on [2018-09-06 Thu 11:37] \\

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7338,22 +7338,11 @@ For example,
 :END:
 #+end_src
 
-should export these ~notes~ in TOML front-matter (and the equivalent
-in YAML):
-#+begin_src toml
-[[notes]]
-  index = 0
-  date = 2018-09-06T11:37:00-04:00
-  content = "A note."
-[[notes]]
-  index = 1
-  date = 2018-09-06T11:45:00-04:00
-  content = "Another note."
-#+end_src
+should export these ~notes~ in arrays of TOML tables.
 
 - Note :: The state change notes are intentionally put in this test
           LOGBOOK, because we want to ensure that they don't seep into
-          the ~notes~ front-matter.
+          the ~org-logbook~ front-matter.
 ** Extra Front-matter tests                        :extra:verbatim:src_block:
 *** Extra Front-matter
 :PROPERTIES:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7303,6 +7303,7 @@ This test removes the ~foo~ front-matter key from the exported file
 :LOG_INTO_DRAWER: t
 :LOGGING: TODO(!) DRAFT(!) DONE(!)
 :EXPORT_OPTIONS: d:t
+:EXPORT_HUGO_LAYOUT: alternate-single
 :END:
 *** DONE Parsing notes from LOGBOOK
 :PROPERTIES:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7306,6 +7306,9 @@ This test removes the ~foo~ front-matter key from the exported file
 :EXPORT_OPTIONS: d:t
 :END:
 :LOGBOOK:
+- Note taken on [2022-05-04 Wed 13:15] \\
+  This new note added last should be the first element of the
+  ~[[logbook_notes]]~ TOML table array.
 - Note taken on [2022-04-08 Fri 14:53] \\
   This note addition prompt shows up on typing the ~C-c C-z~ binding.
   See [[info:org#Drawers]].
@@ -7318,8 +7321,8 @@ This test removes the ~foo~ front-matter key from the exported file
 - State "TODO"       from              [2018-09-06 Thu 11:25]
 :END:
 #+begin_description
-Parse notes from LOGBOOK into a TOML table (YAML map?) of ~notes~
-front-matter.
+Parse notes from LOGBOOK into a TOML table (YAML map?) of
+~logbook_notes~ front-matter.
 #+end_description
 
 {{{oxhugoissue(203)}}}
@@ -7338,11 +7341,13 @@ For example,
 :END:
 #+end_src
 
-should export these ~notes~ in arrays of TOML tables.
+should export only the notes to an array of TOML tables with key
+~logbook_notes~. The notes are ordered starting from the newest note
+first in the TOML table array to the oldest note at the last.
 
 - Note :: The state change notes are intentionally put in this test
-          LOGBOOK, because we want to ensure that they don't seep into
-          the ~org-logbook~ front-matter.
+  LOGBOOK, because we want to ensure that they don't seep into the
+  ~logbook_notes~ front-matter.
 ** Extra Front-matter tests                        :extra:verbatim:src_block:
 *** Extra Front-matter
 :PROPERTIES:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7349,12 +7349,12 @@ For example,
 #+end_src
 
 should export only the notes to an array of TOML tables with key
-~logbook.notes~. The notes are ordered starting from the newest note
-first in the TOML table array to the oldest note at the last.
+~logbook.<..>.notes~. The notes are ordered starting from the newest
+note first in the TOML table array to the oldest note at the last.
 
 - Note :: The state change notes are intentionally put in this test
   LOGBOOK, because we want to ensure that they don't seep into the
-  ~logbook.notes~ front-matter.
+  ~logbook.<..>.notes~ front-matter.
 *** LOGBOOK Notes in nested headings
 :PROPERTIES:
 :EXPORT_FILE_NAME: logbook-notes-in-nested-headings

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7351,6 +7351,27 @@ first in the TOML table array to the oldest note at the last.
 - Note :: The state change notes are intentionally put in this test
   LOGBOOK, because we want to ensure that they don't seep into the
   ~logbook.notes~ front-matter.
+*** LOGBOOK Notes in nested headings
+:PROPERTIES:
+:EXPORT_FILE_NAME: logbook-notes-in-nested-headings
+:END:
+:LOGBOOK:
+- Note taken on [2022-05-11 Wed 12:17] \\
+  Note in the top-heading LOGBOOK drawer
+:END:
+#+begin_description
+Parse notes from LOGBOOK drawers in top-level and nested headings.
+#+end_description
+**** Sub-heading
+:LOGBOOK:
+- Note taken on [2022-05-11 Wed 12:18] \\
+  LOGBOOK note in a sub-heading
+:END:
+**** Sub heading *with* /markup/
+:LOGBOOK:
+- Note taken on [2022-05-11 Wed 17:12] \\
+  Another note in a different sub heading.
+:END:
 ** Extra Front-matter tests                        :extra:verbatim:src_block:
 *** Extra Front-matter
 :PROPERTIES:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7321,8 +7321,8 @@ This test removes the ~foo~ front-matter key from the exported file
 - Note taken on [2018-09-06 Thu 11:37] \\
   A note ~mono~.
 - State "DONE"       from "DRAFT"      [2018-09-06 Thu 11:25]
-- State "DRAFT"      from "TODO"       [2018-09-06 Thu 11:25]
-- State "TODO"       from              [2018-09-06 Thu 11:25]
+- State "DRAFT"      from "TODO"       [2018-09-04 Tue 11:25]
+- State "TODO"       from              [2018-09-01 Sat 11:25]
 :END:
 #+begin_description
 Parse notes from LOGBOOK into a TOML table (YAML map?) of

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7308,7 +7308,7 @@ This test removes the ~foo~ front-matter key from the exported file
 :LOGBOOK:
 - Note taken on [2022-05-04 Wed 13:15] \\
   This new note added last should be the first element of the
-  ~[[logbook_notes]]~ TOML table array.
+  ~[[logbook.notes]]~ TOML table array.
 - Note taken on [2022-04-08 Fri 14:53] \\
   This note addition prompt shows up on typing the ~C-c C-z~ binding.
   See [[info:org#Drawers]].
@@ -7322,7 +7322,7 @@ This test removes the ~foo~ front-matter key from the exported file
 :END:
 #+begin_description
 Parse notes from LOGBOOK into a TOML table (YAML map?) of
-~logbook_notes~ front-matter.
+~logbook.notes~ front-matter.
 #+end_description
 
 {{{oxhugoissue(203)}}}
@@ -7342,12 +7342,12 @@ For example,
 #+end_src
 
 should export only the notes to an array of TOML tables with key
-~logbook_notes~. The notes are ordered starting from the newest note
+~logbook.notes~. The notes are ordered starting from the newest note
 first in the TOML table array to the oldest note at the last.
 
 - Note :: The state change notes are intentionally put in this test
   LOGBOOK, because we want to ensure that they don't seep into the
-  ~logbook_notes~ front-matter.
+  ~logbook.notes~ front-matter.
 ** Extra Front-matter tests                        :extra:verbatim:src_block:
 *** Extra Front-matter
 :PROPERTIES:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7298,12 +7298,15 @@ be ~authors~ instead of the default ~author~ created by ~ox-hugo~.
 This test removes the ~foo~ front-matter key from the exported file
 (and replaces ~bar~ key with ~zoo~).
 #+end_description
-** DONE Parsing notes from LOGBOOK                            :notes:logbook:
+** LOGBOOK Notes                                              :notes:logbook:
 :PROPERTIES:
-:EXPORT_FILE_NAME: parsing-notes-from-logbook
 :LOG_INTO_DRAWER: t
 :LOGGING: TODO(!) DRAFT(!) DONE(!)
 :EXPORT_OPTIONS: d:t
+:END:
+*** DONE Parsing notes from LOGBOOK
+:PROPERTIES:
+:EXPORT_FILE_NAME: parsing-notes-from-logbook
 :END:
 :LOGBOOK:
 - Note taken on [2022-05-04 Wed 13:15] \\

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -5864,7 +5864,7 @@ front-matter.
 In this post the =:EXPORT_DATE:= property is set to =2012-2017=, but
 the export will still happen fine, with the =date= front-matter not
 set.
-*** DONE Parsing date from LOGBOOK                         :logbook:noexport:
+*** DONE Parsing date from LOGBOOK                                  :logbook:
 :PROPERTIES:
 :EXPORT_FILE_NAME: parsing-date-from-logbook
 :LOG_INTO_DRAWER: t
@@ -5872,6 +5872,7 @@ set.
 :EXPORT_OPTIONS: d:t
 :END:
 :LOGBOOK:
+- State "DONE"       from "TEST__TODO" [2022-01-11 Tue 11:22]
 - State "DONE"       from "DRAFT"      [2018-09-06 Thu 11:42]
 - State "DONE"       from "DRAFT"      [2018-09-06 Thu 11:38]
 :END:
@@ -5897,7 +5898,7 @@ binding.
 :EXPORT_HUGO_LASTMOD: 2018-01-23
 :END:
 The =lastmod= for this post is Hugo-compatible i.e. [[https://tools.ietf.org/html/rfc3339#section-5.8][RFC3339-compliant]].
-*** DONE Parsing lastmod from LOGBOOK                      :logbook:noexport:
+*** DONE Parsing lastmod from LOGBOOK                               :logbook:
 :PROPERTIES:
 :EXPORT_FILE_NAME: parsing-lastmod-from-logbook
 :LOG_INTO_DRAWER: t
@@ -7297,7 +7298,7 @@ be ~authors~ instead of the default ~author~ created by ~ox-hugo~.
 This test removes the ~foo~ front-matter key from the exported file
 (and replaces ~bar~ key with ~zoo~).
 #+end_description
-** DONE Parsing notes from LOGBOOK                   :notes:logbook:noexport:
+** DONE Parsing notes from LOGBOOK                            :notes:logbook:
 :PROPERTIES:
 :EXPORT_FILE_NAME: parsing-notes-from-logbook
 :LOG_INTO_DRAWER: t
@@ -7306,9 +7307,9 @@ This test removes the ~foo~ front-matter key from the exported file
 :END:
 :LOGBOOK:
 - Note taken on [2018-09-06 Thu 11:45] \\
-  Another note.
+  Another note *bold* /italics/.
 - Note taken on [2018-09-06 Thu 11:37] \\
-  A note
+  A note ~mono~.
 - State "DONE"       from "DRAFT"      [2018-09-06 Thu 11:25]
 - State "DRAFT"      from "TODO"       [2018-09-06 Thu 11:25]
 - State "TODO"       from              [2018-09-06 Thu 11:25]

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -5904,6 +5904,7 @@ The =lastmod= for this post is Hugo-compatible i.e. [[https://tools.ietf.org/htm
 :LOG_INTO_DRAWER: t
 :LOGGING: DONE(!)
 :EXPORT_OPTIONS: d:t
+:EXPORT_HUGO_AUTO_SET_LASTMOD: t
 :END:
 :LOGBOOK:
 - State "DONE"       from "DRAFT"      [2018-09-06 Thu 11:41]
@@ -5919,7 +5920,9 @@ In the case of multiple ~"State "DONE" from .."~ entries,
 - Use the newest entry to set the ~lastmod~.
 - Use the oldest entry to set the ~date~.
 
-*Do not auto-set ~lastmod~ using ~current-time~ in this case.~
+The ~lastmod~ field parsed from LOGBOOK transitions will have the
+highest precedence. So it will *not be auto-set* even if the
+~:EXPORT_HUGO_AUTO_SET_LASTMOD: t~ property is set.
 ** Publish Date                                                 :publishdate:
 *** Publish date set using Org time stamp
 :PROPERTIES:

--- a/test/site/content/posts/logbook-notes-in-nested-headings.md
+++ b/test/site/content/posts/logbook-notes-in-nested-headings.md
@@ -1,0 +1,24 @@
++++
+title = "LOGBOOK Notes in nested headings"
+description = "Parse notes from LOGBOOK drawers in top-level and nested headings."
+tags = ["front-matter", "notes", "logbook"]
+draft = false
+[logbook]
+  [logbook."Sub heading with markup"]
+    [[logbook."Sub heading with markup".notes]]
+      timestamp = 2022-05-11T17:12:00+00:00
+      note = "Another note in a different sub heading."
+  [logbook.Sub-heading]
+    [[logbook.Sub-heading.notes]]
+      timestamp = 2022-05-11T12:18:00+00:00
+      note = "LOGBOOK note in a sub-heading"
+  [logbook._toplevel]
+    [[logbook._toplevel.notes]]
+      timestamp = 2022-05-11T12:17:00+00:00
+      note = "Note in the top-heading LOGBOOK drawer"
++++
+
+## Sub-heading {#sub-heading}
+
+
+## Sub heading **with** _markup_ {#sub-heading-with-markup}

--- a/test/site/content/posts/logbook-notes-in-nested-headings.md
+++ b/test/site/content/posts/logbook-notes-in-nested-headings.md
@@ -1,6 +1,7 @@
 +++
 title = "LOGBOOK Notes in nested headings"
 description = "Parse notes from LOGBOOK drawers in top-level and nested headings."
+layout = "alternate-single"
 tags = ["front-matter", "notes", "logbook"]
 draft = false
 [logbook]

--- a/test/site/content/posts/parsing-date-from-logbook.md
+++ b/test/site/content/posts/parsing-date-from-logbook.md
@@ -1,0 +1,18 @@
++++
+title = "Parsing date from LOGBOOK"
+description = """
+  Parse the date from an entry like `"- State "DONE" from "DRAFT"
+  [2018-09-06 Thu 11:25]`.
+  """
+tags = ["dates", "date", "logbook"]
+draft = false
++++
+
+-   State "DONE"       from "TEST\__TODO" <span class="timestamp-wrapper"><span class="timestamp">[2022-01-11 Tue 11:22]</span></span>
+-   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:42]</span></span>
+-   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:38]</span></span>
+
+`ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)
+
+In the case of multiple `"State "DONE" from .."` entries, use the
+oldest entry to set the `date`.

--- a/test/site/content/posts/parsing-date-from-logbook.md
+++ b/test/site/content/posts/parsing-date-from-logbook.md
@@ -6,11 +6,19 @@ description = """
   """
 tags = ["dates", "date", "logbook"]
 draft = false
+[[org-logbook]]
+  timestamp = 2022-01-11T11:22:00-05:00
+  to-state = "DONE"
+  from-state = "TEST\\__TODO"
+[[org-logbook]]
+  timestamp = 2018-09-06T11:42:00-04:00
+  to-state = "DONE"
+  from-state = "DRAFT"
+[[org-logbook]]
+  timestamp = 2018-09-06T11:38:00-04:00
+  to-state = "DONE"
+  from-state = "DRAFT"
 +++
-
--   State "DONE"       from "TEST\__TODO" <span class="timestamp-wrapper"><span class="timestamp">[2022-01-11 Tue 11:22]</span></span>
--   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:42]</span></span>
--   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:38]</span></span>
 
 `ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)
 

--- a/test/site/content/posts/parsing-date-from-logbook.md
+++ b/test/site/content/posts/parsing-date-from-logbook.md
@@ -6,18 +6,6 @@ description = """
   """
 tags = ["dates", "date", "logbook"]
 draft = false
-[[org-logbook]]
-  timestamp = 2022-01-11T11:22:00-05:00
-  to-state = "DONE"
-  from-state = "TEST\\__TODO"
-[[org-logbook]]
-  timestamp = 2018-09-06T11:42:00-04:00
-  to-state = "DONE"
-  from-state = "DRAFT"
-[[org-logbook]]
-  timestamp = 2018-09-06T11:38:00-04:00
-  to-state = "DONE"
-  from-state = "DRAFT"
 +++
 
 `ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)

--- a/test/site/content/posts/parsing-date-from-logbook.md
+++ b/test/site/content/posts/parsing-date-from-logbook.md
@@ -4,6 +4,8 @@ description = """
   Parse the date from an entry like `"- State "DONE" from "DRAFT"
   [2018-09-06 Thu 11:25]`.
   """
+date = 2018-09-06T11:38:00+00:00
+lastmod = 2022-01-11T11:22:00+00:00
 tags = ["dates", "date", "logbook"]
 draft = false
 +++

--- a/test/site/content/posts/parsing-lastmod-from-logbook.md
+++ b/test/site/content/posts/parsing-lastmod-from-logbook.md
@@ -1,0 +1,21 @@
++++
+title = "Parsing lastmod from LOGBOOK"
+description = """
+  If LOGBOOK has multiple entries of `"- State "DONE" from .."`, use the
+  newest entry to parse the `lastmod` date from.
+  """
+tags = ["dates", "lastmod", "logbook"]
+draft = false
++++
+
+-   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:41]</span></span>
+-   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:40]</span></span>
+
+`ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)
+
+In the case of multiple `"State "DONE" from .."` entries,
+
+-   Use the newest entry to set the `lastmod`.
+-   Use the oldest entry to set the `date`.
+
+\*Do not auto-set `lastmod` using `current-time` in this case.~

--- a/test/site/content/posts/parsing-lastmod-from-logbook.md
+++ b/test/site/content/posts/parsing-lastmod-from-logbook.md
@@ -17,4 +17,6 @@ In the case of multiple `"State "DONE" from .."` entries,
 -   Use the newest entry to set the `lastmod`.
 -   Use the oldest entry to set the `date`.
 
-\*Do not auto-set `lastmod` using `current-time` in this case.~
+The `lastmod` field parsed from LOGBOOK transitions will have the
+highest precedence. So it will **not be auto-set** even if the
+`:EXPORT_HUGO_AUTO_SET_LASTMOD: t` property is set.

--- a/test/site/content/posts/parsing-lastmod-from-logbook.md
+++ b/test/site/content/posts/parsing-lastmod-from-logbook.md
@@ -6,14 +6,6 @@ description = """
   """
 tags = ["dates", "lastmod", "logbook"]
 draft = false
-[[org-logbook]]
-  timestamp = 2018-09-06T11:41:00-04:00
-  to-state = "DONE"
-  from-state = "DRAFT"
-[[org-logbook]]
-  timestamp = 2018-09-06T11:40:00-04:00
-  to-state = "DONE"
-  from-state = "DRAFT"
 +++
 
 `ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)

--- a/test/site/content/posts/parsing-lastmod-from-logbook.md
+++ b/test/site/content/posts/parsing-lastmod-from-logbook.md
@@ -4,6 +4,8 @@ description = """
   If LOGBOOK has multiple entries of `"- State "DONE" from .."`, use the
   newest entry to parse the `lastmod` date from.
   """
+date = 2018-09-06T11:40:00+00:00
+lastmod = 2018-09-06T11:41:00+00:00
 tags = ["dates", "lastmod", "logbook"]
 draft = false
 +++

--- a/test/site/content/posts/parsing-lastmod-from-logbook.md
+++ b/test/site/content/posts/parsing-lastmod-from-logbook.md
@@ -6,10 +6,15 @@ description = """
   """
 tags = ["dates", "lastmod", "logbook"]
 draft = false
+[[org-logbook]]
+  timestamp = 2018-09-06T11:41:00-04:00
+  to-state = "DONE"
+  from-state = "DRAFT"
+[[org-logbook]]
+  timestamp = 2018-09-06T11:40:00-04:00
+  to-state = "DONE"
+  from-state = "DRAFT"
 +++
-
--   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:41]</span></span>
--   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:40]</span></span>
 
 `ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)
 

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -1,0 +1,52 @@
++++
+title = "Parsing notes from LOGBOOK"
+description = """
+  Parse notes from LOGBOOK into a TOML table (YAML map?) of `notes`
+  front-matter.
+  """
+tags = ["front-matter", "notes", "logbook"]
+draft = false
++++
+
+-   Note taken on <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:45] </span></span> <br />
+    Another note **bold** _italics_.
+-   Note taken on <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:37] </span></span> <br />
+    A note `mono`.
+-   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:25]</span></span>
+-   State "DRAFT"      from "TODO"       <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:25]</span></span>
+-   State "TODO"       from              <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:25]</span></span>
+
+`ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)
+
+For example,
+
+```org
+:LOGBOOK:
+- Note taken on [2018-09-06 Thu 11:45] \\
+  Another note.
+- Note taken on [2018-09-06 Thu 11:37] \\
+  A note
+- State "DONE"       from "DRAFT"      [2018-09-06 Thu 11:25]
+- State "DRAFT"      from "TODO"       [2018-09-06 Thu 11:25]
+- State "TODO"       from              [2018-09-06 Thu 11:25]
+:END:
+```
+
+should export these `notes` in TOML front-matter (and the equivalent
+in YAML):
+
+```toml
+[[notes]]
+  index = 0
+  date = 2018-09-06T11:37:00-04:00
+  content = "A note."
+[[notes]]
+  index = 1
+  date = 2018-09-06T11:45:00-04:00
+  content = "Another note."
+```
+
+Note
+: The state change notes are intentionally put in this test
+    LOGBOOK, because we want to ensure that they don't seep into
+    the `notes` front-matter.

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -6,15 +6,30 @@ description = """
   """
 tags = ["front-matter", "notes", "logbook"]
 draft = false
+[[org-logbook]]
+  timestamp = 2022-04-08T14:53:00-04:00
+  note = """
+    This note addition prompt shows up on typing the `C-c C-z` binding.
+    See [Org Info: Drawers](https://orgmode.org/manual/Drawers.html "Emacs Lisp: (info \\"(org) Drawers\\")").
+    """
+[[org-logbook]]
+  timestamp = 2018-09-06T11:45:00-04:00
+  note = "Another note **bold** _italics_."
+[[org-logbook]]
+  timestamp = 2018-09-06T11:37:00-04:00
+  note = "A note `mono`."
+[[org-logbook]]
+  timestamp = 2018-09-06T11:25:00-04:00
+  to-state = "DONE"
+  from-state = "DRAFT"
+[[org-logbook]]
+  timestamp = 2018-09-06T11:25:00-04:00
+  to-state = "DRAFT"
+  from-state = "TODO"
+[[org-logbook]]
+  timestamp = 2018-09-06T11:25:00-04:00
+  to-state = "TODO"
 +++
-
--   Note taken on <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:45] </span></span> <br />
-    Another note **bold** _italics_.
--   Note taken on <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:37] </span></span> <br />
-    A note `mono`.
--   State "DONE"       from "DRAFT"      <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:25]</span></span>
--   State "DRAFT"      from "TODO"       <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:25]</span></span>
--   State "TODO"       from              <span class="timestamp-wrapper"><span class="timestamp">[2018-09-06 Thu 11:25]</span></span>
 
 `ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)
 
@@ -32,21 +47,9 @@ For example,
 :END:
 ```
 
-should export these `notes` in TOML front-matter (and the equivalent
-in YAML):
-
-```toml
-[[notes]]
-  index = 0
-  date = 2018-09-06T11:37:00-04:00
-  content = "A note."
-[[notes]]
-  index = 1
-  date = 2018-09-06T11:45:00-04:00
-  content = "Another note."
-```
+should export these `notes` in arrays of TOML tables.
 
 Note
 : The state change notes are intentionally put in this test
     LOGBOOK, because we want to ensure that they don't seep into
-    the `notes` front-matter.
+    the `org-logbook` front-matter.

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -1,34 +1,29 @@
 +++
 title = "Parsing notes from LOGBOOK"
 description = """
-  Parse notes from LOGBOOK into a TOML table (YAML map?) of `notes`
-  front-matter.
+  Parse notes from LOGBOOK into a TOML table (YAML map?) of
+  `logbook_notes` front-matter.
   """
 tags = ["front-matter", "notes", "logbook"]
 draft = false
-[[org-logbook]]
-  timestamp = 2022-04-08T14:53:00-04:00
+[[logbook_notes]]
+  timestamp = 2022-05-04T13:15:00+00:00
+  note = """
+    This new note added last should be the first element of the
+    `[[logbook_notes]]` TOML table array.
+    """
+[[logbook_notes]]
+  timestamp = 2022-04-08T14:53:00+00:00
   note = """
     This note addition prompt shows up on typing the `C-c C-z` binding.
     See [Org Info: Drawers](https://orgmode.org/manual/Drawers.html "Emacs Lisp: (info \\"(org) Drawers\\")").
     """
-[[org-logbook]]
-  timestamp = 2018-09-06T11:45:00-04:00
+[[logbook_notes]]
+  timestamp = 2018-09-06T11:45:00+00:00
   note = "Another note **bold** _italics_."
-[[org-logbook]]
-  timestamp = 2018-09-06T11:37:00-04:00
+[[logbook_notes]]
+  timestamp = 2018-09-06T11:37:00+00:00
   note = "A note `mono`."
-[[org-logbook]]
-  timestamp = 2018-09-06T11:25:00-04:00
-  to-state = "DONE"
-  from-state = "DRAFT"
-[[org-logbook]]
-  timestamp = 2018-09-06T11:25:00-04:00
-  to-state = "DRAFT"
-  from-state = "TODO"
-[[org-logbook]]
-  timestamp = 2018-09-06T11:25:00-04:00
-  to-state = "TODO"
 +++
 
 `ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)
@@ -47,9 +42,11 @@ For example,
 :END:
 ```
 
-should export these `notes` in arrays of TOML tables.
+should export only the notes to an array of TOML tables with key
+`logbook_notes`. The notes are ordered starting from the newest note
+first in the TOML table array to the oldest note at the last.
 
 Note
 : The state change notes are intentionally put in this test
-    LOGBOOK, because we want to ensure that they don't seep into
-    the `org-logbook` front-matter.
+    LOGBOOK, because we want to ensure that they don't seep into the
+    `logbook_notes` front-matter.

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -6,24 +6,25 @@ description = """
   """
 tags = ["front-matter", "notes", "logbook"]
 draft = false
-[[logbook_notes]]
-  timestamp = 2022-05-04T13:15:00+00:00
-  note = """
-    This new note added last should be the first element of the
-    `[[logbook_notes]]` TOML table array.
-    """
-[[logbook_notes]]
-  timestamp = 2022-04-08T14:53:00+00:00
-  note = """
-    This note addition prompt shows up on typing the `C-c C-z` binding.
-    See [Org Info: Drawers](https://orgmode.org/manual/Drawers.html "Emacs Lisp: (info \\"(org) Drawers\\")").
-    """
-[[logbook_notes]]
-  timestamp = 2018-09-06T11:45:00+00:00
-  note = "Another note **bold** _italics_."
-[[logbook_notes]]
-  timestamp = 2018-09-06T11:37:00+00:00
-  note = "A note `mono`."
+[logbook]
+  [[logbook.notes]]
+    timestamp = 2022-05-04T13:15:00+00:00
+    note = """
+      This new note added last should be the first element of the
+      `[[logbook_notes]]` TOML table array.
+      """
+  [[logbook.notes]]
+    timestamp = 2022-04-08T14:53:00+00:00
+    note = """
+      This note addition prompt shows up on typing the `C-c C-z` binding.
+      See [Org Info: Drawers](https://orgmode.org/manual/Drawers.html "Emacs Lisp: (info \\"(org) Drawers\\")").
+      """
+  [[logbook.notes]]
+    timestamp = 2018-09-06T11:45:00+00:00
+    note = "Another note **bold** _italics_."
+  [[logbook.notes]]
+    timestamp = 2018-09-06T11:37:00+00:00
+    note = "A note `mono`."
 +++
 
 `ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -4,6 +4,7 @@ description = """
   Parse notes from LOGBOOK into a TOML table (YAML map?) of
   `logbook.notes` front-matter.
   """
+layout = "alternate-single"
 tags = ["front-matter", "notes", "logbook"]
 draft = false
 [logbook]

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -7,24 +7,25 @@ description = """
 tags = ["front-matter", "notes", "logbook"]
 draft = false
 [logbook]
-  [[logbook.notes]]
-    timestamp = 2022-05-04T13:15:00+00:00
-    note = """
-      This new note added last should be the first element of the
-      `[[logbook.notes]]` TOML table array.
-      """
-  [[logbook.notes]]
-    timestamp = 2022-04-08T14:53:00+00:00
-    note = """
-      This note addition prompt shows up on typing the `C-c C-z` binding.
-      See [Org Info: Drawers](https://orgmode.org/manual/Drawers.html "Emacs Lisp: (info \\"(org) Drawers\\")").
-      """
-  [[logbook.notes]]
-    timestamp = 2018-09-06T11:45:00+00:00
-    note = "Another note **bold** _italics_."
-  [[logbook.notes]]
-    timestamp = 2018-09-06T11:37:00+00:00
-    note = "A note `mono`."
+  [logbook._toplevel]
+    [[logbook._toplevel.notes]]
+      timestamp = 2022-05-04T13:15:00+00:00
+      note = """
+  This new note added last should be the first element of the
+  `[[logbook.notes]]` TOML table array.
+  """
+    [[logbook._toplevel.notes]]
+      timestamp = 2022-04-08T14:53:00+00:00
+      note = """
+  This note addition prompt shows up on typing the `C-c C-z` binding.
+  See [Org Info: Drawers](https://orgmode.org/manual/Drawers.html "Emacs Lisp: (info \\"(org) Drawers\\")").
+  """
+    [[logbook._toplevel.notes]]
+      timestamp = 2018-09-06T11:45:00+00:00
+      note = "Another note **bold** _italics_."
+    [[logbook._toplevel.notes]]
+      timestamp = 2018-09-06T11:37:00+00:00
+      note = "A note `mono`."
 +++
 
 `ox-hugo` Issue #[203](https://github.com/kaushalmodi/ox-hugo/issues/203)

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -2,7 +2,7 @@
 title = "Parsing notes from LOGBOOK"
 description = """
   Parse notes from LOGBOOK into a TOML table (YAML map?) of
-  `logbook_notes` front-matter.
+  `logbook.notes` front-matter.
   """
 tags = ["front-matter", "notes", "logbook"]
 draft = false
@@ -11,7 +11,7 @@ draft = false
     timestamp = 2022-05-04T13:15:00+00:00
     note = """
       This new note added last should be the first element of the
-      `[[logbook_notes]]` TOML table array.
+      `[[logbook.notes]]` TOML table array.
       """
   [[logbook.notes]]
     timestamp = 2022-04-08T14:53:00+00:00
@@ -44,10 +44,10 @@ For example,
 ```
 
 should export only the notes to an array of TOML tables with key
-`logbook_notes`. The notes are ordered starting from the newest note
+`logbook.notes`. The notes are ordered starting from the newest note
 first in the TOML table array to the oldest note at the last.
 
 Note
 : The state change notes are intentionally put in this test
     LOGBOOK, because we want to ensure that they don't seep into the
-    `logbook_notes` front-matter.
+    `logbook.notes` front-matter.

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -47,10 +47,10 @@ For example,
 ```
 
 should export only the notes to an array of TOML tables with key
-`logbook.notes`. The notes are ordered starting from the newest note
-first in the TOML table array to the oldest note at the last.
+`logbook.<..>.notes`. The notes are ordered starting from the newest
+note first in the TOML table array to the oldest note at the last.
 
 Note
 : The state change notes are intentionally put in this test
     LOGBOOK, because we want to ensure that they don't seep into the
-    `logbook.notes` front-matter.
+    `logbook.<..>.notes` front-matter.

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -4,6 +4,7 @@ description = """
   Parse notes from LOGBOOK into a TOML table (YAML map?) of
   `logbook.notes` front-matter.
   """
+date = 2018-09-06T11:25:00+00:00
 layout = "alternate-single"
 tags = ["front-matter", "notes", "logbook"]
 draft = false

--- a/test/site/layouts/_default/_markup/render-heading.html
+++ b/test/site/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,6 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }}
+  <a href="#{{ .Anchor | safeURL }}"><small>#</small></a>
+</h{{ .Level }}>
+{{ partial "logbook_notes.html"
+           (dict "page" $.Page
+                 "notes_param" (printf "logbook.%s.notes" .PlainText)) }}

--- a/test/site/layouts/_default/alternate-single.html
+++ b/test/site/layouts/_default/alternate-single.html
@@ -2,6 +2,10 @@
 
 {{ "**This is `alternate-single` layout from `_default`.**" | markdownify }}
 
+{{ partial "logbook_notes.html"
+           (dict "page" $.Page
+                 "notes_param" "logbook._toplevel.notes") }}
+
 <hr>
 {{ .Content }}
 

--- a/test/site/layouts/partials/logbook_notes.html
+++ b/test/site/layouts/partials/logbook_notes.html
@@ -1,0 +1,17 @@
+{{ with .page.Param .notes_param }}
+    <dl>
+        {{ range . }}
+            <dt>
+                <span class="timestamp-wrapper">
+                    <span class="timestamp">
+                        {{ printf `&lt;%s&gt;` (time.Format "2006-01-02" .timestamp)
+                        | safeHTML }}
+                    </span>
+                </span>
+            </dt>
+            <dd>
+                {{ .note | $.page.RenderString | emojify }}
+            </dd>
+        {{ end }}
+    </dl>
+{{ end }}


### PR DESCRIPTION
Fixes https://github.com/kaushalmodi/ox-hugo/issues/203

- [x] Fix run time error when parsing plist data only on Emacs 26.3 - https://lists.gnu.org/r/help-gnu-emacs/2022-05/msg00022.html -- The "fix" was actually a workaround to use alist instead of plist for the logbook entry. 
- [x] Export LOGBOOK notes to `logbook.notes` TOML Table array
- [x] Interpret `date` from LOGBOOK state changes
- [x] Interpret `lastmod` from LOGBOOK state changes 
- [x] Update ox-hugo manual with info on `:LOGBOOK:` drawer exports

### Example usage

[scripter.co commit # cae86abc](https://gitlab.com/kaushalmodi/kaushalmodi.gitlab.io/-/commit/cae86abc0bdf6c9c2ceda1e249453f1642038cdc)