### PR TITLE
Better `<<target>>` and  `<<<radio-target>>>` links that don't change on each export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,18 +237,13 @@ ctemp:
 	@find $(OX_HUGO_TEST_SITE_DIR)/content -name "*.*~" -delete
 	@find ./doc/content -name "*.*~" -delete
 
-# Before doing the diff, replace the randomly generated org reference
-# id's like "org123abcd" with "orgxxxxxxx" so that the diff doesn't
-# fail on those id mismatches.
-# Also get rid of all changes in $(OX_HUGO_TEST_SITE_DIR)/content
-# after making a copy to $(OX_HUGO_TEST_SITE_DIR)/content-modified.
+# Get rid of all changes in $(OX_HUGO_TEST_SITE_DIR)/content after
+# making a copy to $(OX_HUGO_TEST_SITE_DIR)/content-modified.
 # https://stackoverflow.com/a/16589534/1219634
 diffgolden:
 	@rm -rf $(OX_HUGO_TEST_SITE_DIR)/content-modified
 	@cp -rf $(OX_HUGO_TEST_SITE_DIR)/content $(OX_HUGO_TEST_SITE_DIR)/content-modified
 	@git checkout --ignore-skip-worktree-bits -- $(OX_HUGO_TEST_SITE_DIR)/content
-	@find $(OX_HUGO_TEST_SITE_DIR)/content-modified -name "*.md" -exec perl -pi -e 's/(["#]org)([a-f0-9]{7})/\1xxxxxxx/' -- '{}' +
-	@find $(OX_HUGO_TEST_SITE_DIR)/content-golden -name "*.md" -exec perl -pi -e 's/(["#]org)([a-f0-9]{7})/\1xxxxxxx/' -- '{}' +
 	@diff -r $(OX_HUGO_TEST_SITE_DIR)/content-modified $(OX_HUGO_TEST_SITE_DIR)/content-golden
 
 clean: ctemp

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -123,6 +123,7 @@ tag needs to be `python'."
                      (plain-list . org-blackfriday-plain-list)
                      (plain-text . org-blackfriday-plain-text)
                      (quote-block . org-blackfriday-quote-block)
+                     (radio-target . org-blackfriday-radio-target)
                      (special-block . org-blackfriday-special-block)
                      (src-block . org-blackfriday-src-block)
                      (strike-through . org-blackfriday-strike-through)
@@ -193,6 +194,7 @@ If TAG is not specified, it defaults to \"div\"."
 
 Returns nil if the SYMBOL's prefix string isn't defined."
   (let ((prefix-alist '((figure . "figure--")
+                        (radio . "org-radio--")
                         (src-block . "code-snippet--")
                         (table . "table--")
                         (target . "org-target--"))))
@@ -964,6 +966,16 @@ communication channel."
                       (when next-is-quote
                         "\n\n<!--quoteend-->")))
     ret))
+
+;;;; Radio Target
+(defun org-blackfriday-radio-target (radio-target text info)
+  "Transcode a RADIO-TARGET object from Org to HTML.
+CONTENTS is nil.  INFO is a plist holding contextual
+information."
+  (let ((ref (format "%s%s"
+                     (org-blackfriday--get-ref-prefix 'radio)
+                     (org-element-property :value radio-target))))
+    (org-html--anchor ref text nil info)))
 
 ;;;; Special Block
 (defun org-blackfriday-special-block (special-block contents info)

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -129,6 +129,7 @@ tag needs to be `python'."
                      (table-cell . org-blackfriday-table-cell)
                      (table-row . org-blackfriday-table-row)
                      (table . org-blackfriday-table)
+                     (target . org-blackfriday-target)
                      (verse-block . org-blackfriday-verse-block)))
 
 
@@ -1308,6 +1309,15 @@ contextual information."
 
       (concat table-pre table-anchor caption-html
               blank-line-before-table tbl table-post))))
+
+;;;; Target
+(defun org-blackfriday-target (target _contents info)
+  "Transcode a TARGET object from Org to HTML.
+CONTENTS is nil.  INFO is a plist holding contextual
+information."
+  (let* ((ref-prefix "org-target--")
+         (ref (format "%s%s" ref-prefix (org-element-property :value target))))
+    (org-html--anchor ref nil nil info)))
 
 ;;;; Verse Block
 (defun org-blackfriday-verse-block (_verse-block contents info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2169,14 +2169,16 @@ and rewrite link paths to make blogging more seamless."
                                        (eq (org-element-type destination) 'paragraph))
                                   (let ((figure-ref (org-blackfriday--get-reference destination)))
                                     (if (org-string-nw-p figure-ref)
-                                        (replace-regexp-in-string "\\`org-paragraph--" "figure--" figure-ref)
+                                        (replace-regexp-in-string
+                                         "\\`org-paragraph--"
+                                         (org-blackfriday--get-ref-prefix 'figure)
+                                         figure-ref)
                                       (org-export-get-reference destination info))))
                                  ;; Ref to a <<target>>.
                                  ((eq (org-element-type destination) 'target)
-                                  ;; Keep the below "org-target--" prefix in
-                                  ;; sync with that in
-                                  ;; `org-blackfriday-target'.
-                                  (format "org-target--%s" raw-path)) ;If the target is <<xyz>>, `raw-path' will be "xyz"
+                                  (format "%s%s"
+                                          (org-blackfriday--get-ref-prefix (org-element-type destination))
+                                          raw-path)) ;If the target is <<xyz>>, `raw-path' will be "xyz"
                                  ;; Ref to all other link destinations.
                                  (t
                                   (org-export-get-reference destination info)))))
@@ -2674,7 +2676,10 @@ communication channel."
       (let ((figure-ref (org-blackfriday--get-reference paragraph))
             label)
         (when (org-string-nw-p figure-ref)
-          (setq figure-ref (replace-regexp-in-string "\\`org-paragraph--" "figure--" figure-ref)))
+          (setq figure-ref (replace-regexp-in-string
+                            "\\`org-paragraph--"
+                            (org-blackfriday--get-ref-prefix 'figure)
+                            figure-ref)))
         (setq label (if figure-ref
                         (format "<a id=\"%s\"></a>\n\n" figure-ref)
                       ""))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2320,9 +2320,12 @@ and rewrite link paths to make blogging more seamless."
       (let ((ref (org-element-property :path link)))
         (format (org-export-get-coderef-format ref desc)
                 (org-export-resolve-coderef ref info))))
-     ((equal type "radio")
+     ((string= type "radio")
       (let ((destination (org-export-resolve-radio-link link info)))
-        (format "[%s](#%s)" desc (org-export-get-reference destination info))))
+        (format "[%s](#%s%s)"
+                desc
+                (org-blackfriday--get-ref-prefix 'radio)
+                (org-element-property :value destination))))
      (t
       (let* ((link-param-str "")
              (path (cond

--- a/test/site/content/posts/link-destination.md
+++ b/test/site/content/posts/link-destination.md
@@ -6,7 +6,7 @@ draft = false
 
 ## External target {#external-target}
 
-<a id="org371fa62"></a>
+<a id="org-target--external-target"></a>
 
 
 ## External target with **bold** and _italic_ {#external-target-with-bold-and-italic}

--- a/test/site/content/posts/links-outside-the-same-post.md
+++ b/test/site/content/posts/links-outside-the-same-post.md
@@ -30,7 +30,7 @@ init file.
 -   [Link to CUSTOM_ID within the same post](#internal-target)
 -   [Link to ID within the same post](#internal-target)
 -   [Link to heading within the same post](#internal-target)
--   [Link to target within the same post](#orgac7640c)
+-   [Link to target within the same post](#org-target--internal-target)
 
 
 ## Cross-post links {#cross-post-links}
@@ -68,7 +68,7 @@ resolved to the containing post.
 
 ## Internal target {#internal-target}
 
-<a id="orgac7640c"></a>
+<a id="org-target--internal-target"></a>
 
 
 ## Link destination {#link-destination}
@@ -76,7 +76,7 @@ resolved to the containing post.
 
 ### External target {#external-target}
 
-<a id="org15cb7d5"></a>
+<a id="org-target--external-target"></a>
 
 
 ### External target with **bold** and _italic_ {#external-target-with-bold-and-italic}

--- a/test/site/content/posts/links-to-org-targets.md
+++ b/test/site/content/posts/links-to-org-targets.md
@@ -16,7 +16,7 @@ will output below (_lorem-ipsum_ added to increase page content so
 that the link jump is evident):
 
 -   one item
--   <a id="orgf486ef7"></a>another item
+-   <a id="org-target--target"></a>another item
 
 _Scroll to the end of the below 'lorem-ipsum' block to find the test
 link._
@@ -73,4 +73,4 @@ suscipit nec nec neque. Suspendisse vitae tincidunt justo, sed
 molestie velit. Nullam pellentesque convallis ante, vel posuere libero
 blandit in.
 
-**Here we refer to item [2](#orgf486ef7).**
+**Here we refer to item [2](#org-target--target).**

--- a/test/site/content/posts/radio-targets.md
+++ b/test/site/content/posts/radio-targets.md
@@ -5,7 +5,7 @@ tags = ["links", "internal-links", "radio-targets"]
 draft = false
 +++
 
-Here I am referencing to [asdf123](#org405da13) that I talk about later.
+Here I am referencing to [asdf123](#org-radio--asdf123) that I talk about later.
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et
 quam metus. Etiam in iaculis mi, sit amet pretium magna. Donec ut dui
@@ -111,7 +111,7 @@ suscipit nec nec neque. Suspendisse vitae tincidunt justo, sed
 molestie velit. Nullam pellentesque convallis ante, vel posuere libero
 blandit in.
 
-Here I talk about the [asdf123](#org405da13) topic again.
+Here I talk about the [asdf123](#org-radio--asdf123) topic again.
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et
 quam metus. Etiam in iaculis mi, sit amet pretium magna. Donec ut dui
@@ -217,4 +217,4 @@ suscipit nec nec neque. Suspendisse vitae tincidunt justo, sed
 molestie velit. Nullam pellentesque convallis ante, vel posuere libero
 blandit in.
 
-Here I talk about <a id="org405da13">asdf123</a>.
+Here I talk about <a id="org-radio--asdf123">asdf123</a>.


### PR DESCRIPTION
Fixes https://github.com/kaushalmodi/ox-hugo/issues/507

With Org snippet like below:

    <<xyz>>
    [[xyz][link text]]

Earlier, it exported as below where that ref would change on each
export:

    <a id="orgf486ef7"></a>
    <a href="#orgf486ef7">link text</a>

Now it will always export to:

    <a id="org-target--xyz"></a>
    <a href="#org-target--xyz">link text</a>