### PR TITLE
Add test for https://github.com/kaushalmodi/ox-hugo/issues/514

### DIFF
--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -527,6 +527,17 @@ This heading is wrapped in an ~aside~ tag with classes ~outline-1~ and
 :END:
 This heading is wrapped in a ~blockquote~ tag with classes ~outline-2~
 and ~baz~.
+** Export with planning info                                       :planning:
+:PROPERTIES:
+:EXPORT_FILE_NAME: planning-info
+:EXPORT_OPTIONS: p:t
+:END:
+#+begin_description
+Export the SCHEDULED, DEADLINE, etc. planning info time stamps.
+#+end_description
+{{{oxhugoissue(514)}}}
+*** TODO Some plan
+SCHEDULED: <2022-01-20 Mon> DEADLINE: <2022-01-30 Mon>
 * Title in Front Matter                                               :title:
 ** Awesome title with "quoted text"
 :PROPERTIES:

--- a/test/site/content/posts/planning-info.md
+++ b/test/site/content/posts/planning-info.md
@@ -1,0 +1,13 @@
++++
+title = "Export with planning info"
+description = "Export the SCHEDULED, DEADLINE, etc. planning info time stamps."
+tags = ["headings", "planning"]
+draft = false
++++
+
+`ox-hugo` Issue #[514](https://github.com/kaushalmodi/ox-hugo/issues/514)
+
+
+## <span class="org-todo todo TODO">TODO</span> Some plan {#some-plan}
+
+<p><span class="timestamp-wrapper"><span class="timestamp-kwd">DEADLINE:</span> <span class="timestamp">&lt;2022-01-30 Sun&gt; </span> <span class="timestamp-kwd">SCHEDULED:</span> <span class="timestamp">&lt;2022-01-20 Thu&gt;</span></span></p>


### PR DESCRIPTION
@stefanv It looks like planning info is already exported corrected with `#+options: p:t` is set. This PR simply adds a test case for that.

This feature got inherited from ox-html automatically.