### PR TITLE
Ordered list update

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -807,11 +807,12 @@ exported instead:
                            ox-md-style-desc-list)
                        "-")
                       ((eq parent-list-type 'ordered)
-                       (format "%d." item-num))
+                       (format "%d. " item-num))
                       (t             ;Non-nested descriptive list item
                        (when (> item-num 1)
                          "\n")))) ;Newline between each descriptive list item
-             (padding (unless bf-style-desc-list
+             (padding (when (and (not bf-style-desc-list)
+                                 (<= (length bullet) 3))
                         (make-string (- 4 (length bullet)) ? )))
              (tag (when desc-list?
                     (let* ((tag1 (org-element-property :tag item))

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -294,21 +294,33 @@ in the column, or by the maximum cell with in the column."
         (puthash column max-width org-blackfriday-width-cookies)))))
 
 ;;;; Plain List Helper
-(defun org-blackfriday--ordered-list-with-custom-counter-p (plain-list)
-  "Return non-nil is PLAIN-LIST element has an item with custom counter.
-Returns nil immediately if PLAIN-LIST is not an ordered list."
+(defun org-blackfriday--export-ordered-list-as-html-p (plain-list)
+  "Return non-nil if the PLAIN-LIST needs to be exported as HTML.
+
+The PLAIN-LIST is exported as HTML if the list is an ordered list
+and a custom counter is used on second or later item in the list.
+
+Returns nil otherwise."
   (let ((type (org-element-property :type plain-list))
         has-custom-counter)
     (when (eq 'ordered type)
-      (let* ((list-contents (org-element-contents plain-list)))
-        (dolist (el list-contents)
-          (when (eq 'item (car el))
-            (let* ((item-plist (car (cdr el)))
-                   (counter (plist-get item-plist :counter)))
-              ;; (message "dbg: %S" counter)
-              (when counter
-                (setq has-custom-counter t)))))))
-    ;; (message "has custom counter: %S" has-custom-counter)
+      (let ((list-contents (org-element-contents plain-list))
+            (item-num 1))
+        (setq has-custom-counter
+              (catch 'break
+                (dolist (el list-contents)
+                  (when (eq 'item (car el))
+                    (let* ((item-plist (car (cdr el)))
+                           (counter (plist-get item-plist :counter)))
+                      ;; (message "dbg: item num: %d counter: %S" item-num counter)
+                      ;; Make special provision for the custom counter
+                      ;; notation [@N] only if it's present on second
+                      ;; or later items.
+                      (when (and (> item-num 1)
+                                 counter)
+                        (throw 'break t))))
+                  (cl-incf item-num))))))
+    ;; (message "dbg: has custom counter: %S" has-custom-counter)
     has-custom-counter))
 
 ;;;; Table Cell Alignment
@@ -762,11 +774,11 @@ If that list is nested, `ox-md' style descriptive list is
 exported instead:
 
     -   **Term1:** Description of term 1."
-  (let* ((parent-list (org-export-get-parent item)))
+  (let ((parent-list (org-export-get-parent item)))
     ;; If this item is in an ordered list and if this or any other
     ;; item in this list is using a custom counter, export this list
     ;; item in HTML.
-    (if (org-blackfriday--ordered-list-with-custom-counter-p parent-list)
+    (if (org-blackfriday--export-ordered-list-as-html-p parent-list)
         (org-html-format-list-item contents 'ordered nil info
                                    (org-element-property :counter item))
       (let* ((parent-list (org-export-get-parent item))
@@ -888,9 +900,7 @@ INFO is a plist holding contextual information."
 CONTENTS is the plain-list contents.  INFO is a plist used as a
 communication channel."
   (let (ret)
-    (if (org-blackfriday--ordered-list-with-custom-counter-p plain-list)
-        ;; If this is an ordered list and if any item in this list is
-        ;; using a custom counter, export this list in HTML.
+    (if (org-blackfriday--export-ordered-list-as-html-p plain-list)
         (setq ret (concat
                    (org-blackfriday--div-wrap-maybe plain-list nil info)
                    (org-html-plain-list plain-list contents info)))

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4003,6 +4003,18 @@ Another example:
 7. [@7] This will be 7!
 100. [@100] This will be 100!
 
+Ordered list numbers larger then 99:
+
+100. [@100] This will be 100!
+101. This will be 101.
+102. This will be 102.
+
+
+999999997. [@999999997] This will be 999999997!
+999999998. This will be 999999998.
+999999999. This will be 999999999. CommonMark 0.30 [[https://spec.commonmark.org/0.30/#ordered-list-marker][allows]] an ordered
+           list marker to be at max 9 digits long.
+
 See [[https://orgmode.org/manual/Plain-Lists.html][(org) Plain Lists]] to read more about plain lists in Org.
 ** Checklist
 :PROPERTIES:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -3980,28 +3980,28 @@ Paragraph outside the list.
 Ordered lists with custom counter.
 
 1. This will be 1.
-1. This will be 2.
+2. This will be 2.
 
 
-1. [@10] This will be 10!
-1. This will be 11.
+10. [@10] This will be 10!
+11. This will be 11.
 
 
-1. [@17] This will be 17!
-1. This will be 18.
-1. [@123] This will be 123!
-1. This will be 124.
+17. [@17] This will be 17!
+18. This will be 18.
+123. [@123] This will be 123!
+124. This will be 124.
 
 
 1. This will be 1 again.
-1. This will be 2.
+2. This will be 2.
 
 Another example:
 
 1. This will be 1.
-1. [@3] This will be 3!
-1. [@7] This will be 7!
-1. [@100] This will be 100!
+3. [@3] This will be 3!
+7. [@7] This will be 7!
+100. [@100] This will be 100!
 
 See [[https://orgmode.org/manual/Plain-Lists.html][(org) Plain Lists]] to read more about plain lists in Org.
 ** Checklist

--- a/test/site/content/posts/force-ordered-list-numbering.md
+++ b/test/site/content/posts/force-ordered-list-numbering.md
@@ -36,4 +36,17 @@ Another example:
 <li value="100">This will be 100!</li>
 </ol>
 
+Ordered list numbers larger then 99:
+
+100. This will be 100!
+101. This will be 101.
+102. This will be 102.
+
+<!--listend-->
+
+999999997. This will be 999999997!
+999999998. This will be 999999998.
+999999999. This will be 999999999. CommonMark 0.30 [allows](https://spec.commonmark.org/0.30/#ordered-list-marker) an ordered
+    list marker to be at max 9 digits long.
+
 See [(org) Plain Lists](https://orgmode.org/manual/Plain-Lists.html) to read more about plain lists in Org.

--- a/test/site/content/posts/force-ordered-list-numbering.md
+++ b/test/site/content/posts/force-ordered-list-numbering.md
@@ -12,10 +12,10 @@ Ordered lists with custom counter.
 
 <!--listend-->
 
-<ol class="org-ol">
-<li value="10">This will be 10!</li>
-<li>This will be 11.</li>
-</ol>
+10. This will be 10!
+11. This will be 11.
+
+<!--listend-->
 
 <ol class="org-ol">
 <li value="17">This will be 17!</li>


### PR DESCRIPTION
1. Prevent export of ordered list in HTML format if only the first item in the list as custom numbering.
2. Fix ordered list export if the number has more than 2 digits; fixes https://github.com/kaushalmodi/ox-hugo/issues/517