### PR TITLE
Preserve line breaks from Org source

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -994,7 +994,7 @@ matches with \"\\\" as needed."
     (setq text (org-html-convert-special-strings text)))
   ;; Handle break preservation, if required.
   (when (plist-get info :preserve-breaks)
-    (setq text (replace-regexp-in-string "[ \t]*\n" "  \n" text)))
+    (setq text (replace-regexp-in-string "[ \t]*\n" " <br/>\n" text)))
   ;; Return value.
   text)
 

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -6359,6 +6359,14 @@ The front-matter for this post contains the default Creator string.
 :EXPORT_FILE_NAME: custom-creator
 :END:
 The front-matter for this post contains a custom Creator string.
+** Preserve Breaks                                          :preserve_breaks:
+:PROPERTIES:
+:EXPORT_FILE_NAME: preserve-breaks
+:EXPORT_OPTIONS: \n:t
+:END:
+abc
+def
+ghi
 * Export snippets and blocks
 ** Export snippet                                            :export_snippet:
 *** Export snippet Hugo                                                :hugo:

--- a/test/site/content/posts/preserve-breaks.md
+++ b/test/site/content/posts/preserve-breaks.md
@@ -1,0 +1,9 @@
++++
+title = "Preserve Breaks"
+tags = ["export-option", "preserve-breaks"]
+draft = false
++++
+
+abc <br/>
+def <br/>
+ghi


### PR DESCRIPTION
Fixes https://github.com/kaushalmodi/ox-hugo/issues/527.

This feature is like the site-wide Goldmark config (ref:
https://github.com/kaushalmodi/ox-hugo/issues/526#issuecomment-1013724072):

    [markup.goldmark.renderer]
      hardWraps = true

.. but using the "\n:t" export option, this feature can be enabled
only for specific posts.