### PR TITLE
Fix export when using `':t` export option

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -965,38 +965,41 @@ separated by blank lines.
 This function is almost same as `org-md-plain-text' except it
 first escapes any existing \"\\\", and then escapes other string
 matches with \"\\\" as needed."
-  (when (plist-get info :with-smart-quotes)
-    (setq text (org-export-activate-smart-quotes text :html info)))
-  ;; The below series of replacements in `text' is order sensitive.
-  ;; Protect `, * and \
-  (setq text (replace-regexp-in-string "[`*\\]" "\\\\\\&" text))
-  ;; Protect _ only if it is preceded or followed by a word boundary
-  ;; ("\b" doesn't work because _ itself is considered to be a word
-  ;; boundary).
-  ;; "foo_ bar" -> "foo\_ bar"
-  (setq text (replace-regexp-in-string "\\([[:graph:]]\\)\\([_]\\)\\([[:space:].!?]\\|\\'\\)" "\\1\\\\\\2\\3" text))
-  ;; "foo _bar" -> "foo \_bar"
-  (setq text (replace-regexp-in-string "\\([[:space:]]\\|\\`\\)\\([_]\\)\\([[:graph:]]\\)" "\\1\\\\\\2\\3" text))
-  ;; Protect the characters in `org-html-protect-char-alist' (`<',
-  ;; `>', `&').
-  (setq text (org-html-encode-plain-text text))
-  ;; Protect braces when verbatim shortcode mentions are detected.
-  (setq text (replace-regexp-in-string "{{%" "{&lbrace;%" text))
-  (setq text (replace-regexp-in-string "%}}" "%&rbrace;}" text))
-  ;; Protect ambiguous #.  This will protect # at the beginning of
-  ;; a line, but not at the beginning of a paragraph.  See
-  ;; `org-md-paragraph'.
-  (setq text (replace-regexp-in-string "\n#" "\n\\\\#" text))
-  ;; Protect ambiguous !
-  (setq text (replace-regexp-in-string "\\(!\\)\\[" "\\\\!" text nil nil 1))
-  ;; Handle special strings, if required.
-  (when (plist-get info :with-special-strings)
-    (setq text (org-html-convert-special-strings text)))
-  ;; Handle break preservation, if required.
-  (when (plist-get info :preserve-breaks)
-    (setq text (replace-regexp-in-string "[ \t]*\n" " <br/>\n" text)))
-  ;; Return value.
-  text)
+  (let ((orig-text text))
+    ;; The below series of replacements in `text' is order
+    ;; sensitive.
+    ;; Protect `, * and \
+    (setq text (replace-regexp-in-string "[`*\\]" "\\\\\\&" text))
+    ;; Protect _ only if it is preceded or followed by a word boundary
+    ;; ("\b" doesn't work because _ itself is considered to be a word
+    ;; boundary).
+    ;; "foo_ bar" -> "foo\_ bar"
+    (setq text (replace-regexp-in-string "\\([[:graph:]]\\)\\([_]\\)\\([[:space:].!?]\\|\\'\\)" "\\1\\\\\\2\\3" text))
+    ;; "foo _bar" -> "foo \_bar"
+    (setq text (replace-regexp-in-string "\\([[:space:]]\\|\\`\\)\\([_]\\)\\([[:graph:]]\\)" "\\1\\\\\\2\\3" text))
+    ;; Protect the characters in `org-html-protect-char-alist' (`<',
+    ;; `>', `&').
+    (setq text (org-html-encode-plain-text text))
+    ;; Protect braces when verbatim shortcode mentions are detected.
+    (setq text (replace-regexp-in-string "{{%" "{&lbrace;%" text))
+    (setq text (replace-regexp-in-string "%}}" "%&rbrace;}" text))
+    ;; Protect ambiguous #.  This will protect # at the beginning of a
+    ;; line, but not at the beginning of a paragraph.  See
+    ;; `org-md-paragraph'.
+    (setq text (replace-regexp-in-string "\n#" "\n\\\\#" text))
+    ;; Protect ambiguous `!'
+    (setq text (replace-regexp-in-string "\\(!\\)\\[" "\\\\!" text nil nil 1))
+    ;; Convert to smart quotes, if required.
+    (when (plist-get info :with-smart-quotes)
+      (setq text (org-export-activate-smart-quotes text :html info orig-text)))
+    ;; Handle special strings, if required.
+    (when (plist-get info :with-special-strings)
+      (setq text (org-html-convert-special-strings text)))
+    ;; Handle break preservation, if required.
+    (when (plist-get info :preserve-breaks)
+      (setq text (replace-regexp-in-string "[ \t]*\n" " <br/>\n" text)))
+    ;; Return value.
+    text))
 
 ;;;; Quote Block
 (defun org-blackfriday-quote-block (quote-block contents info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -566,7 +566,7 @@ HTML element."
                    (:section-numbers nil "num" org-hugo-export-with-section-numbers)
                    (:author "AUTHOR" nil user-full-name newline)
                    (:creator "CREATOR" nil org-hugo-export-creator-string)
-                   (:with-smart-quotes nil "'" nil)
+                   (:with-smart-quotes nil "'" nil) ;Hugo/Goldmark does more correct conversion to smart quotes, especially for single quotes.
                    (:with-special-strings nil "-" nil) ;Hugo/Goldmark does the auto-conversion of "--" -> "–", "---" -> "—" and "..." -> "…"
                    (:with-sub-superscript nil "^" '{}) ;Require curly braces to be wrapped around text to sub/super-scripted
                    (:hugo-with-locale "HUGO_WITH_LOCALE" nil nil)

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -6213,6 +6213,50 @@ The front-matter for this post contains a custom Creator string.
 abc
 def
 ghi
+** Smart Quotes                                                :smart_quotes:
+*** Smart Quotes Test
+:PROPERTIES:
+:CUSTOM_ID: smart-quotes-test
+:END:
+**** Single quotes
+- Single quotes surrounded by spaces: 'abc'
+- Second single quote followed by a period: 'abc'.
+- Second single quote followed by a comma: 'abc',
+- Brackets inside single quotes: '(abc)', '[abc]', '{abc}', 'xyz
+  (abc)', 'xyz [abc]', 'xyz {abc}', '(abc) xyz', '[abc] xyz', '{abc}
+  xyz'
+- Brackets inside single quotes (now with periods instead of commas):
+  '(abc)'. '[abc]'. '{abc}'. 'xyz (abc)'. 'xyz [abc]'. 'xyz
+  {abc}'. '(abc) xyz'. '[abc] xyz'. '{abc} xyz'
+- Single quotes in contractions: it's, I'll, I've, can't
+**** Double quotes
+- Double quotes surrounded by spaces: "abc"
+- Second double quote followed by a period: "abc".
+- Second double quote followed by a comma: "abc",
+- Brackets inside double quotes: "(abc)", "[abc]", "{abc}", "xyz
+  (abc)", "xyz [abc]", "xyz {abc}", "(abc) xyz", "[abc] xyz", "{abc}
+  xyz"
+- Brackets inside double quotes (now with periods instead of commas):
+  "(abc)". "[abc]". "{abc}". "xyz (abc)". "xyz [abc]". "xyz
+  {abc}". "(abc) xyz". "[abc] xyz". "{abc} xyz"
+*** Smart Quotes Enabled                                             :enable:
+:PROPERTIES:
+:EXPORT_FILE_NAME: smart-quotes-enabled
+:EXPORT_OPTIONS: ':t
+:END:
+#+begin_description
+Org mode smart quotes processing enabled
+#+end_description
+#+include: "./all-posts.org::#smart-quotes-test" :only-contents t
+*** Smart Quotes Disabled                                           :disable:
+:PROPERTIES:
+:EXPORT_FILE_NAME: smart-quotes-disabled
+:EXPORT_OPTIONS: ':nil
+:END:
+#+begin_description
+Org mode smart quotes processing disabled
+#+end_description
+#+include: "./all-posts.org::#smart-quotes-test" :only-contents t
 * Export snippets and blocks
 ** Export snippet                                            :export_snippet:
 *** Export snippet Hugo                                                :hugo:

--- a/test/site/content/posts/smart-quotes-disabled.md
+++ b/test/site/content/posts/smart-quotes-disabled.md
@@ -1,0 +1,32 @@
++++
+title = "Smart Quotes Disabled"
+description = "Org mode smart quotes processing disabled"
+tags = ["export-option", "smart-quotes", "disable"]
+draft = false
++++
+
+## Single quotes {#single-quotes}
+
+-   Single quotes surrounded by spaces: 'abc'
+-   Second single quote followed by a period: 'abc'.
+-   Second single quote followed by a comma: 'abc',
+-   Brackets inside single quotes: '(abc)', '[abc]', '{abc}', 'xyz
+    (abc)', 'xyz [abc]', 'xyz {abc}', '(abc) xyz', '[abc] xyz', '{abc}
+    xyz'
+-   Brackets inside single quotes (now with periods instead of commas):
+    '(abc)'. '[abc]'. '{abc}'. 'xyz (abc)'. 'xyz [abc]'. 'xyz
+    {abc}'. '(abc) xyz'. '[abc] xyz'. '{abc} xyz'
+-   Single quotes in contractions: it's, I'll, I've, can't
+
+
+## Double quotes {#double-quotes}
+
+-   Double quotes surrounded by spaces: "abc"
+-   Second double quote followed by a period: "abc".
+-   Second double quote followed by a comma: "abc",
+-   Brackets inside double quotes: "(abc)", "[abc]", "{abc}", "xyz
+    (abc)", "xyz [abc]", "xyz {abc}", "(abc) xyz", "[abc] xyz", "{abc}
+    xyz"
+-   Brackets inside double quotes (now with periods instead of commas):
+    "(abc)". "[abc]". "{abc}". "xyz (abc)". "xyz [abc]". "xyz
+    {abc}". "(abc) xyz". "[abc] xyz". "{abc} xyz"

--- a/test/site/content/posts/smart-quotes-enabled.md
+++ b/test/site/content/posts/smart-quotes-enabled.md
@@ -1,0 +1,32 @@
++++
+title = "Smart Quotes Enabled"
+description = "Org mode smart quotes processing enabled"
+tags = ["export-option", "smart-quotes", "enable"]
+draft = false
++++
+
+## Single quotes {#single-quotes}
+
+-   Single quotes surrounded by spaces: &rsquo;abc&rsquo;
+-   Second single quote followed by a period: &rsquo;abc&rsquo;.
+-   Second single quote followed by a comma: &rsquo;abc&rsquo;,
+-   Brackets inside single quotes: &rsquo;(abc)&rsquo;, &rsquo;[abc]&rsquo;, &rsquo;{abc}&rsquo;, &rsquo;xyz
+    (abc)&rsquo;, &rsquo;xyz [abc]&rsquo;, &rsquo;xyz {abc}&rsquo;, &rsquo;(abc) xyz&rsquo;, &rsquo;[abc] xyz&rsquo;, &rsquo;{abc}
+    xyz&rsquo;
+-   Brackets inside single quotes (now with periods instead of commas):
+    &rsquo;(abc)&rsquo;. &rsquo;[abc]&rsquo;. &rsquo;{abc}&rsquo;. &rsquo;xyz (abc)&rsquo;. &rsquo;xyz [abc]&rsquo;. &rsquo;xyz
+    {abc}&rsquo;. &rsquo;(abc) xyz&rsquo;. &rsquo;[abc] xyz&rsquo;. &rsquo;{abc} xyz&rsquo;
+-   Single quotes in contractions: it&rsquo;s, I&rsquo;ll, I&rsquo;ve, can&rsquo;t
+
+
+## Double quotes {#double-quotes}
+
+-   Double quotes surrounded by spaces: &ldquo;abc&rdquo;
+-   Second double quote followed by a period: &ldquo;abc&rdquo;.
+-   Second double quote followed by a comma: &ldquo;abc&rdquo;,
+-   Brackets inside double quotes: &ldquo;(abc)&rdquo;, &ldquo;[abc]&rdquo;, &ldquo;{abc}&rdquo;, &ldquo;xyz
+    (abc)&rdquo;, &ldquo;xyz [abc]&rdquo;, &ldquo;xyz {abc}&rdquo;, &ldquo;(abc) xyz&rdquo;, &ldquo;[abc] xyz&rdquo;, &ldquo;{abc}
+    xyz&rdquo;
+-   Brackets inside double quotes (now with periods instead of commas):
+    &ldquo;(abc)&rdquo;. &ldquo;[abc]&rdquo;. &ldquo;{abc}&rdquo;. &ldquo;xyz (abc)&rdquo;. &ldquo;xyz [abc]&rdquo;. &ldquo;xyz
+    {abc}&rdquo;. &ldquo;(abc) xyz&rdquo;. &ldquo;[abc] xyz&rdquo;. &ldquo;{abc} xyz&rdquo;


### PR DESCRIPTION
Recognize `#+options: ':t`.

https://orgmode.org/manual/Export-Settings.html

![image](https://user-images.githubusercontent.com/3578197/149641203-7a6cf00d-abcd-4b2f-a178-d67aa8f950e7.png)

