### PR TITLE
Support whitespace trimming around special blks using markers <, >

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3283,6 +3283,9 @@ description = """
 See
 {{{relref(~HUGO_PAIRED_SHORTCODES~,shortcodes/#hugo-paired-shortcodes)}}}.
 **** Other Special Blocks (~div~ tags)
+:PROPERTIES:
+:CUSTOM_ID: special-blocks--div-tags
+:END:
 If the Special Block /tag/ used isn't found in
 ~org-blackfriday-html5-inline-elements~ or ~org-html-html5-elements~,
 that block exports just as an HTML ~div~ block.
@@ -3322,6 +3325,9 @@ which will render as:
 #+begin_red
 This text will be in red.
 #+end_red
+
+/See the [[* Whitespace Trimming][Whitespace Trimming]] section if you need to export with
+~<span>~ tags instead of ~<div>~ tags./
 **** Raw Org contents
 By default, the content inside the Org special blocks will have some
 default processing done by the exporter -- Org entities like ~\sum~ will
@@ -3399,6 +3405,13 @@ after the special block name.
 - ~<~ suffix :: Trim whitespace only before the block.
 - ~>~ suffix :: Trim whitespace only after the block.
 - ~<>~ suffix :: Trim whitespace both before and after the block.
+
+#+begin_note
+By default if a special block tag is not recognized as an HTML block
+or inline element, or as a Hugo shortcode, it defaults to exporting
+[[#special-blocks--div-tags][with ~<div>~ tags]]. But if any of the whitespace trimming markers is
+used in a special block, it will export with ~<span>~ tags.
+#+end_note
 
 #+include: "../test/site/content-org/all-posts.org::* Whitespace trimming around special blocks" :only-contents t
 *** Shortcodes

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3389,6 +3389,18 @@ Then simply put /tikz/ snippets in the Org source like so:
 #+end_src
 
 {{{test-search(tikzjax)}}}
+**** Whitespace Trimming
+Whitespace trimming around exported Org Special Blocks is supported.
+
+Whether the whitespace before the exported block, after the block, or
+at both spaces is trimmed is decided by using some special markers
+after the special block name.
+
+- ~<~ suffix :: Trim whitespace only before the block.
+- ~>~ suffix :: Trim whitespace only after the block.
+- ~<>~ suffix :: Trim whitespace both before and after the block.
+
+#+include: "../test/site/content-org/all-posts.org::* Whitespace trimming around special blocks" :only-contents t
 *** Shortcodes
 :PROPERTIES:
 :EXPORT_FILE_NAME: shortcodes

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -1084,7 +1084,9 @@ This function is adapted from `org-html-special-block'."
          (html5-inline-fancy (member block-type org-blackfriday-html5-inline-elements))
          (html5-block-fancy (member block-type org-html-html5-elements))
          (html5-fancy (or html5-inline-fancy html5-block-fancy))
-         (attributes (org-export-read-attribute :attr_html special-block)))
+         (attributes (org-export-read-attribute :attr_html special-block))
+         (trim-pre-tag (or (plist-get info :trim-pre-tag) ""))
+         (trim-post-tag (or (plist-get info :trim-post-tag) "")))
     (unless html5-fancy
       (let ((class (plist-get attributes :class)))
         (setq attributes (plist-put attributes :class
@@ -1166,16 +1168,19 @@ This function is adapted from `org-html-special-block'."
                    (org-blackfriday--org-contents-to-html special-block))))
                 block-type))
        (html5-inline-fancy ;Inline HTML elements like `mark', `cite'.
-        (format "<%s%s>%s</%s>"
-                block-type attr-str contents block-type))
+        (format "%s<%s%s>%s</%s>%s"
+                trim-pre-tag block-type attr-str
+                contents block-type trim-post-tag))
        (html5-block-fancy
-        (format "<%s%s>%s\n\n%s\n\n</%s>"
-                block-type attr-str
+        (format "%s<%s%s>%s\n\n%s\n\n</%s>%s"
+                trim-pre-tag block-type attr-str
                 (org-blackfriday--extra-div-hack info block-type)
-                contents block-type))
+                contents block-type trim-post-tag))
        (t
-        (format "<div%s>%s\n\n%s\n\n</div>"
-                attr-str (org-blackfriday--extra-div-hack info) contents))))))
+        (format "%s<div%s>%s\n\n%s\n\n</div>%s"
+                trim-pre-tag attr-str
+                (org-blackfriday--extra-div-hack info)
+                contents trim-post-tag))))))
 
 ;;;; Src Block
 (defun org-blackfriday-src-block (src-block _contents info)

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -1177,10 +1177,18 @@ This function is adapted from `org-html-special-block'."
                 (org-blackfriday--extra-div-hack info block-type)
                 contents block-type trim-post-tag))
        (t
-        (format "%s<div%s>%s\n\n%s\n\n</div>%s"
-                trim-pre-tag attr-str
-                (org-blackfriday--extra-div-hack info)
-                contents trim-post-tag))))))
+        (if (or (org-string-nw-p trim-pre-tag)
+                (org-string-nw-p trim-post-tag))
+            (progn ;Use <span> tag if any of the trimming options is enabled.
+              (format "%s<span%s>%s</span>%s"
+                      trim-pre-tag attr-str
+                      contents trim-post-tag)
+              )
+          (progn                        ;Use <div> tag otherwise.
+            (format "%s<div%s>%s\n\n%s\n\n</div>%s"
+                    trim-pre-tag attr-str
+                    (org-blackfriday--extra-div-hack info)
+                    contents trim-post-tag))))))))
 
 ;;;; Src Block
 (defun org-blackfriday-src-block (src-block _contents info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -150,6 +150,14 @@ Examples:
   2017-07-31T17:05:38+04:00
   2017-07-31T17:05:38-04:00.")
 
+(defvar org-hugo--trim-pre-marker "<!-- trim-pre -->"
+  "Special string inserted internally to know where the whitespace
+preceding an exported Org element needs to be trimmed.")
+
+(defvar org-hugo--trim-post-marker "<!-- trim-post -->"
+  "Special string inserted internally to know where the whitespace
+following an exported Org element needs to be trimmed.")
+
 (defconst org-hugo--preprocess-buffer t
   "Enable pre-processing of the current Org buffer.
 
@@ -1821,7 +1829,13 @@ holding export options."
                        (wholenump toc-level)
                        (> toc-level 0)) ;TOC will be exported only if toc-level is positive
                   (concat (org-hugo--build-toc info toc-level) "\n")
-                "")))
+                ""))
+         (contents (replace-regexp-in-string ;Trim stuff before selected exported elements
+                    (concat "\\([[:space:]]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
+                    " " contents))
+         (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
+                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]]\\|\n\\)+")
+                    " " contents)))
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat
                toc
@@ -2801,8 +2815,20 @@ more information.
 For all other special blocks, processing is passed on to
 `org-blackfriday-special-block'.
 
+If a `block-type' has a \"<>\" suffix, whitespace exported before
+and after that block is trimmed.  If a `block-type' has a \"<\"
+suffix, only the whitespace *before* that block is trimmed.  And
+finally, if a `block-type' has a \">\" suffix, only the
+whitespace *after* that block is trimmed.
+
 INFO is a plist holding export options."
   (let* ((block-type (org-element-property :type special-block))
+         (trim-pre (or (string-suffix-p "<>" block-type)
+                       (string-suffix-p "<" block-type)))
+         (trim-pre-tag (or (and trim-pre org-hugo--trim-pre-marker) ""))
+         (trim-post (string-suffix-p ">" block-type))
+         (trim-post-tag (or (and trim-post org-hugo--trim-post-marker) ""))
+         (block-type (replace-regexp-in-string "\\`\\(.+?\\)[<>]*\\'" "\\1" block-type))
          (paired-shortcodes (let* ((str (plist-get info :hugo-paired-shortcodes))
                                    (str-list (when (org-string-nw-p str)
                                                (split-string str " "))))
@@ -2816,6 +2842,12 @@ INFO is a plist holding export options."
                           ;; https://lists.gnu.org/r/emacs-orgmode/2022-01/msg00132.html
                           (org-element-interpret-data (org-element-contents special-block))
                         contents)))))
+    ;; (message "[ox-hugo-spl-blk DBG] block-type: %s" block-type)
+    ;; (message "[ox-hugo-spl-blk DBG] trim-pre: %s" trim-pre)
+    ;; (message "[ox-hugo-spl-blk DBG] trim-post: %s" trim-post)
+    (org-element-put-property special-block :type block-type)
+    (plist-put info :trim-pre-tag trim-pre-tag)
+    (plist-put info :trim-post-tag trim-post-tag)
     (when contents
       (cond
        ((string= block-type "tikzjax")
@@ -2867,10 +2899,10 @@ INFO is a plist holding export options."
                (sc-close-char (if (string-prefix-p "%" matched-sc-str)
                                   "%"
                                 ">"))
-               (sc-begin (format "{{%s %s%s%s}}"
-                                 sc-open-char block-type sc-args sc-close-char))
-               (sc-end (format "{{%s /%s %s}}"
-                               sc-open-char block-type sc-close-char)))
+               (sc-begin (format "%s{{%s %s%s%s}}"
+                                 trim-pre-tag sc-open-char block-type sc-args sc-close-char))
+               (sc-end (format "{{%s /%s %s}}%s"
+                               sc-open-char block-type sc-close-char trim-post-tag)))
           ;; (message "[ox-hugo-spl-blk DBG] attr-sc1: %s"
           ;;          (org-element-property :attr_shortcode special-block))
           ;; (message "[ox-hugo-spl-blk DBG] attr-sc: %s" attr-sc)

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4802,6 +4802,63 @@ line 1
 abc def
 #+end_mark>
 line 2
+*** Use ~<span>~ tag if trimming detected
+Below Org block:
+
+#+begin_src org
+line 1
+,#+begin_sidenote
+abc def
+,#+end_sidenote
+line 2
+#+end_src
+
+export with ~<div>~ tags by default:
+
+#+begin_src html -n
+line 1
+
+<div class="sidenote">
+
+abc def
+
+</div>
+
+line 2
+#+end_src
+
+and render as:
+
+line 1
+#+begin_sidenote
+abc def
+#+end_sidenote
+line 2
+
+But if a trimming marker (any of them) is detected, it switches to
+using the ~<span>~ tag. So the below Org block:
+
+#+begin_src org
+line 1
+,#+begin_sidenote<>
+abc def
+,#+end_sidenote<>
+line 2
+#+end_src
+
+will export to:
+
+#+begin_src html -n
+line 1 <span class="sidenote">abc def</span> line 2
+#+end_src
+
+and render as:
+
+line 1
+#+begin_sidenote<>
+abc def
+#+end_sidenote<>
+line 2
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:
 *** Common CSS

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4729,26 +4729,74 @@ Here's a link to the [[circle][Circle]].
 ** Whitespace trimming around special blocks            :whitespace:trimming:
 :PROPERTIES:
 :EXPORT_FILE_NAME: ws-trimming-around-special-blocks
+:EXPORT_DESCRIPTION: Whitespace trimming using special markers <>, < or > after special block names.
 :END:
 *** No trimming
+Below Org block:
+#+begin_src org
+line 1
+,#+begin_mark
+abc def
+,#+end_mark
+line 2
+#+end_src
+
+exports and renders as:
+
 line 1
 #+begin_mark
 abc def
 #+end_mark
 line 2
 *** Whitespace trimmed before and after the ~mark~ special block using ~<>~ suffix
+Below Org block:
+
+#+begin_src org
+line 1
+,#+begin_mark<>
+abc def
+,#+end_mark<>
+line 2
+#+end_src
+
+exports and renders as:
+
 line 1
 #+begin_mark<>
 abc def
 #+end_mark<>
 line 2
 *** Whitespace trimmed only before the ~mark~ special block using ~<~ suffix
+Below Org block:
+
+#+begin_src org
+line 1
+,#+begin_mark<
+abc def
+,#+end_mark<
+line 2
+#+end_src
+
+exports and renders as:
+
 line 1
 #+begin_mark<
 abc def
 #+end_mark<
 line 2
 *** Whitespace trimmed only after the ~mark~ special block using ~>~ suffix
+Below Org block:
+
+#+begin_src org
+line 1
+,#+begin_mark>
+abc def
+,#+end_mark>
+line 2
+#+end_src
+
+exports and renders as:
+
 line 1
 #+begin_mark>
 abc def

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4726,6 +4726,34 @@ TikZJax example
 #+end_tikzjax
 
 Here's a link to the [[circle][Circle]].
+** Whitespace trimming around special blocks            :whitespace:trimming:
+:PROPERTIES:
+:EXPORT_FILE_NAME: ws-trimming-around-special-blocks
+:END:
+*** No trimming
+line 1
+#+begin_mark
+abc def
+#+end_mark
+line 2
+*** Whitespace trimmed before and after the ~mark~ special block using ~<>~ suffix
+line 1
+#+begin_mark<>
+abc def
+#+end_mark<>
+line 2
+*** Whitespace trimmed only before the ~mark~ special block using ~<~ suffix
+line 1
+#+begin_mark<
+abc def
+#+end_mark<
+line 2
+*** Whitespace trimmed only after the ~mark~ special block using ~>~ suffix
+line 1
+#+begin_mark>
+abc def
+#+end_mark>
+line 2
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:
 *** Common CSS

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -79,3 +79,63 @@ exports and renders as:
 line 1
 
 <mark>abc def</mark> line 2
+
+
+## Use `<span>` tag if trimming detected {#use-span-tag-if-trimming-detected}
+
+Below Org block:
+
+```org
+line 1
+#+begin_sidenote
+abc def
+#+end_sidenote
+line 2
+```
+
+export with `<div>` tags by default:
+
+```html { linenos=table, linenostart=1 }
+line 1
+
+<div class="sidenote">
+
+abc def
+
+</div>
+
+line 2
+```
+
+and render as:
+
+line 1
+
+<div class="sidenote">
+
+abc def
+
+</div>
+
+line 2
+
+But if a trimming marker (any of them) is detected, it switches to
+using the `<span>` tag. So the below Org block:
+
+```org
+line 1
+#+begin_sidenote<>
+abc def
+#+end_sidenote<>
+line 2
+```
+
+will export to:
+
+```html { linenos=table, linenostart=1 }
+line 1 <span class="sidenote">abc def</span> line 2
+```
+
+and render as:
+
+line 1 <span class="sidenote">abc def</span> line 2

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -1,0 +1,32 @@
++++
+title = "Whitespace trimming around special blocks"
+tags = ["special-block", "whitespace", "trimming"]
+draft = false
++++
+
+## No trimming {#no-trimming}
+
+line 1
+
+<mark>abc def</mark>
+
+line 2
+
+
+## Whitespace trimmed before and after the `mark` special block using `<>` suffix {#whitespace-trimmed-before-and-after-the-mark-special-block-using-suffix}
+
+line 1 <mark>abc def</mark> line 2
+
+
+## Whitespace trimmed only before the `mark` special block using `<` suffix {#whitespace-trimmed-only-before-the-mark-special-block-using-suffix}
+
+line 1 <mark>abc def</mark>
+
+line 2
+
+
+## Whitespace trimmed only after the `mark` special block using `>` suffix {#whitespace-trimmed-only-after-the-mark-special-block-using-suffix}
+
+line 1
+
+<mark>abc def</mark> line 2

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -1,10 +1,23 @@
 +++
 title = "Whitespace trimming around special blocks"
+description = "Whitespace trimming using special markers <>, < or > after special block names."
 tags = ["special-block", "whitespace", "trimming"]
 draft = false
 +++
 
 ## No trimming {#no-trimming}
+
+Below Org block:
+
+```org
+line 1
+#+begin_mark
+abc def
+#+end_mark
+line 2
+```
+
+exports and renders as:
 
 line 1
 
@@ -15,10 +28,34 @@ line 2
 
 ## Whitespace trimmed before and after the `mark` special block using `<>` suffix {#whitespace-trimmed-before-and-after-the-mark-special-block-using-suffix}
 
+Below Org block:
+
+```org
+line 1
+#+begin_mark<>
+abc def
+#+end_mark<>
+line 2
+```
+
+exports and renders as:
+
 line 1 <mark>abc def</mark> line 2
 
 
 ## Whitespace trimmed only before the `mark` special block using `<` suffix {#whitespace-trimmed-only-before-the-mark-special-block-using-suffix}
+
+Below Org block:
+
+```org
+line 1
+#+begin_mark<
+abc def
+#+end_mark<
+line 2
+```
+
+exports and renders as:
 
 line 1 <mark>abc def</mark>
 
@@ -26,6 +63,18 @@ line 2
 
 
 ## Whitespace trimmed only after the `mark` special block using `>` suffix {#whitespace-trimmed-only-after-the-mark-special-block-using-suffix}
+
+Below Org block:
+
+```org
+line 1
+#+begin_mark>
+abc def
+#+end_mark>
+line 2
+```
+
+exports and renders as:
 
 line 1
 


### PR DESCRIPTION
Trim whitespace before:

    #+begin_foo<
    #+end_foo<

Trim whitespace after:

    #+begin_foo>
    #+end_foo>

Trim whitespace both before and after:

    #+begin_foo<>
    #+end_foo<>