### PR TITLE
[feature] Whitespace trimming around Org Special Blocks

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3353,9 +3353,9 @@ default processing done by the exporter -- Org entities like ~\sum~ will
 be replaced by its HTML entity ~&sum;~, ~foo_{bar}~ will be replaced
 with ~foo<sub>bar</sub>~, and so on.
 
-But many times, the user might want to keep the contents of the
-special block as-as, in its raw form. If the user wants to do this for
-a special block of the /type/ FOO:
+But the user might want to keep the contents of the special block
+as-as, in its raw form, for some special block types. If the user
+wants to do this for a special block of the /type/ FOO:
 
 #+begin_src org
 ,#+begin_FOO
@@ -3363,11 +3363,11 @@ Some content
 ,#+end_FOO
 #+end_src
 
-, they need to add ~"FOO"~ to the customization variable
-~org-hugo-special-block-raw-content-types~.
+, they need to add ~("FOO" . (:raw t))~ to the customization variable
+~org-hugo-special-block-type-properties~.
 
-By default , ~"katex"~ is added to this list. So when using a special
-block like,
+By default , ~("katex" . (:raw t))~ is added to this list. So when
+using a special block like,
 
 #+begin_src org
 ,#+begin_katex
@@ -3377,17 +3377,6 @@ E = -J \sum\_{i=1}^N s\_i s\_{i+1}
 
 , the equation in the content of that special block: ~E = -J
 \sum\_{i=1}^N s\_i s\_{i+1}~ will be exported to Markdown as-is.
-
------
-
-If the ~"FOO"~ block type is one of types in
-~org-blackfriday-html5-inline-elements~ (see [[* HTML5 inline elements][HTML5 inline elements]]) or
-~org-html-html5-elements~ (see [[* HTML5 block elements][HTML5 block elements]]) and you need to
-export the raw contents for that, it needs to be added to
-~org-blackfriday-special-block-raw-content-types~.
-
-By default, ~"video"~ and ~"audio"~ are added to
-~org-blackfriday-special-block-raw-content-types~.
 **** TikZJax
 ~ox-hugo~ supports exporting raw /tikz/ snippet to Markdown which can be
 rendered to images using the [[https://tikzjax.com/][TikZJax]] project.

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3150,6 +3150,7 @@ will export as:
 
 and render as:
 
+#+header: :trim-pre nil
 #+begin_mark
 This sentence is marked.
 #+end_mark

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3404,13 +3404,18 @@ Then simply put /tikz/ snippets in the Org source like so:
 
 {{{test-search(tikzjax)}}}
 **** Whitespace Trimming
-Whitespace trimming around exported Org Special Blocks is supported
-with the help of ~#+header:~ keywords above those blocks.
+The default whitespace trimming around exported Org Special Blocks can
+be configured by setting the ~:trim-pre~ and ~:trim-post~ properties
+for specific special block types in the
+~org-hugo-special-block-type-properties~ defcustom.
 
-- If the header has ~:trim-pre t~, whitespace is removed before the
+- If ~:trim-pre~ is set to ~t~, whitespace is removed before the
   block.
-- If the header has ~:trim-post t~, whitespace is removed after the
+- If ~:trim-post~ is set to ~t~, whitespace is removed after the
   block.
+
+The default values of these properties can be overridden by using the
+~#+header:~ keywords above the special blocks.
 
 #+begin_note
 If a special block tag is not recognized as an HTML block or inline

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3415,21 +3415,19 @@ Then simply put /tikz/ snippets in the Org source like so:
 
 {{{test-search(tikzjax)}}}
 **** Whitespace Trimming
-Whitespace trimming around exported Org Special Blocks is supported.
+Whitespace trimming around exported Org Special Blocks is supported
+with the help of ~#+header:~ keywords above those blocks.
 
-Whether the whitespace before the exported block, after the block, or
-at both spaces is trimmed is decided by using some special markers
-after the special block name.
-
-- ~<~ suffix :: Trim whitespace only before the block.
-- ~>~ suffix :: Trim whitespace only after the block.
-- ~<>~ suffix :: Trim whitespace both before and after the block.
+- If the header has ~:trim-pre t~, whitespace is removed before the
+  block.
+- If the header has ~:trim-post t~, whitespace is removed after the
+  block.
 
 #+begin_note
-By default if a special block tag is not recognized as an HTML block
-or inline element, or as a Hugo shortcode, it defaults to exporting
-[[#special-blocks--div-tags][with ~<div>~ tags]]. But if any of the whitespace trimming markers is
-used in a special block, it will export with ~<span>~ tags.
+If a special block tag is not recognized as an HTML block or inline
+element, or as a Hugo shortcode, it defaults to exporting [[#special-blocks--div-tags][with ~<div>~
+tags]]. But if either pre or post trimming options are detected for a
+special block, it will export with ~<span>~ tags.
 #+end_note
 
 #+include: "../test/site/content-org/all-posts.org::* Whitespace trimming around special blocks" :only-contents t

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3302,6 +3302,9 @@ description = """
 See
 {{{relref(~HUGO_PAIRED_SHORTCODES~,shortcodes/#hugo-paired-shortcodes)}}}.
 **** Other Special Blocks (~div~ tags)
+:PROPERTIES:
+:CUSTOM_ID: special-blocks--div-tags
+:END:
 If the Special Block /tag/ used isn't found in
 ~org-blackfriday-html5-inline-elements~ or ~org-html-html5-elements~,
 that block exports just as an HTML ~div~ block.
@@ -3341,6 +3344,9 @@ which will render as:
 #+begin_red
 This text will be in red.
 #+end_red
+
+/See the [[* Whitespace Trimming][Whitespace Trimming]] section if you need to export with
+~<span>~ tags instead of ~<div>~ tags./
 **** Raw Org contents
 By default, the content inside the Org special blocks will have some
 default processing done by the exporter -- Org entities like ~\sum~ will
@@ -3408,6 +3414,25 @@ Then simply put /tikz/ snippets in the Org source like so:
 #+end_src
 
 {{{test-search(tikzjax)}}}
+**** Whitespace Trimming
+Whitespace trimming around exported Org Special Blocks is supported.
+
+Whether the whitespace before the exported block, after the block, or
+at both spaces is trimmed is decided by using some special markers
+after the special block name.
+
+- ~<~ suffix :: Trim whitespace only before the block.
+- ~>~ suffix :: Trim whitespace only after the block.
+- ~<>~ suffix :: Trim whitespace both before and after the block.
+
+#+begin_note
+By default if a special block tag is not recognized as an HTML block
+or inline element, or as a Hugo shortcode, it defaults to exporting
+[[#special-blocks--div-tags][with ~<div>~ tags]]. But if any of the whitespace trimming markers is
+used in a special block, it will export with ~<span>~ tags.
+#+end_note
+
+#+include: "../test/site/content-org/all-posts.org::* Whitespace trimming around special blocks" :only-contents t
 *** Shortcodes
 :PROPERTIES:
 :EXPORT_FILE_NAME: shortcodes

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3408,15 +3408,40 @@ Then simply put /tikz/ snippets in the Org source like so:
 The default whitespace trimming around exported Org Special Blocks can
 be configured by setting the ~:trim-pre~ and ~:trim-post~ properties
 for specific special block types in the
-~org-hugo-special-block-type-properties~ defcustom.
+~org-hugo-special-block-type-properties~ customization variable.
 
-- If ~:trim-pre~ is set to ~t~, whitespace is removed before the
-  block.
-- If ~:trim-post~ is set to ~t~, whitespace is removed after the
-  block.
+- If ~:trim-pre~ is set to ~t~, whitespace before the block is
+  removed.
+- If ~:trim-post~ is set to ~t~, whitespace after the block is
+  removed.
 
-The default values of these properties can be overridden by using the
-~#+header:~ keywords above the special blocks.
+#+begin_note
+For the types not specified in
+~org-hugo-special-block-type-properties~, the default behavior is like
+that of ~'(:trim-pre nil :trim-post nil)~.
+#+end_note
+
+Here's an example of specifying trimming options for a new special
+block type "sidenote":
+
+#+begin_src elisp
+(with-eval-after-load 'ox-hugo
+  (add-to-list 'org-hugo-special-block-type-properties '("sidenote" . (:trim-pre t :trim-post t))))
+#+end_src
+
+Here's an example of overriding properties for one of the types, say "mark":
+
+#+begin_src elisp
+(with-eval-after-load 'ox-hugo
+  (setcdr (assoc "mark" org-hugo-special-block-type-properties) '(:trim-pre t :trim-post nil)))
+#+end_src
+
+Or, you can ~M-x customize-group~, select ~org-select-hugo~ and tweak
+this variable in that UI.
+
+The default values set this way can be overridden in the Org file by
+using the ~#+header:~ keyword above the special blocks. Below examples
+demonstrate the usage of this ~#+header~ keyword.
 
 #+begin_note
 If a special block tag is not recognized as an HTML block or inline

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -128,16 +128,6 @@ tag needs to be `python'."
            (string "Src Block language")
            (string "Syntax highlighting language"))))
 
-(defcustom org-blackfriday-special-block-raw-content-types '("video" "audio")
-  "List of special block types for which the exported contents
-should be same as the raw content in Org source.
-
-Each element is a string representing a type of Org special
-block."
-  :group 'org-export-blackfriday
-  :type '(repeat string))
-;;;###autoload (put 'org-blackfriday-special-block-raw-content-types 'safe-local-variable (lambda (x) (stringp x)))
-
 
 
 ;;; Define Back-End
@@ -1081,6 +1071,7 @@ INFO is a plist used as a communication channel.
 
 This function is adapted from `org-html-special-block'."
   (let* ((block-type (org-element-property :type special-block))
+         (block-type-plist (org-element-property :type-plist special-block))
          (html5-inline-fancy (member block-type org-blackfriday-html5-inline-elements))
          (html5-block-fancy (member block-type org-html-html5-elements))
          (html5-fancy (or html5-inline-fancy html5-block-fancy))
@@ -1094,7 +1085,7 @@ This function is adapted from `org-html-special-block'."
                                         (concat class " " block-type)
                                       block-type)))))
     (let* ((contents (or (org-trim
-                          (if (member block-type org-blackfriday-special-block-raw-content-types)
+                          (if (plist-get block-type-plist :raw)
                               ;; https://lists.gnu.org/r/emacs-orgmode/2022-01/msg00132.html
                               (org-element-interpret-data (org-element-contents special-block))
                             contents))

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -1084,7 +1084,9 @@ This function is adapted from `org-html-special-block'."
          (html5-inline-fancy (member block-type org-blackfriday-html5-inline-elements))
          (html5-block-fancy (member block-type org-html-html5-elements))
          (html5-fancy (or html5-inline-fancy html5-block-fancy))
-         (attributes (org-export-read-attribute :attr_html special-block)))
+         (attributes (org-export-read-attribute :attr_html special-block))
+         (trim-pre-tag (or (plist-get info :trim-pre-tag) ""))
+         (trim-post-tag (or (plist-get info :trim-post-tag) "")))
     (unless html5-fancy
       (let ((class (plist-get attributes :class)))
         (setq attributes (plist-put attributes :class
@@ -1166,16 +1168,27 @@ This function is adapted from `org-html-special-block'."
                    (org-blackfriday--org-contents-to-html special-block))))
                 block-type))
        (html5-inline-fancy ;Inline HTML elements like `mark', `cite'.
-        (format "<%s%s>%s</%s>"
-                block-type attr-str contents block-type))
+        (format "%s<%s%s>%s</%s>%s"
+                trim-pre-tag block-type attr-str
+                contents block-type trim-post-tag))
        (html5-block-fancy
-        (format "<%s%s>%s\n\n%s\n\n</%s>"
-                block-type attr-str
+        (format "%s<%s%s>%s\n\n%s\n\n</%s>%s"
+                trim-pre-tag block-type attr-str
                 (org-blackfriday--extra-div-hack info block-type)
-                contents block-type))
+                contents block-type trim-post-tag))
        (t
-        (format "<div%s>%s\n\n%s\n\n</div>"
-                attr-str (org-blackfriday--extra-div-hack info) contents))))))
+        (if (or (org-string-nw-p trim-pre-tag)
+                (org-string-nw-p trim-post-tag))
+            (progn ;Use <span> tag if any of the trimming options is enabled.
+              (format "%s<span%s>%s</span>%s"
+                      trim-pre-tag attr-str
+                      contents trim-post-tag)
+              )
+          (progn                        ;Use <div> tag otherwise.
+            (format "%s<div%s>%s\n\n%s\n\n</div>%s"
+                    trim-pre-tag attr-str
+                    (org-blackfriday--extra-div-hack info)
+                    contents trim-post-tag))))))))
 
 ;;;; Src Block
 (defun org-blackfriday-src-block (src-block _contents info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2850,11 +2850,11 @@ more information.
 For all other special blocks, processing is passed on to
 `org-blackfriday-special-block'.
 
-If a `block-type' has a \"<>\" suffix, whitespace exported before
-and after that block is trimmed.  If a `block-type' has a \"<\"
-suffix, only the whitespace *before* that block is trimmed.  And
-finally, if a `block-type' has a \">\" suffix, only the
-whitespace *after* that block is trimmed.
+If a block type has the `:trim-pre' property set to `t' in
+`org-hugo-special-block-type-properties' or in the `#+header'
+keyword above the special block, whitespace exported before that
+block is trimmed.  Similarly, if `:trim-post' property is set to
+`t', whitespace after that block is trimmed.
 
 INFO is a plist holding export options."
   (let* ((block-type (org-element-property :type special-block))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1834,8 +1834,8 @@ holding export options."
                     (concat "\\([[:space:]>]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
                     " " contents))
          (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
-                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+")
-                    " " contents)))
+                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+\\([^-]\\)")
+                    " \\2" contents)))
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat
                toc

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1853,11 +1853,12 @@ holding export options."
                   (concat (org-hugo--build-toc info toc-level) "\n")
                 ""))
          (contents (replace-regexp-in-string ;Trim stuff before selected exported elements
-                    (concat "\\([^`]\\)\\([[:space:]>]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
-                    "\\1 " contents))
+                    (concat "\\([[:space:]>]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
+                    "\n" contents))
          (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
-                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+\\([^-#`]\\)")
-                    " \\2" contents)))
+                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+")
+                    "\n" contents))
+         )
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat
                toc

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1834,7 +1834,7 @@ holding export options."
                     (concat "\\([[:space:]>]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
                     " " contents))
          (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
-                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+\\([^-]\\)")
+                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+\\([^-#]\\)")
                     " \\2" contents)))
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2850,9 +2850,11 @@ INFO is a plist holding export options."
                   (car (org-element-property :header special-block))))
          (trim-pre (or (alist-get :trim-pre header) ;`:trim-pre' in #+header has higher precedence.
                        (plist-get block-type-plist :trim-pre)))
+         (trim-pre (org-hugo--value-get-true-p trim-pre)) ;If "nil", converts to nil
          (trim-pre-tag (if trim-pre org-hugo--trim-pre-marker ""))
          (trim-post (or (alist-get :trim-post header) ;`:trim-post' in #+header has higher precedence.
                         (plist-get block-type-plist :trim-pre)))
+         (trim-post (org-hugo--value-get-true-p trim-post)) ;If "nil", converts to nil
          (trim-post-tag (if trim-post org-hugo--trim-post-marker ""))
          (paired-shortcodes (let* ((str (plist-get info :hugo-paired-shortcodes))
                                    (str-list (when (org-string-nw-p str)
@@ -2868,9 +2870,10 @@ INFO is a plist holding export options."
                           (org-element-interpret-data (org-element-contents special-block))
                         contents)))))
     ;; (message "[ox-hugo-spl-blk DBG] block-type: %s" block-type)
-    ;; (message "[ox-hugo-spl-blk DBG] header: %s" header)
-    ;; (message "[ox-hugo-spl-blk DBG] trim-pre: %s" trim-pre)
-    ;; (message "[ox-hugo-spl-blk DBG] trim-post: %s" trim-post)
+    ;; (message "[ox-hugo-spl-blk DBG] last element?: %s" (null (org-export-get-next-element special-block info)))
+    ;; (message "[ox-hugo-spl-blk DBG] %s: header: %s" block-type header)
+    ;; (message "[ox-hugo-spl-blk DBG] %s: trim-pre (type = %S): %S" block-type (type-of trim-pre) trim-pre)
+    ;; (message "[ox-hugo-spl-blk DBG] %s: trim-post (type = %S): %S" block-type (type-of trim-post) trim-post)
     (plist-put info :type-plist block-type-plist)
     (plist-put info :trim-pre-tag trim-pre-tag)
     (plist-put info :trim-post-tag trim-post-tag)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1855,8 +1855,8 @@ holding export options."
          ;; Handling the case of special blocks inside markdown quote
          ;; blocks.
          (contents (replace-regexp-in-string
-                    (concat "\\(\n> \\)*" (regexp-quote org-hugo--trim-pre-marker))
-                    ;;          ^^^^ Markdown quote blocks have lines beginning with "> ".
+                    (concat "\\(\n\\s-*> \\)*" (regexp-quote org-hugo--trim-pre-marker))
+                    ;;          ^^^^^^^^ Markdown quote blocks have lines beginning with "> ".
                     org-hugo--trim-pre-marker ;Keep the trim marker; it will be removed next.
                     contents))
          (contents (replace-regexp-in-string

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1831,10 +1831,10 @@ holding export options."
                   (concat (org-hugo--build-toc info toc-level) "\n")
                 ""))
          (contents (replace-regexp-in-string ;Trim stuff before selected exported elements
-                    (concat "\\([[:space:]>]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
-                    " " contents))
+                    (concat "\\([^`]\\)\\([[:space:]>]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
+                    "\\1 " contents))
          (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
-                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+\\([^-#]\\)")
+                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+\\([^-#`]\\)")
                     " \\2" contents)))
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -545,7 +545,7 @@ For the special block types not specified in this variable, the
 default behavior is same as if (:raw nil :trim-pre nil :trim-post
 nil) plist were associated with them."
   :group 'org-export-hugo
-  :type '(list (cons string (plist :key-type symbol :value-type boolean))))
+  :type '(alist :key-type string :value-type (plist :key-type symbol :value-type boolean)))
 
 
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1856,7 +1856,7 @@ holding export options."
          ;; blocks.
          (contents (replace-regexp-in-string
                     (concat "\\(\n> \\)*" (regexp-quote org-hugo--trim-pre-marker))
-                    ;;          ^^ Markdown quote blocks have lines beginning with "> ".
+                    ;;          ^^^^ Markdown quote blocks have lines beginning with "> ".
                     org-hugo--trim-pre-marker ;Keep the trim marker; it will be removed next.
                     contents))
          (contents (replace-regexp-in-string
@@ -1953,28 +1953,28 @@ Returns a plist with these elements:
 
 Throw an error if no block contains REF."
   (or (org-element-map (plist-get info :parse-tree) '(example-block src-block)
-	    (lambda (el)
-	      (with-temp-buffer
-	        (insert (org-trim (org-element-property :value el)))
-	        (let* ((ref-info ())
+        (lambda (el)
+          (with-temp-buffer
+            (insert (org-trim (org-element-property :value el)))
+            (let* ((ref-info ())
                    (label-fmt (or (org-element-property :label-fmt el)
-				                  org-coderef-label-format))
-		           (ref-re (org-src-coderef-regexp label-fmt ref)))
-	          ;; Element containing REF is found.  Resolve it to
-	          ;; either a label or a line number, as needed.
-	          (when (re-search-backward ref-re nil :noerror)
+                                  org-coderef-label-format))
+                   (ref-re (org-src-coderef-regexp label-fmt ref)))
+              ;; Element containing REF is found.  Resolve it to
+              ;; either a label or a line number, as needed.
+              (when (re-search-backward ref-re nil :noerror)
                 (let* ((line-num (+ (or (org-export-get-loc el info) 0)
-		                            (line-number-at-pos)))
+                                    (line-number-at-pos)))
                        (ref-str (format "%s" (if (org-element-property :use-labels el)
                                                  ref
                                                line-num))))
-		          (setq ref-info (plist-put ref-info :line-num line-num))
+                  (setq ref-info (plist-put ref-info :line-num line-num))
                   (setq ref-info (plist-put ref-info :ref ref-str))
                   (let ((anchor-prefix (or (org-element-property :anchor-prefix el) ;set in `org-hugo-src-block'
                                            (cdr (org-hugo--get-coderef-anchor-prefix el)))))
                     (setq ref-info (plist-put ref-info :anchor-prefix anchor-prefix))))
                 ref-info))))
-	    info 'first-match)
+        info 'first-match)
       (signal 'org-link-broken (list ref))))
 
 (defun org-hugo-link (link desc info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2852,8 +2852,10 @@ INFO is a plist holding export options."
                        (plist-get block-type-plist :trim-pre)))
          (trim-pre (org-hugo--value-get-true-p trim-pre)) ;If "nil", converts to nil
          (trim-pre-tag (if trim-pre org-hugo--trim-pre-marker ""))
-         (trim-post (or (alist-get :trim-post header) ;`:trim-post' in #+header has higher precedence.
-                        (plist-get block-type-plist :trim-pre)))
+         (last-element-p (null (org-export-get-next-element special-block info)))
+         (trim-post (unless last-element-p ;No need to add trim-post markers if this is the last element.
+                      (or (alist-get :trim-post header) ;`:trim-post' in #+header has higher precedence.
+                          (plist-get block-type-plist :trim-pre))))
          (trim-post (org-hugo--value-get-true-p trim-post)) ;If "nil", converts to nil
          (trim-post-tag (if trim-post org-hugo--trim-post-marker ""))
          (paired-shortcodes (let* ((str (plist-get info :hugo-paired-shortcodes))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1864,9 +1864,13 @@ holding export options."
                     "\n"
                     contents))
          (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
-                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+")
-                    "\n" contents))
-         )
+                    (concat (regexp-quote org-hugo--trim-post-marker)
+                            ;; Pull up the contents from the next
+                            ;; line, unless the next line is a list
+                            ;; item (-), a heading (#) or a code block
+                            ;; (`).
+                            "\\([[:space:]>]\\|\n\\)+\\([^-#`]\\)")
+                    " \\2" contents)))
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat
                toc

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -150,6 +150,14 @@ Examples:
   2017-07-31T17:05:38+04:00
   2017-07-31T17:05:38-04:00.")
 
+(defvar org-hugo--trim-pre-marker "<!-- trim-pre -->"
+  "Special string inserted internally to know where the whitespace
+preceding an exported Org element needs to be trimmed.")
+
+(defvar org-hugo--trim-post-marker "<!-- trim-post -->"
+  "Special string inserted internally to know where the whitespace
+following an exported Org element needs to be trimmed.")
+
 (defconst org-hugo--preprocess-buffer t
   "Enable pre-processing of the current Org buffer.
 
@@ -1821,7 +1829,13 @@ holding export options."
                        (wholenump toc-level)
                        (> toc-level 0)) ;TOC will be exported only if toc-level is positive
                   (concat (org-hugo--build-toc info toc-level) "\n")
-                "")))
+                ""))
+         (contents (replace-regexp-in-string ;Trim stuff before selected exported elements
+                    (concat "\\([[:space:]]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
+                    " " contents))
+         (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
+                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]]\\|\n\\)+")
+                    " " contents)))
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat
                toc
@@ -2801,8 +2815,20 @@ more information.
 For all other special blocks, processing is passed on to
 `org-blackfriday-special-block'.
 
+If a `block-type' has a \"<>\" suffix, whitespace exported before
+and after that block is trimmed.  If a `block-type' has a \"<\"
+suffix, only the whitespace *before* that block is trimmed.  And
+finally, if a `block-type' has a \">\" suffix, only the
+whitespace *after* that block is trimmed.
+
 INFO is a plist holding export options."
   (let* ((block-type (org-element-property :type special-block))
+         (trim-pre (or (string-suffix-p "<>" block-type)
+                       (string-suffix-p "<" block-type)))
+         (trim-pre-tag (or (and trim-pre org-hugo--trim-pre-marker) ""))
+         (trim-post (string-suffix-p ">" block-type))
+         (trim-post-tag (or (and trim-post org-hugo--trim-post-marker) ""))
+         (block-type (replace-regexp-in-string "\\`\\(.+?\\)[<>]*\\'" "\\1" block-type))
          (paired-shortcodes (let* ((str (plist-get info :hugo-paired-shortcodes))
                                    (str-list (when (org-string-nw-p str)
                                                (split-string str " "))))
@@ -2816,6 +2842,12 @@ INFO is a plist holding export options."
                           ;; https://lists.gnu.org/r/emacs-orgmode/2022-01/msg00132.html
                           (org-element-interpret-data (org-element-contents special-block))
                         contents)))))
+    ;; (message "[ox-hugo-spl-blk DBG] block-type: %s" block-type)
+    ;; (message "[ox-hugo-spl-blk DBG] trim-pre: %s" trim-pre)
+    ;; (message "[ox-hugo-spl-blk DBG] trim-post: %s" trim-post)
+    (org-element-put-property special-block :type block-type)
+    (plist-put info :trim-pre-tag trim-pre-tag)
+    (plist-put info :trim-post-tag trim-post-tag)
     (when contents
       (cond
        ((string= block-type "tikzjax")
@@ -2867,10 +2899,10 @@ INFO is a plist holding export options."
                (sc-close-char (if (string-prefix-p "%" matched-sc-str)
                                   "%"
                                 ">"))
-               (sc-begin (format "{{%s %s%s%s}}"
-                                 sc-open-char block-type sc-args sc-close-char))
-               (sc-end (format "{{%s /%s %s}}"
-                               sc-open-char block-type sc-close-char)))
+               (sc-begin (format "%s{{%s %s%s%s}}"
+                                 trim-pre-tag sc-open-char block-type sc-args sc-close-char))
+               (sc-end (format "{{%s /%s %s}}%s"
+                               sc-open-char block-type sc-close-char trim-post-tag)))
           ;; (message "[ox-hugo-spl-blk DBG] attr-sc1: %s"
           ;;          (org-element-property :attr_shortcode special-block))
           ;; (message "[ox-hugo-spl-blk DBG] attr-sc: %s" attr-sc)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1852,9 +1852,17 @@ holding export options."
                        (> toc-level 0)) ;TOC will be exported only if toc-level is positive
                   (concat (org-hugo--build-toc info toc-level) "\n")
                 ""))
-         (contents (replace-regexp-in-string ;Trim stuff before selected exported elements
-                    (concat "\\([[:space:]>]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
-                    "\n" contents))
+         ;; Handling the case of special blocks inside markdown quote
+         ;; blocks.
+         (contents (replace-regexp-in-string
+                    (concat "\\(\n> \\)*" (regexp-quote org-hugo--trim-pre-marker))
+                    ;;          ^^ Markdown quote blocks have lines beginning with "> ".
+                    org-hugo--trim-pre-marker ;Keep the trim marker; it will be removed next.
+                    contents))
+         (contents (replace-regexp-in-string
+                    (concat "\\([[:space:]]\\|\n\\)*" (regexp-quote org-hugo--trim-pre-marker))
+                    "\n"
+                    contents))
          (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
                     (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+")
                     "\n" contents))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2823,12 +2823,12 @@ whitespace *after* that block is trimmed.
 
 INFO is a plist holding export options."
   (let* ((block-type (org-element-property :type special-block))
-         (trim-pre (or (string-suffix-p "<>" block-type)
-                       (string-suffix-p "<" block-type)))
+         (header (org-babel-parse-header-arguments
+                  (car (org-element-property :header special-block))))
+         (trim-pre (alist-get :trim-pre header))
          (trim-pre-tag (or (and trim-pre org-hugo--trim-pre-marker) ""))
-         (trim-post (string-suffix-p ">" block-type))
+         (trim-post (alist-get :trim-post header))
          (trim-post-tag (or (and trim-post org-hugo--trim-post-marker) ""))
-         (block-type (replace-regexp-in-string "\\`\\(.+?\\)[<>]*\\'" "\\1" block-type))
          (paired-shortcodes (let* ((str (plist-get info :hugo-paired-shortcodes))
                                    (str-list (when (org-string-nw-p str)
                                                (split-string str " "))))
@@ -2843,9 +2843,9 @@ INFO is a plist holding export options."
                           (org-element-interpret-data (org-element-contents special-block))
                         contents)))))
     ;; (message "[ox-hugo-spl-blk DBG] block-type: %s" block-type)
+    ;; (message "[ox-hugo-spl-blk DBG] header: %s" header)
     ;; (message "[ox-hugo-spl-blk DBG] trim-pre: %s" trim-pre)
     ;; (message "[ox-hugo-spl-blk DBG] trim-post: %s" trim-post)
-    (org-element-put-property special-block :type block-type)
     (plist-put info :trim-pre-tag trim-pre-tag)
     (plist-put info :trim-post-tag trim-post-tag)
     (when contents

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1831,10 +1831,10 @@ holding export options."
                   (concat (org-hugo--build-toc info toc-level) "\n")
                 ""))
          (contents (replace-regexp-in-string ;Trim stuff before selected exported elements
-                    (concat "\\([[:space:]]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
+                    (concat "\\([[:space:]>]\\|\n\\)+" (regexp-quote org-hugo--trim-pre-marker))
                     " " contents))
          (contents (replace-regexp-in-string ;Trim stuff after selected exported elements
-                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]]\\|\n\\)+")
+                    (concat (regexp-quote org-hugo--trim-post-marker) "\\([[:space:]>]\\|\n\\)+")
                     " " contents)))
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4892,6 +4892,17 @@ line 2
 
 line 4 (line 3, above, is blank, but inside the quote block)
 #+end_quote
+
+- Special block in a quote block in a list
+  #+begin_quote
+  line 1
+  #+begin_mark
+  marked text
+  #+end_mark
+  line 2
+
+  line 4 (line 3, above, is blank, but inside the quote block)
+  #+end_quote
 **** Whitespace trimming before list elements
 something
 #+begin_mark

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4922,6 +4922,18 @@ something
 #+begin_mark
 marked text
 #+end_mark
+**** ~>~ character before a special block with ~:trim_pre~ set
+#+begin_export html
+<style>
+  .red {
+    color: red;
+  }
+</style>
+#+end_export
+#+attr_html: :class red
+#+begin_mark
+This marked text's foreground is red.
+#+end_mark
 **** Last element of a post
 #+begin_mark
 No "post" trim markers should be inserted after this block as it's the

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4868,10 +4868,14 @@ line 1
 abc def
 #+end_sidenote
 line 2
-*** Whitespace trimming around special blocks (corner cases)
+*** Whitespace trimming around special blocks (corner cases)   :corner_cases:
 :PROPERTIES:
 :EXPORT_FILE_NAME: ws-trimming-around-special-blocks-corner-cases
 :END:
+#+begin_description
+Corner cases for testing the whitespace trimming around the special
+blocks.
+#+end_description
 **** Whitespace trimming inside quote blocks
 #+begin_quote
 line 1
@@ -4879,6 +4883,8 @@ line 1
 marked text
 #+end_mark
 line 2
+
+line 4 (line 3, above, is blank, but inside the quote block)
 #+end_quote
 **** Whitespace trimming before list elements
 something
@@ -4911,6 +4917,11 @@ something
 marked text
 #+end_mark
 ~inline code 2~
+something
+**** Whitespace trimming with ~:trim-pre~ set immediately after a heading
+#+begin_mark
+marked text
+#+end_mark
 **** Last element of a post
 #+begin_mark
 No "post" trim markers should be inserted after this block as it's the

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4911,6 +4911,11 @@ something
 marked text
 #+end_mark
 ~inline code 2~
+**** Last element of a post
+#+begin_mark
+No "post" trim markers should be inserted after this block as it's the
+last element of this post.
+#+end_mark
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:
 *** Common CSS

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4879,6 +4879,12 @@ marked text
 #+end_mark<>
 - list item 1
 - list item 2
+**** Whitespace trimming before headings
+something
+#+begin_mark<>
+marked text
+#+end_mark<>
+***** Next heading
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:
 *** Common CSS

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4551,9 +4551,9 @@ Unmarked.
 #+begin_mark
 /Some/ *marked* text --- 2.5.
 #+end_mark
-
 Unmarked again.
 
+#+header: :trim-pre nil :trim-post nil
 #+begin_mark
 Page Bundles of =page= [[https://gohugo.io/templates/section-templates/#page-kinds][/Kind/]] are always /leaf bundles/.. and vice versa.
 #+end_mark
@@ -4875,7 +4875,6 @@ line 2
 **** Whitespace trimming inside quote blocks
 #+begin_quote
 line 1
-#+header: :trim-pre t :trim-post t
 #+begin_mark
 marked text
 #+end_mark
@@ -4883,7 +4882,6 @@ line 2
 #+end_quote
 **** Whitespace trimming before list elements
 something
-#+header: :trim-pre t :trim-post t
 #+begin_mark
 marked text
 #+end_mark
@@ -4891,28 +4889,24 @@ marked text
 - list item 2
 **** Whitespace trimming before headings
 something
-#+header: :trim-pre t :trim-post t
 #+begin_mark
 marked text
 #+end_mark
 ***** Next heading
 **** Whitespace trimming before and after code blocks
 something
-#+header: :trim-pre t :trim-post t
 #+begin_mark
 marked text
 #+end_mark
 #+begin_example
 code line
 #+end_example
-#+header: :trim-pre t :trim-post t
 #+begin_mark
 marked text
 #+end_mark
 
 something
 ~inline code 1~
-#+header: :trim-pre t :trim-post t
 #+begin_mark
 marked text
 #+end_mark
@@ -7288,6 +7282,7 @@ Do not render this page, but.. still list it.
 See the [[../][parent]] list page -- This page is not rendered, but its content
 and metadata can be found using the ~site.GetPage~ method.
 
+#+header: :trim-pre nil
 #+begin_mark
 This page is listed on that parent list page, but the link won't lead
 to this page as.. it did not get rendered. That link will point to

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4820,9 +4820,9 @@ Below Org block:
 
 #+begin_src org
 line 1
-,#+begin_sidenote
+,#+begin_foo
 abc def
-,#+end_sidenote
+,#+end_foo
 line 2
 #+end_src
 
@@ -4831,7 +4831,7 @@ exports with ~<div>~ tags by default:
 #+begin_src html -n
 line 1
 
-<div class="sidenote">
+<div class="foo">
 
 abc def
 
@@ -4843,9 +4843,9 @@ line 2
 and renders as:
 
 line 1
-#+begin_sidenote
+#+begin_foo
 abc def
-#+end_sidenote
+#+end_foo
 line 2
 
 But if any of the trimming options are set in the header, it switches
@@ -4854,25 +4854,25 @@ to using the ~<span>~ tag. So the below Org block:
 #+begin_src org
 line 1
 ,#+header: :trim-pre t :trim-post t
-,#+begin_sidenote
+,#+begin_foo
 abc def
-,#+end_sidenote
+,#+end_foo
 line 2
 #+end_src
 
 will export to:
 
 #+begin_src html -n
-line 1 <span class="sidenote">abc def</span> line 2
+line 1 <span class="foo">abc def</span> line 2
 #+end_src
 
 and render as:
 
 line 1
 #+header: :trim-pre t :trim-post t
-#+begin_sidenote
+#+begin_foo
 abc def
-#+end_sidenote
+#+end_foo
 line 2
 *** Whitespace trimming around special blocks (corner cases)   :corner_cases:
 :PROPERTIES:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4726,12 +4726,13 @@ TikZJax example
 #+end_tikzjax
 
 Here's a link to the [[circle][Circle]].
-** Whitespace trimming around special blocks            :whitespace:trimming:
+** Whitespace trimming                                  :whitespace:trimming:
+*** Whitespace trimming around special blocks
 :PROPERTIES:
 :EXPORT_FILE_NAME: ws-trimming-around-special-blocks
 :EXPORT_DESCRIPTION: Whitespace trimming using special markers <>, < or > after special block names.
 :END:
-*** No trimming
+**** No trimming
 Below Org block:
 #+begin_src org
 line 1
@@ -4748,7 +4749,7 @@ line 1
 abc def
 #+end_mark
 line 2
-*** Whitespace trimmed before and after the ~mark~ special block using ~<>~ suffix
+**** Whitespace trimmed before and after the ~mark~ special block using ~<>~ suffix
 Below Org block:
 
 #+begin_src org
@@ -4766,7 +4767,7 @@ line 1
 abc def
 #+end_mark<>
 line 2
-*** Whitespace trimmed only before the ~mark~ special block using ~<~ suffix
+**** Whitespace trimmed only before the ~mark~ special block using ~<~ suffix
 Below Org block:
 
 #+begin_src org
@@ -4784,7 +4785,7 @@ line 1
 abc def
 #+end_mark<
 line 2
-*** Whitespace trimmed only after the ~mark~ special block using ~>~ suffix
+**** Whitespace trimmed only after the ~mark~ special block using ~>~ suffix
 Below Org block:
 
 #+begin_src org
@@ -4802,7 +4803,7 @@ line 1
 abc def
 #+end_mark>
 line 2
-*** Use ~<span>~ tag if trimming detected
+**** Use ~<span>~ tag if trimming detected
 Below Org block:
 
 #+begin_src org
@@ -4859,6 +4860,18 @@ line 1
 abc def
 #+end_sidenote<>
 line 2
+*** Whitespace trimming around special blocks (corner cases)         :quotes:
+:PROPERTIES:
+:EXPORT_FILE_NAME: ws-trimming-around-special-blocks-corner-cases
+:END:
+**** Whitespace trimming inside quote blocks
+#+begin_quote
+line 1
+#+begin_mark<>
+abc def
+#+end_mark<>
+line 2
+#+end_quote
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:
 *** Common CSS

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4732,8 +4732,9 @@ Here's a link to the [[circle][Circle]].
 :EXPORT_FILE_NAME: ws-trimming-around-special-blocks
 :EXPORT_DESCRIPTION: Whitespace trimming using ~#+header: :trim-pre t :trim-post t~ before special blocks.
 :END:
-**** No trimming
+**** Whitespace trimmed before and after the ~mark~ special block (default)
 Below Org block:
+
 #+begin_src org
 line 1
 ,#+begin_mark
@@ -4745,26 +4746,6 @@ line 2
 exports and renders as:
 
 line 1
-#+begin_mark
-abc def
-#+end_mark
-line 2
-**** Whitespace trimmed before and after the ~mark~ special block
-Below Org block:
-
-#+begin_src org
-line 1
-,#+header: :trim-pre t :trim-post t
-,#+begin_mark
-abc def
-,#+end_mark
-line 2
-#+end_src
-
-exports and renders as:
-
-line 1
-#+header: :trim-pre t :trim-post t
 #+begin_mark
 abc def
 #+end_mark
@@ -4774,7 +4755,7 @@ Below Org block:
 
 #+begin_src org
 line 1
-,#+header: :trim-pre t
+,#+header: :trim-post nil
 ,#+begin_mark
 abc def
 ,#+end_mark
@@ -4784,7 +4765,7 @@ line 2
 exports and renders as:
 
 line 1
-#+header: :trim-pre t
+#+header: :trim-post nil
 #+begin_mark
 abc def
 #+end_mark
@@ -4794,7 +4775,7 @@ Below Org block:
 
 #+begin_src org
 line 1
-,#+header: :trim-post t
+,#+header: :trim-pre nil
 ,#+begin_mark
 abc def
 ,#+end_mark
@@ -4804,7 +4785,26 @@ line 2
 exports and renders as:
 
 line 1
-#+header: :trim-post t
+#+header: :trim-pre nil
+#+begin_mark
+abc def
+#+end_mark
+line 2
+**** No trimming
+Below Org block:
+#+begin_src org
+line 1
+,#+header: :trim-pre nil :trim-post nil
+,#+begin_mark
+abc def
+,#+end_mark
+line 2
+#+end_src
+
+exports and renders as:
+
+line 1
+#+header: :trim-pre nil :trim-post nil
 #+begin_mark
 abc def
 #+end_mark

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4860,7 +4860,7 @@ line 1
 abc def
 #+end_sidenote<>
 line 2
-*** Whitespace trimming around special blocks (corner cases)         :quotes:
+*** Whitespace trimming around special blocks (corner cases)
 :PROPERTIES:
 :EXPORT_FILE_NAME: ws-trimming-around-special-blocks-corner-cases
 :END:
@@ -4885,6 +4885,24 @@ something
 marked text
 #+end_mark<>
 ***** Next heading
+**** Whitespace trimming before and after code blocks
+something
+#+begin_mark<>
+marked text
+#+end_mark<>
+#+begin_example
+code line
+#+end_example
+#+begin_mark<>
+marked text
+#+end_mark<>
+
+something
+~inline code 1~
+#+begin_mark<>
+marked text
+#+end_mark<>
+~inline code 2~
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:
 *** Common CSS

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4726,6 +4726,139 @@ TikZJax example
 #+end_tikzjax
 
 Here's a link to the [[circle][Circle]].
+** Whitespace trimming around special blocks            :whitespace:trimming:
+:PROPERTIES:
+:EXPORT_FILE_NAME: ws-trimming-around-special-blocks
+:EXPORT_DESCRIPTION: Whitespace trimming using special markers <>, < or > after special block names.
+:END:
+*** No trimming
+Below Org block:
+#+begin_src org
+line 1
+,#+begin_mark
+abc def
+,#+end_mark
+line 2
+#+end_src
+
+exports and renders as:
+
+line 1
+#+begin_mark
+abc def
+#+end_mark
+line 2
+*** Whitespace trimmed before and after the ~mark~ special block using ~<>~ suffix
+Below Org block:
+
+#+begin_src org
+line 1
+,#+begin_mark<>
+abc def
+,#+end_mark<>
+line 2
+#+end_src
+
+exports and renders as:
+
+line 1
+#+begin_mark<>
+abc def
+#+end_mark<>
+line 2
+*** Whitespace trimmed only before the ~mark~ special block using ~<~ suffix
+Below Org block:
+
+#+begin_src org
+line 1
+,#+begin_mark<
+abc def
+,#+end_mark<
+line 2
+#+end_src
+
+exports and renders as:
+
+line 1
+#+begin_mark<
+abc def
+#+end_mark<
+line 2
+*** Whitespace trimmed only after the ~mark~ special block using ~>~ suffix
+Below Org block:
+
+#+begin_src org
+line 1
+,#+begin_mark>
+abc def
+,#+end_mark>
+line 2
+#+end_src
+
+exports and renders as:
+
+line 1
+#+begin_mark>
+abc def
+#+end_mark>
+line 2
+*** Use ~<span>~ tag if trimming detected
+Below Org block:
+
+#+begin_src org
+line 1
+,#+begin_sidenote
+abc def
+,#+end_sidenote
+line 2
+#+end_src
+
+export with ~<div>~ tags by default:
+
+#+begin_src html -n
+line 1
+
+<div class="sidenote">
+
+abc def
+
+</div>
+
+line 2
+#+end_src
+
+and render as:
+
+line 1
+#+begin_sidenote
+abc def
+#+end_sidenote
+line 2
+
+But if a trimming marker (any of them) is detected, it switches to
+using the ~<span>~ tag. So the below Org block:
+
+#+begin_src org
+line 1
+,#+begin_sidenote<>
+abc def
+,#+end_sidenote<>
+line 2
+#+end_src
+
+will export to:
+
+#+begin_src html -n
+line 1 <span class="sidenote">abc def</span> line 2
+#+end_src
+
+and render as:
+
+line 1
+#+begin_sidenote<>
+abc def
+#+end_sidenote<>
+line 2
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:
 *** Common CSS

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4732,6 +4732,12 @@ Here's a link to the [[circle][Circle]].
 :EXPORT_FILE_NAME: ws-trimming-around-special-blocks
 :EXPORT_DESCRIPTION: Whitespace trimming using ~#+header: :trim-pre t :trim-post t~ before special blocks.
 :END:
+By default (in ~org-hugo-special-block-type-properties~), the "mark"
+special block type has ~:trim-pre~ and ~:trim-post~ both set to ~t~,
+because typically the ~<mark>~ is used to highlight words and phrases
+mid-sentence and we wouldn't want to introduce a paragraph break
+before or after a ~<mark>~ element.
+
 **** Whitespace trimmed before and after the ~mark~ special block (default)
 Below Org block:
 

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4730,7 +4730,7 @@ Here's a link to the [[circle][Circle]].
 *** Whitespace trimming around special blocks
 :PROPERTIES:
 :EXPORT_FILE_NAME: ws-trimming-around-special-blocks
-:EXPORT_DESCRIPTION: Whitespace trimming using special markers <>, < or > after special block names.
+:EXPORT_DESCRIPTION: Whitespace trimming using ~#+header: :trim-pre t :trim-post t~ before special blocks.
 :END:
 **** No trimming
 Below Org block:
@@ -4749,59 +4749,65 @@ line 1
 abc def
 #+end_mark
 line 2
-**** Whitespace trimmed before and after the ~mark~ special block using ~<>~ suffix
+**** Whitespace trimmed before and after the ~mark~ special block
 Below Org block:
 
 #+begin_src org
 line 1
-,#+begin_mark<>
+,#+header: :trim-pre t :trim-post t
+,#+begin_mark
 abc def
-,#+end_mark<>
+,#+end_mark
 line 2
 #+end_src
 
 exports and renders as:
 
 line 1
-#+begin_mark<>
+#+header: :trim-pre t :trim-post t
+#+begin_mark
 abc def
-#+end_mark<>
+#+end_mark
 line 2
-**** Whitespace trimmed only before the ~mark~ special block using ~<~ suffix
+**** Whitespace trimmed only before the ~mark~ special block
 Below Org block:
 
 #+begin_src org
 line 1
-,#+begin_mark<
+,#+header: :trim-pre t
+,#+begin_mark
 abc def
-,#+end_mark<
+,#+end_mark
 line 2
 #+end_src
 
 exports and renders as:
 
 line 1
-#+begin_mark<
+#+header: :trim-pre t
+#+begin_mark
 abc def
-#+end_mark<
+#+end_mark
 line 2
-**** Whitespace trimmed only after the ~mark~ special block using ~>~ suffix
+**** Whitespace trimmed only after the ~mark~ special block
 Below Org block:
 
 #+begin_src org
 line 1
-,#+begin_mark>
+,#+header: :trim-post t
+,#+begin_mark
 abc def
-,#+end_mark>
+,#+end_mark
 line 2
 #+end_src
 
 exports and renders as:
 
 line 1
-#+begin_mark>
+#+header: :trim-post t
+#+begin_mark
 abc def
-#+end_mark>
+#+end_mark
 line 2
 **** Use ~<span>~ tag if trimming detected
 Below Org block:
@@ -4814,7 +4820,7 @@ abc def
 line 2
 #+end_src
 
-export with ~<div>~ tags by default:
+exports with ~<div>~ tags by default:
 
 #+begin_src html -n
 line 1
@@ -4828,7 +4834,7 @@ abc def
 line 2
 #+end_src
 
-and render as:
+and renders as:
 
 line 1
 #+begin_sidenote
@@ -4836,14 +4842,15 @@ abc def
 #+end_sidenote
 line 2
 
-But if a trimming marker (any of them) is detected, it switches to
-using the ~<span>~ tag. So the below Org block:
+But if any of the trimming options are set in the header, it switches
+to using the ~<span>~ tag. So the below Org block:
 
 #+begin_src org
 line 1
-,#+begin_sidenote<>
+,#+header: :trim-pre t :trim-post t
+,#+begin_sidenote
 abc def
-,#+end_sidenote<>
+,#+end_sidenote
 line 2
 #+end_src
 
@@ -4856,9 +4863,10 @@ line 1 <span class="sidenote">abc def</span> line 2
 and render as:
 
 line 1
-#+begin_sidenote<>
+#+header: :trim-pre t :trim-post t
+#+begin_sidenote
 abc def
-#+end_sidenote<>
+#+end_sidenote
 line 2
 *** Whitespace trimming around special blocks (corner cases)
 :PROPERTIES:
@@ -4867,41 +4875,47 @@ line 2
 **** Whitespace trimming inside quote blocks
 #+begin_quote
 line 1
-#+begin_mark<>
+#+header: :trim-pre t :trim-post t
+#+begin_mark
 marked text
-#+end_mark<>
+#+end_mark
 line 2
 #+end_quote
 **** Whitespace trimming before list elements
 something
-#+begin_mark<>
+#+header: :trim-pre t :trim-post t
+#+begin_mark
 marked text
-#+end_mark<>
+#+end_mark
 - list item 1
 - list item 2
 **** Whitespace trimming before headings
 something
-#+begin_mark<>
+#+header: :trim-pre t :trim-post t
+#+begin_mark
 marked text
-#+end_mark<>
+#+end_mark
 ***** Next heading
 **** Whitespace trimming before and after code blocks
 something
-#+begin_mark<>
+#+header: :trim-pre t :trim-post t
+#+begin_mark
 marked text
-#+end_mark<>
+#+end_mark
 #+begin_example
 code line
 #+end_example
-#+begin_mark<>
+#+header: :trim-pre t :trim-post t
+#+begin_mark
 marked text
-#+end_mark<>
+#+end_mark
 
 something
 ~inline code 1~
-#+begin_mark<>
+#+header: :trim-pre t :trim-post t
+#+begin_mark
 marked text
-#+end_mark<>
+#+end_mark
 ~inline code 2~
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4868,10 +4868,17 @@ line 2
 #+begin_quote
 line 1
 #+begin_mark<>
-abc def
+marked text
 #+end_mark<>
 line 2
 #+end_quote
+**** Whitespace trimming before list elements
+something
+#+begin_mark<>
+marked text
+#+end_mark<>
+- list item 1
+- list item 2
 * Shortcodes                                                      :shortcode:
 ** Alert CSS                                                       :noexport:
 *** Common CSS

--- a/test/site/content/posts/build-front-matter/do-not-render.md
+++ b/test/site/content/posts/build-front-matter/do-not-render.md
@@ -17,4 +17,4 @@ and metadata can be found using the `site.GetPage` method.
 <mark>This page is listed on that parent list page, but the link won't lead
 to this page as.. it did not get rendered. That link will point to
 that page itself because with `render` set to `false` or `"never"`,
-the `.Permalink` and `.RelPermalink` get set to `""`.</mark>
+the `.Permalink` and `.RelPermalink` get set to `""`.</mark><!-- trim-post -->

--- a/test/site/content/posts/build-front-matter/do-not-render.md
+++ b/test/site/content/posts/build-front-matter/do-not-render.md
@@ -17,4 +17,4 @@ and metadata can be found using the `site.GetPage` method.
 <mark>This page is listed on that parent list page, but the link won't lead
 to this page as.. it did not get rendered. That link will point to
 that page itself because with `render` set to `false` or `"never"`,
-the `.Permalink` and `.RelPermalink` get set to `""`.</mark><!-- trim-post -->
+the `.Permalink` and `.RelPermalink` get set to `""`.</mark>

--- a/test/site/content/posts/special-blocks.md
+++ b/test/site/content/posts/special-blocks.md
@@ -44,11 +44,7 @@ _Some_ **text** --- 2
 
 ### Inline HTML5 elements {#inline-html5-elements}
 
-Unmarked.
-
-<mark>_Some_ **marked** text --- 2.5.</mark>
-
-Unmarked again.
+Unmarked. <mark>_Some_ **marked** text --- 2.5.</mark> Unmarked again.
 
 <mark>Page Bundles of `page` [_Kind_](https://gohugo.io/templates/section-templates/#page-kinds) are always _leaf bundles_.. and vice versa.</mark>
 

--- a/test/site/content/posts/special-blocks.md
+++ b/test/site/content/posts/special-blocks.md
@@ -45,8 +45,7 @@ _Some_ **text** --- 2
 ### Inline HTML5 elements {#inline-html5-elements}
 
 Unmarked.
-<mark>_Some_ **marked** text --- 2.5.</mark>
-Unmarked again.
+<mark>_Some_ **marked** text --- 2.5.</mark> Unmarked again.
 
 <mark>Page Bundles of `page` [_Kind_](https://gohugo.io/templates/section-templates/#page-kinds) are always _leaf bundles_.. and vice versa.</mark>
 

--- a/test/site/content/posts/special-blocks.md
+++ b/test/site/content/posts/special-blocks.md
@@ -44,7 +44,9 @@ _Some_ **text** --- 2
 
 ### Inline HTML5 elements {#inline-html5-elements}
 
-Unmarked. <mark>_Some_ **marked** text --- 2.5.</mark> Unmarked again.
+Unmarked.
+<mark>_Some_ **marked** text --- 2.5.</mark>
+Unmarked again.
 
 <mark>Page Bundles of `page` [_Kind_](https://gohugo.io/templates/section-templates/#page-kinds) are always _leaf bundles_.. and vice versa.</mark>
 

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -19,6 +19,8 @@ something <mark>marked text</mark>
 ## Whitespace trimming before headings {#whitespace-trimming-before-headings}
 
 something <mark>marked text</mark>
+
+
 ### Next heading {#next-heading}
 
 
@@ -32,3 +34,7 @@ code line
 `inline code 1`
  <mark>marked text</mark>
 `inline code 2`
+
+
+## Last element of a post {#last-element-of-a-post} <mark>No "post" trim markers should be inserted after this block as it's the
+last element of this post.</mark>

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -11,16 +11,14 @@ draft = false
 ## Whitespace trimming inside quote blocks {#whitespace-trimming-inside-quote-blocks}
 
 > line 1
-<mark>marked text</mark>
-line 2
+<mark>marked text</mark> line 2
 >
 > line 4 (line 3, above, is blank, but inside the quote block)
 
 -   Special block in a quote block in a list
 
     > line 1
-<mark>marked text</mark>
-line 2
+<mark>marked text</mark> line 2
     >
     > line 4 (line 3, above, is blank, but inside the quote block)
 
@@ -49,8 +47,7 @@ something
 ```text
 code line
 ```
-<mark>marked text</mark>
-something
+<mark>marked text</mark> something
 `inline code 1`
 <mark>marked text</mark>
 `inline code 2`

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -53,6 +53,16 @@ something
 <mark>marked text</mark>
 
 
+## `>` character before a special block with `:trim_pre` set {#character-before-a-special-block-with-trim-pre-set}
+
+<style>
+  .red {
+    color: red;
+  }
+</style>
+<mark class="red">This marked text's foreground is red.</mark>
+
+
 ## Last element of a post {#last-element-of-a-post}
 <mark>No "post" trim markers should be inserted after this block as it's the
 last element of this post.</mark>

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -1,24 +1,34 @@
 +++
 title = "Whitespace trimming around special blocks (corner cases)"
-tags = ["special-block", "whitespace", "trimming"]
+description = """
+  Corner cases for testing the whitespace trimming around the special
+  blocks.
+  """
+tags = ["special-block", "whitespace", "trimming", "corner-cases"]
 draft = false
 +++
 
 ## Whitespace trimming inside quote blocks {#whitespace-trimming-inside-quote-blocks}
 
-> line 1 <mark>marked text</mark> line 2
+> line 1
+<mark>marked text</mark>
+line 2
+>
+> line 4 (line 3, above, is blank, but inside the quote block)
 
 
 ## Whitespace trimming before list elements {#whitespace-trimming-before-list-elements}
 
-something <mark>marked text</mark>
+something
+<mark>marked text</mark>
 -   list item 1
 -   list item 2
 
 
 ## Whitespace trimming before headings {#whitespace-trimming-before-headings}
 
-something <mark>marked text</mark>
+something
+<mark>marked text</mark>
 
 
 ### Next heading {#next-heading}
@@ -26,15 +36,23 @@ something <mark>marked text</mark>
 
 ## Whitespace trimming before and after code blocks {#whitespace-trimming-before-and-after-code-blocks}
 
-something <mark>marked text</mark>
+something
+<mark>marked text</mark>
 ```text
 code line
 ```
- <mark>marked text</mark> something
+<mark>marked text</mark>
+something
 `inline code 1`
- <mark>marked text</mark>
+<mark>marked text</mark>
 `inline code 2`
+something
 
 
-## Last element of a post {#last-element-of-a-post} <mark>No "post" trim markers should be inserted after this block as it's the
+## Whitespace trimming with `:trim-pre` set immediately after a heading {#whitespace-trimming-with-trim-pre-set-immediately-after-a-heading}
+<mark>marked text</mark>
+
+
+## Last element of a post {#last-element-of-a-post}
+<mark>No "post" trim markers should be inserted after this block as it's the
 last element of this post.</mark>

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -14,3 +14,9 @@ draft = false
 something <mark>marked text</mark>
 -   list item 1
 -   list item 2
+
+
+## Whitespace trimming before headings {#whitespace-trimming-before-headings}
+
+something <mark>marked text</mark>
+### Next heading {#next-heading}

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -1,6 +1,6 @@
 +++
 title = "Whitespace trimming around special blocks (corner cases)"
-tags = ["special-block", "whitespace", "trimming", "quotes"]
+tags = ["special-block", "whitespace", "trimming"]
 draft = false
 +++
 
@@ -20,3 +20,15 @@ something <mark>marked text</mark>
 
 something <mark>marked text</mark>
 ### Next heading {#next-heading}
+
+
+## Whitespace trimming before and after code blocks {#whitespace-trimming-before-and-after-code-blocks}
+
+something <mark>marked text</mark>
+```text
+code line
+```
+ <mark>marked text</mark> something
+`inline code 1`
+ <mark>marked text</mark>
+`inline code 2`

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -16,6 +16,14 @@ line 2
 >
 > line 4 (line 3, above, is blank, but inside the quote block)
 
+-   Special block in a quote block in a list
+
+    > line 1
+<mark>marked text</mark>
+line 2
+    >
+    > line 4 (line 3, above, is blank, but inside the quote block)
+
 
 ## Whitespace trimming before list elements {#whitespace-trimming-before-list-elements}
 

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -6,4 +6,11 @@ draft = false
 
 ## Whitespace trimming inside quote blocks {#whitespace-trimming-inside-quote-blocks}
 
-> line 1 <mark>abc def</mark> line 2
+> line 1 <mark>marked text</mark> line 2
+
+
+## Whitespace trimming before list elements {#whitespace-trimming-before-list-elements}
+
+something <mark>marked text</mark>
+-   list item 1
+-   list item 2

--- a/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks-corner-cases.md
@@ -1,0 +1,9 @@
++++
+title = "Whitespace trimming around special blocks (corner cases)"
+tags = ["special-block", "whitespace", "trimming", "quotes"]
+draft = false
++++
+
+## Whitespace trimming inside quote blocks {#whitespace-trimming-inside-quote-blocks}
+
+> line 1 <mark>abc def</mark> line 2

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -1,6 +1,6 @@
 +++
 title = "Whitespace trimming around special blocks"
-description = "Whitespace trimming using special markers <>, < or > after special block names."
+description = "Whitespace trimming using ~#+header: :trim-pre t :trim-post t~ before special blocks."
 tags = ["special-block", "whitespace", "trimming"]
 draft = false
 +++
@@ -26,15 +26,16 @@ line 1
 line 2
 
 
-## Whitespace trimmed before and after the `mark` special block using `<>` suffix {#whitespace-trimmed-before-and-after-the-mark-special-block-using-suffix}
+## Whitespace trimmed before and after the `mark` special block {#whitespace-trimmed-before-and-after-the-mark-special-block}
 
 Below Org block:
 
 ```org
 line 1
-#+begin_mark<>
+#+header: :trim-pre t :trim-post t
+#+begin_mark
 abc def
-#+end_mark<>
+#+end_mark
 line 2
 ```
 
@@ -43,15 +44,16 @@ exports and renders as:
 line 1 <mark>abc def</mark> line 2
 
 
-## Whitespace trimmed only before the `mark` special block using `<` suffix {#whitespace-trimmed-only-before-the-mark-special-block-using-suffix}
+## Whitespace trimmed only before the `mark` special block {#whitespace-trimmed-only-before-the-mark-special-block}
 
 Below Org block:
 
 ```org
 line 1
-#+begin_mark<
+#+header: :trim-pre t
+#+begin_mark
 abc def
-#+end_mark<
+#+end_mark
 line 2
 ```
 
@@ -62,15 +64,16 @@ line 1 <mark>abc def</mark>
 line 2
 
 
-## Whitespace trimmed only after the `mark` special block using `>` suffix {#whitespace-trimmed-only-after-the-mark-special-block-using-suffix}
+## Whitespace trimmed only after the `mark` special block {#whitespace-trimmed-only-after-the-mark-special-block}
 
 Below Org block:
 
 ```org
 line 1
-#+begin_mark>
+#+header: :trim-post t
+#+begin_mark
 abc def
-#+end_mark>
+#+end_mark
 line 2
 ```
 
@@ -93,7 +96,7 @@ abc def
 line 2
 ```
 
-export with `<div>` tags by default:
+exports with `<div>` tags by default:
 
 ```html { linenos=table, linenostart=1 }
 line 1
@@ -107,7 +110,7 @@ abc def
 line 2
 ```
 
-and render as:
+and renders as:
 
 line 1
 
@@ -119,14 +122,15 @@ abc def
 
 line 2
 
-But if a trimming marker (any of them) is detected, it switches to
-using the `<span>` tag. So the below Org block:
+But if any of the trimming options are set in the header, it switches
+to using the `<span>` tag. So the below Org block:
 
 ```org
 line 1
-#+begin_sidenote<>
+#+header: :trim-pre t :trim-post t
+#+begin_sidenote
 abc def
-#+end_sidenote<>
+#+end_sidenote
 line 2
 ```
 

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -1,0 +1,141 @@
++++
+title = "Whitespace trimming around special blocks"
+description = "Whitespace trimming using special markers <>, < or > after special block names."
+tags = ["special-block", "whitespace", "trimming"]
+draft = false
++++
+
+## No trimming {#no-trimming}
+
+Below Org block:
+
+```org
+line 1
+#+begin_mark
+abc def
+#+end_mark
+line 2
+```
+
+exports and renders as:
+
+line 1
+
+<mark>abc def</mark>
+
+line 2
+
+
+## Whitespace trimmed before and after the `mark` special block using `<>` suffix {#whitespace-trimmed-before-and-after-the-mark-special-block-using-suffix}
+
+Below Org block:
+
+```org
+line 1
+#+begin_mark<>
+abc def
+#+end_mark<>
+line 2
+```
+
+exports and renders as:
+
+line 1 <mark>abc def</mark> line 2
+
+
+## Whitespace trimmed only before the `mark` special block using `<` suffix {#whitespace-trimmed-only-before-the-mark-special-block-using-suffix}
+
+Below Org block:
+
+```org
+line 1
+#+begin_mark<
+abc def
+#+end_mark<
+line 2
+```
+
+exports and renders as:
+
+line 1 <mark>abc def</mark>
+
+line 2
+
+
+## Whitespace trimmed only after the `mark` special block using `>` suffix {#whitespace-trimmed-only-after-the-mark-special-block-using-suffix}
+
+Below Org block:
+
+```org
+line 1
+#+begin_mark>
+abc def
+#+end_mark>
+line 2
+```
+
+exports and renders as:
+
+line 1
+
+<mark>abc def</mark> line 2
+
+
+## Use `<span>` tag if trimming detected {#use-span-tag-if-trimming-detected}
+
+Below Org block:
+
+```org
+line 1
+#+begin_sidenote
+abc def
+#+end_sidenote
+line 2
+```
+
+export with `<div>` tags by default:
+
+```html { linenos=table, linenostart=1 }
+line 1
+
+<div class="sidenote">
+
+abc def
+
+</div>
+
+line 2
+```
+
+and render as:
+
+line 1
+
+<div class="sidenote">
+
+abc def
+
+</div>
+
+line 2
+
+But if a trimming marker (any of them) is detected, it switches to
+using the `<span>` tag. So the below Org block:
+
+```org
+line 1
+#+begin_sidenote<>
+abc def
+#+end_sidenote<>
+line 2
+```
+
+will export to:
+
+```html { linenos=table, linenostart=1 }
+line 1 <span class="sidenote">abc def</span> line 2
+```
+
+and render as:
+
+line 1 <span class="sidenote">abc def</span> line 2

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -5,6 +5,13 @@ tags = ["special-block", "whitespace", "trimming"]
 draft = false
 +++
 
+By default (in `org-hugo-special-block-type-properties`), the "mark"
+special block type has `:trim-pre` and `:trim-post` both set to `t`,
+because typically the `<mark>` is used to highlight words and phrases
+mid-sentence and we wouldn't want to introduce a paragraph break
+before or after a `<mark>` element.
+
+
 ## Whitespace trimmed before and after the `mark` special block (default) {#whitespace-trimmed-before-and-after-the-mark-special-block--default}
 
 Below Org block:

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -27,8 +27,7 @@ line 2
 exports and renders as:
 
 line 1
-<mark>abc def</mark>
-line 2
+<mark>abc def</mark> line 2
 
 
 ## Whitespace trimmed only before the `mark` special block {#whitespace-trimmed-only-before-the-mark-special-block}
@@ -69,8 +68,7 @@ exports and renders as:
 
 line 1
 
-<mark>abc def</mark>
-line 2
+<mark>abc def</mark> line 2
 
 
 ## No trimming {#no-trimming}
@@ -154,5 +152,4 @@ line 1 <span class="foo">abc def</span> line 2
 and render as:
 
 line 1
-<span class="foo">abc def</span>
-line 2
+<span class="foo">abc def</span> line 2

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -5,34 +5,12 @@ tags = ["special-block", "whitespace", "trimming"]
 draft = false
 +++
 
-## No trimming {#no-trimming}
+## Whitespace trimmed before and after the `mark` special block (default) {#whitespace-trimmed-before-and-after-the-mark-special-block--default}
 
 Below Org block:
 
 ```org
 line 1
-#+begin_mark
-abc def
-#+end_mark
-line 2
-```
-
-exports and renders as:
-
-line 1
-
-<mark>abc def</mark>
-
-line 2
-
-
-## Whitespace trimmed before and after the `mark` special block {#whitespace-trimmed-before-and-after-the-mark-special-block}
-
-Below Org block:
-
-```org
-line 1
-#+header: :trim-pre t :trim-post t
 #+begin_mark
 abc def
 #+end_mark
@@ -50,7 +28,7 @@ Below Org block:
 
 ```org
 line 1
-#+header: :trim-pre t
+#+header: :trim-post nil
 #+begin_mark
 abc def
 #+end_mark
@@ -59,9 +37,7 @@ line 2
 
 exports and renders as:
 
-line 1 <mark>abc def</mark>
-
-line 2
+line 1 <mark>abc def</mark> line 2
 
 
 ## Whitespace trimmed only after the `mark` special block {#whitespace-trimmed-only-after-the-mark-special-block}
@@ -70,7 +46,7 @@ Below Org block:
 
 ```org
 line 1
-#+header: :trim-post t
+#+header: :trim-pre nil
 #+begin_mark
 abc def
 #+end_mark
@@ -79,9 +55,25 @@ line 2
 
 exports and renders as:
 
-line 1
+line 1 <mark>abc def</mark> line 2
 
-<mark>abc def</mark> line 2
+
+## No trimming {#no-trimming}
+
+Below Org block:
+
+```org
+line 1
+#+header: :trim-pre nil :trim-post nil
+#+begin_mark
+abc def
+#+end_mark
+line 2
+```
+
+exports and renders as:
+
+line 1 <mark>abc def</mark> line 2
 
 
 ## Use `<span>` tag if trimming detected {#use-span-tag-if-trimming-detected}

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -19,7 +19,9 @@ line 2
 
 exports and renders as:
 
-line 1 <mark>abc def</mark> line 2
+line 1
+<mark>abc def</mark>
+line 2
 
 
 ## Whitespace trimmed only before the `mark` special block {#whitespace-trimmed-only-before-the-mark-special-block}
@@ -37,7 +39,8 @@ line 2
 
 exports and renders as:
 
-line 1 <mark>abc def</mark>
+line 1
+<mark>abc def</mark>
 
 line 2
 
@@ -59,7 +62,8 @@ exports and renders as:
 
 line 1
 
-<mark>abc def</mark> line 2
+<mark>abc def</mark>
+line 2
 
 
 ## No trimming {#no-trimming}
@@ -142,4 +146,6 @@ line 1 <span class="sidenote">abc def</span> line 2
 
 and render as:
 
-line 1 <span class="sidenote">abc def</span> line 2
+line 1
+<span class="sidenote">abc def</span>
+line 2

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -101,9 +101,9 @@ Below Org block:
 
 ```org
 line 1
-#+begin_sidenote
+#+begin_foo
 abc def
-#+end_sidenote
+#+end_foo
 line 2
 ```
 
@@ -112,7 +112,7 @@ exports with `<div>` tags by default:
 ```html { linenos=table, linenostart=1 }
 line 1
 
-<div class="sidenote">
+<div class="foo">
 
 abc def
 
@@ -125,7 +125,7 @@ and renders as:
 
 line 1
 
-<div class="sidenote">
+<div class="foo">
 
 abc def
 
@@ -139,20 +139,20 @@ to using the `<span>` tag. So the below Org block:
 ```org
 line 1
 #+header: :trim-pre t :trim-post t
-#+begin_sidenote
+#+begin_foo
 abc def
-#+end_sidenote
+#+end_foo
 line 2
 ```
 
 will export to:
 
 ```html { linenos=table, linenostart=1 }
-line 1 <span class="sidenote">abc def</span> line 2
+line 1 <span class="foo">abc def</span> line 2
 ```
 
 and render as:
 
 line 1
-<span class="sidenote">abc def</span>
+<span class="foo">abc def</span>
 line 2

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -37,7 +37,9 @@ line 2
 
 exports and renders as:
 
-line 1 <mark>abc def</mark> line 2
+line 1 <mark>abc def</mark>
+
+line 2
 
 
 ## Whitespace trimmed only after the `mark` special block {#whitespace-trimmed-only-after-the-mark-special-block}
@@ -55,7 +57,9 @@ line 2
 
 exports and renders as:
 
-line 1 <mark>abc def</mark> line 2
+line 1
+
+<mark>abc def</mark> line 2
 
 
 ## No trimming {#no-trimming}
@@ -73,7 +77,11 @@ line 2
 
 exports and renders as:
 
-line 1 <mark>abc def</mark> line 2
+line 1
+
+<mark>abc def</mark>
+
+line 2
 
 
 ## Use `<span>` tag if trimming detected {#use-span-tag-if-trimming-detected}


### PR DESCRIPTION
Another take of the implementation in https://github.com/kaushalmodi/ox-hugo/pull/536.

This time, I want to implement this **without** introducing special characters appended to the special block names like `#+begin_mark<>` .. `#+end_mark<>`.

---

### Using `:trim-pre` and `:trim-post` in `#+header` keyword above Org Special blocks

```org
line 1
#+header: :trim-pre t :trim-post t
#+begin_mark
abc def
#+end_mark
line 2
```

will export to

```html
line 1 <mark>abc def</mark> line 2
```

### Default `:trim-pre` and `:trim-post` defcustom

**TBD**


