### PR TITLE
Use the Org ID property as an alias

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -766,27 +766,29 @@ subtree* i.e. an Org subtree that has the =EXPORT_FILE_NAME= property
 set.
 #+caption: Hugo front-matter translation for subtree-based exports
 #+attr_html: :class sane-table
-|------------------------------------+----------------------------------------+----------------------------------------------------------------------------|
-| Hugo front-matter (TOML)           | Org                                    | Org description                                                            |
-|------------------------------------+----------------------------------------+----------------------------------------------------------------------------|
-| =title = "foo"=                    | =* foo=                                | Subtree heading                                                            |
-| =date = 2017-09-11T14:32:00-04:00= | =CLOSED: [2017-09-11 Mon 14:32]=       | Auto-inserted =CLOSED= subtree property when switch to Org *DONE* state    |
-| =date = 2017-07-24=                | =:EXPORT_DATE: 2017-07-24=             | Subtree property                                                           |
+|------------------------------------+-----------------------------------------+----------------------------------------------------------------------------|
+| Hugo front-matter (TOML)           | Org                                     | Org description                                                            |
+|------------------------------------+-----------------------------------------+----------------------------------------------------------------------------|
+| =title = "foo"=                    | =* foo=                                 | Subtree heading                                                            |
+| =date = 2017-09-11T14:32:00-04:00= | =CLOSED: [2017-09-11 Mon 14:32]=        | Auto-inserted =CLOSED= subtree property when switch to Org *DONE* state    |
+| =date = 2017-07-24=                | =:EXPORT_DATE: 2017-07-24=              | Subtree property                                                           |
 | =publishDate = 2018-01-26=         | =SCHEDULED: <2018-01-26 Fri>=           | Auto-inserted =SCHEDULED= subtree property using default =C-c C-s= binding |
 | =publishDate = 2018-01-26=         | =:EXPORT_HUGO_PUBLISHDATE: 2018-01-26:= | Subtree property                                                           |
 | =expiryDate = 2999-01-01=          | =:EXPORT_HUGO_EXPIRYDATE: 2999-01-01:=  | Subtree property                                                           |
-| =lastmod = <current date>=          | =:EXPORT_HUGO_AUTO_SET_LASTMOD: t=     | Subtree property                                                           |
-| =lastmod = <current date>=          | =#+hugo_auto_set_lastmod: t=           | Org keyword                                                                |
+| =lastmod = <current date>=         | =:EXPORT_HUGO_AUTO_SET_LASTMOD: t=      | Subtree property                                                           |
+| =lastmod = <current date>=         | =#+hugo_auto_set_lastmod: t=            | Org keyword                                                                |
 | =tags = ["toto", "zulu"]=          | =* foo :toto:zulu:=                     | Subtree heading tags                                                       |
 | =categories = ["x", "y"]=          | =* foo :@x:@y:=                         | Subtree heading tags with =@= prefix                                       |
-| =draft = true=                     | =* TODO foo=                           | Subtree heading Org TODO state set to =TODO=[fn:4].                        |
-| =draft = false=                    | =* foo= or =* DONE foo=                | Subtree heading Org TODO state not set or set to =DONE=[fn:4].             |
-| =weight = 123= (manual)            | =:EXPORT_HUGO_WEIGHT: 123=             | Manual setting of page weight                                              |
-| =weight = 123= (auto-calc)         | =:EXPORT_HUGO_WEIGHT: auto=            | When set to =auto=, page weight is auto-calculated                         |
-| =tags_weight = 123= (manual)       | =:EXPORT_HUGO_WEIGHT: :tags 123=       | Manual setting of /FOO/ taxonomy weight, by setting to =:FOO VALUE=        |
-| =tags_weight = 123= (auto-calc)    | =:EXPORT_HUGO_WEIGHT: :tags auto=      | When set to =:FOO auto=, /FOO/ taxonomy weight is auto-calculated          |
-| =weight = 123= (in =[menu.foo]=)   | =:EXPORT_HUGO_MENU: :menu foo=         | Menu weight is auto-calculated unless specified                            |
-|------------------------------------+----------------------------------------+----------------------------------------------------------------------------|
+| =draft = true=                     | =* TODO foo=                            | Subtree heading Org TODO state set to =TODO=[fn:4].                        |
+| =draft = false=                    | =* foo= or =* DONE foo=                 | Subtree heading Org TODO state not set or set to =DONE=[fn:4].             |
+| =weight = 123= (manual)            | =:EXPORT_HUGO_WEIGHT: 123=              | Manual setting of page weight                                              |
+| =weight = 123= (auto-calc)         | =:EXPORT_HUGO_WEIGHT: auto=             | When set to =auto=, page weight is auto-calculated                         |
+| =tags_weight = 123= (manual)       | =:EXPORT_HUGO_WEIGHT: :tags 123=        | Manual setting of /FOO/ taxonomy weight, by setting to =:FOO VALUE=        |
+| =tags_weight = 123= (auto-calc)    | =:EXPORT_HUGO_WEIGHT: :tags auto=       | When set to =:FOO auto=, /FOO/ taxonomy weight is auto-calculated          |
+| =weight = 123= (in =[menu.foo]=)   | =:EXPORT_HUGO_MENU: :menu foo=          | Menu weight is auto-calculated unless specified                            |
+| =aliases = ["my-post-alias"]=      | =:EXPORT_HUGO_ALIASES: my-post-alias=   | Manual setting of a post alias                                             |
+| =aliases = ["123456"]=             | =:ID: 123456=                           | Subtree's =ID= property is auto-exported as the post's alias.              |
+|------------------------------------+-----------------------------------------+----------------------------------------------------------------------------|
 ***** Notes
 - Precedence for =date= parsing :: =CLOSED= subtree property /more
      than/ =EXPORT_DATE= subtree property /more than/ =#+date:=
@@ -798,23 +800,25 @@ set.
 **** For file-based exports
 #+caption: Hugo front-matter translation for file-based exports
 #+attr_html: :class sane-table
-|----------------------------------+--------------------------------------|
-| Hugo front-matter (TOML)         | Org                                  |
-|----------------------------------+--------------------------------------|
-| =title = "foo"=                  | =#+title: foo=                       |
-| =date = 2017-07-24=              | =#+date: 2017-07-24=                 |
-| =publishDate = 2018-01-26=       | =#+hugo_publishdate: 2018-01-26=     |
-| =expiryDate = 2999-01-01=        | =#+hugo_expirydate: 2999-01-01=      |
-| =lastmod = <current date>=        | =#+hugo_auto_set_lastmod: t=         |
-| =tags = ["toto", "zulu"]=        | =#+hugo_tags: toto zulu=             |
-| =categories = ["x", "y"]=        | =#+hugo_categories: x y=             |
-| =draft = true=                   | =#+hugo_draft: true=                 |
-| =draft = false=                  | =#+hugo_draft: false=                |
-| =weight = 123=                   | =#+hugo_weight: 123=                 |
-| =tags_weight = 123=              | =#+hugo_weight: :tags 123=           |
-| =categories_weight = 123=        | =#+hugo_weight: :categories 123=     |
-| =weight = 123= (in =[menu.foo]=) | =#+hugo_menu: :menu foo :weight 123= |
-|----------------------------------+--------------------------------------|
+|----------------------------------+--------------------------------------------------------|
+| Hugo front-matter (TOML)         | Org                                                    |
+|----------------------------------+--------------------------------------------------------|
+| =title = "foo"=                  | =#+title: foo=                                         |
+| =date = 2017-07-24=              | =#+date: 2017-07-24=                                   |
+| =publishDate = 2018-01-26=       | =#+hugo_publishdate: 2018-01-26=                       |
+| =expiryDate = 2999-01-01=        | =#+hugo_expirydate: 2999-01-01=                        |
+| =lastmod = <current date>=       | =#+hugo_auto_set_lastmod: t=                           |
+| =tags = ["toto", "zulu"]=        | =#+hugo_tags: toto zulu=                               |
+| =categories = ["x", "y"]=        | =#+hugo_categories: x y=                               |
+| =draft = true=                   | =#+hugo_draft: true=                                   |
+| =draft = false=                  | =#+hugo_draft: false=                                  |
+| =weight = 123=                   | =#+hugo_weight: 123=                                   |
+| =tags_weight = 123=              | =#+hugo_weight: :tags 123=                             |
+| =categories_weight = 123=        | =#+hugo_weight: :categories 123=                       |
+| =weight = 123= (in =[menu.foo]=) | =#+hugo_menu: :menu foo :weight 123=                   |
+| =aliases = ["my-post-alias"]=    | =#+hugo_aliases: my-post-alias=                        |
+| =aliases = ["123456"]=           | =:ID: 123456= (=:ID:= property at the top of the file) |
+|----------------------------------+--------------------------------------------------------|
 ***** Notes
 - The *auto calculation* of weights for pages, taxonomies and menu
   items works *only* for subtree-based exports.

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -3426,7 +3426,10 @@ INFO is a plist used as a communication channel."
          (aliases-raw (let ((aliases-raw-1 (org-string-nw-p (plist-get info :hugo-aliases))))
                         (when aliases-raw-1
                           (org-split-string aliases-raw-1 " "))))
-         (aliases (let (alias-list)
+         (aliases (let ((org-id (org-id-get))
+                        alias-list)
+                    (when org-id ;If Org ID is set, add it as an alias.
+                      (push org-id alias-list))
                     (dolist (alias aliases-raw)
                       (unless (string-match-p "/" alias)
                         (let ((section (file-name-as-directory ;Suffix section with "/" if it isn't already

--- a/test/site/content/org-id-links-2/org-id-link-other-section.md
+++ b/test/site/content/org-id-links-2/org-id-link-other-section.md
@@ -1,5 +1,6 @@
 +++
 title = "Org-mode ID links in other section"
+aliases = ["094C3D7B-5AE7-45A7-8AD6-D0B45C50A8FE"]
 draft = false
 +++
 

--- a/test/site/content/org-id-links/org-id-link-child.md
+++ b/test/site/content/org-id-links/org-id-link-child.md
@@ -1,5 +1,6 @@
 +++
 title = "Org-mode ID links child"
+aliases = ["FAADA682-B553-48BE-AC15-F80BDEE5A962"]
 draft = false
 +++
 

--- a/test/site/content/org-roam/org-roam-file-A.md
+++ b/test/site/content/org-roam/org-roam-file-A.md
@@ -1,5 +1,6 @@
 +++
 title = "A"
+aliases = ["1e8ccec9-735d-41d0-b0cf-143d9c3e965d"]
 tags = ["org-roam"]
 categories = ["org-id"]
 draft = false

--- a/test/site/content/org-roam/org-roam-file-B.md
+++ b/test/site/content/org-roam/org-roam-file-B.md
@@ -1,5 +1,6 @@
 +++
 title = "B"
+aliases = ["01579e8c-a90b-4c53-af58-e18ff7877d00"]
 tags = ["org-roam"]
 categories = ["org-id"]
 draft = false

--- a/test/site/content/posts/link-destination.md
+++ b/test/site/content/posts/link-destination.md
@@ -1,5 +1,6 @@
 +++
 title = "Link destination"
+aliases = ["1e5e0bcd-caea-40ad-a75b-e488634c2678"]
 tags = ["links"]
 draft = false
 +++


### PR DESCRIPTION
Ref: https://github.com/kaushalmodi/ox-hugo/issues/542

This work for both subtree-based and file-based exports.

If a post has an ID property set (either in the post subtree or at the top of the file), the ID is exported as a Hugo alias as well.

So if a post gets exported as `abc.md` and has its ID 123-456 exported as `aliases = ["123-456"]`, that post can be accessed using both `<baseURL>/abc` and `<baseURL>/123-456`. 

Hugo redirects `<baseURL>/123-456` to `<baseURL>/abc` .

**CAVEAT**:  As this is a simple redirection, `<baseURL>/123-456/#some-anchor` will also redirect but the anchor will be lost.. it will redirect to just `<baseURL>/abc` . Practically, after redirection, someone will be seeing just the final URL `<baseURL>/abc` . So if someone were to copy link to an anchor, that link would have the final URL as well.. example: `<baseURL>/abc/#some-anchor` 