### PR TITLE
Add new defcustom `org-hugo-anchor-functions`

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -3792,6 +3792,73 @@ Additionally, if it has the property ~EXPORT_HTML_CONTAINER_CLASS:
 foo~, the "foo" class gets added to that container tag as well.
 
 {{{test-search(container)}}}
+*** Anchors
+:PROPERTIES:
+:EXPORT_FILE_NAME: anchors
+:END:
+#+begin_description
+Anchors derived for sub-heading and other HTML elements in a page.
+#+end_description
+Hugo supports specifying custom ID's for headings in a page using the
+~{#some-id}~ syntax. See its documentation on [[https://gohugo.io/content-management/cross-references/#heading-ids][Cross References:
+Heading IDs]] for reference.
+
+If the heading ID's are not specified using the above syntax, Hugo
+will generate them automatically. While that is OK in general, it
+becomes problematic when user generates [[* Table of Contents][TOC]] using Org, where the links
+to headings on the page need to be embedded, or uses Org internal or
+external links to reference other headings.
+
+So in order to make the user experience smooth, anchors for all
+headings are always derived withing ~ox-hugo~ and exported using the
+~{#some-id}~ syntax.
+
+The functions used for deriving the anchors can be customized using
+the *~org-hugo-anchor-functions~* variable.
+
+This variable is a list of functions which can return the anchor
+string for a given Org heading element. The first function in the list
+to return a non-nil value wins. So this scheme can be used to set a
+precedence order that the user desires.
+
+This is the default precedence order:
+
+- ~org-hugo-get-custom-id~ :: Use the heading's ~:CUSTOM_ID~ property
+  if set, else return /nil/.
+- ~org-hugo-get-heading-slug~ :: Derive anchor using the heading's
+  text. This could also return /nil/, if the heading has no
+  alphanumeric characters or no text (empty string).
+- ~org-hugo-get-md5~ :: Derive anchor using the few 6 characters of
+  /md5/ based on the heading title text. It returns the /md5/ of an
+  empty string if nothing else works. That way, this function
+  guarantees to return some non-empty string.
+
+Above precedence is set in the default value of
+~org-hugo-anchor-functions~ --- ~'(org-hugo-get-custom-id
+org-hugo-get-heading-slug org-hugo-get-md5)~.
+**** Other anchor functions
+- ~org-hugo-get-id~ :: This function returns the ID, if that property
+  is set for a heading.
+
+  If a user prefers to give higher precedence to Org ID than the
+  heading-derived-slug, they can customize ~org-hugo-anchor-functions~
+  to ~'(org-hugo-get-custom-id org-hugo-get-id
+  org-hugo-get-heading-slug org-hugo-get-md5)~.
+
+  Now if an Org heading looks like this:
+
+  #+begin_src org
+  ,** Heading in a post
+  :PROPERTIES:
+  :ID:       74283e7c-a20b-1c22-af88-e41ff8055d17
+  :END:
+  #+end_src
+
+  , it will be exported as below in Markdown:
+
+  #+begin_src md
+  ### Heading in a post {#74283e7c-a20b-1c22-af88-e41ff8055d17}
+  #+end_src
 ** Meta
 :PROPERTIES:
 :EXPORT_HUGO_MENU: :menu "7.meta"

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1782,14 +1782,13 @@ The `slug' generated from that STR follows these rules:
       (setq str (replace-regexp-in-string "--" "-" str)))
     str))
 
-(defun org-hugo--get-anchor(element info &optional title-str)
+(defun org-hugo--get-anchor(element info)
   "Return an Org heading's anchor.
 
 The anchor is derived in the following precedence:
 
 1. `:CUSTOM_ID' property of the ELEMENT if set
-2. Optional TITLE-STR string argument to this function
-3. `:title' property of the ELEMENT.  If ELEMENT is an Org heading,
+2. `:title' property of the ELEMENT.  If ELEMENT is an Org heading,
    the `:title' will be the heading string.
 
 INFO is a plist used as a communication channel.
@@ -1797,9 +1796,8 @@ INFO is a plist used as a communication channel.
 If the anchor cannot be derived from any of the above, return
 nil."
   (or (org-element-property :CUSTOM_ID element)
-      (let ((title (or (org-string-nw-p title-str)
-                       (org-export-data-with-backend
-                        (org-element-property :title element) 'md info))))
+      (let ((title (org-export-data-with-backend
+                    (org-element-property :title element) 'md info)))
         (when (org-string-nw-p title)
           (org-hugo-slug title :allow-double-hyphens)))))
 
@@ -2050,7 +2048,7 @@ and rewrite link paths to make blogging more seamless."
                     (t
                      title))
               ;; Reference
-              (org-hugo--get-anchor destination info title))))
+              (org-hugo--get-anchor destination info))))
           ;; Links to other Org elements like source blocks, tables,
           ;; paragraphs, standalone figures, <<target>> links, etc.
           (_

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1916,7 +1916,7 @@ channel."
 (defun org-hugo--get-coderef-anchor-prefix (el)
   "Get anchor prefix string for code refs in element EL.
 
-Returns a cons (CODE-REFS . ANCHOR-PREFIX) where
+Return a cons (CODE-REFS . ANCHOR-PREFIX) where
 
 - CODE-REFS is an alist of the type (LINENUM . LABEL) where
 
@@ -1925,7 +1925,7 @@ Returns a cons (CODE-REFS . ANCHOR-PREFIX) where
 
 - ANCHOR-PREFIX is a string.
 
-Returns nil if EL has no code references."
+Return nil if EL has no code references."
   (let ((prefix "org-coderef")
         (hash-len 6)
         (code-refs (cdr (org-export-unravel-code el))))
@@ -1943,7 +1943,7 @@ This function is heavily derived from
 
 INFO is a plist used as a communication channel.
 
-Returns a plist with these elements:
+Return a plist with these elements:
 
 - `:line-num' :: REF associated line number
 
@@ -2542,7 +2542,7 @@ INFO is a plist used as a communication channel."
 - Add \"&nbsp;\" HTML entity before footnote anchors so that the
   anchors won't be on a separate line by themselves.
 
-Returns the processed CONTENTS string from the PARAGRAPH element.
+Return the processed CONTENTS string from the PARAGRAPH element.
 INFO is a plist used as a communication channel."
   (let ((ret contents))
     ;; Join consecutive Chinese, Japanese lines into a single long

--- a/test/site/content/posts/equations-bf-escaping.md
+++ b/test/site/content/posts/equations-bf-escaping.md
@@ -9,7 +9,7 @@ draft = false
 `ox-hugo` Issue #[138](https://github.com/kaushalmodi/ox-hugo/issues/138)
 
 
-## `\|` → `\\|` {#}
+## `\|` → `\\|`
 
 \\[
 C(w,b) = \frac{1}{2n} \sum\_x{{\\|y(x)-a\\|}^2}
@@ -40,7 +40,7 @@ y  &= a^L
 \end{align}
 
 
-## `\{` → `\\{`, `\}` → `\\}` {#}
+## `\{` → `\\{`, `\}` → `\\}`
 
 `ox-hugo` Issue #[258](https://github.com/kaushalmodi/ox-hugo/issues/258)
 

--- a/test/site/content/posts/equations-bf-escaping.md
+++ b/test/site/content/posts/equations-bf-escaping.md
@@ -9,7 +9,7 @@ draft = false
 `ox-hugo` Issue #[138](https://github.com/kaushalmodi/ox-hugo/issues/138)
 
 
-## `\|` → `\\|`
+## `\|` → `\\|` {#9d819a}
 
 \\[
 C(w,b) = \frac{1}{2n} \sum\_x{{\\|y(x)-a\\|}^2}
@@ -40,7 +40,7 @@ y  &= a^L
 \end{align}
 
 
-## `\{` → `\\{`, `\}` → `\\}`
+## `\{` → `\\{`, `\}` → `\\}` {#3d16e4}
 
 `ox-hugo` Issue #[258](https://github.com/kaushalmodi/ox-hugo/issues/258)
 


### PR DESCRIPTION
- `org-hugo--get-anchor`: Remove the unnecessary 3rd optional arg
- Add new defcustom `org-hugo-anchor-functions`
- Never make `org-hugo--get-anchor` return empty string anchors (unless of course if a user changes the default value of `org-hugo-anchor-functions`)