### PR TITLE
Fix `org-hugo-get-id`

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1841,11 +1841,14 @@ The `slug' generated from that STR follows these rules:
 Return nil if ELEMENT doesn't have the CUSTOM_ID property set."
   (org-string-nw-p (org-element-property :CUSTOM_ID element)))
 
-(defun org-hugo-get-id(&optional _element _info)
-  "Return the value of `:ID' property at point.
+(defun org-hugo-get-id(&optional element _info)
+  "Return the value of `:ID' property for ELEMENT.
 
 Return nil if id is not found."
-  (org-id-get))
+  (let ((element-begin (org-element-property :begin element)))
+    (save-excursion
+      (goto-char element-begin)
+      (org-id-get))))
 
 (defun org-hugo-get-heading-slug(element info)
   "Return the slug string derived from an Org heading ELEMENT.

--- a/test/site/content-org/issues/issue-556.org
+++ b/test/site/content-org/issues/issue-556.org
@@ -1,0 +1,57 @@
+:PROPERTIES:
+:ID:       31c61d47-0afc-4d5c-9b60-6c154a1c518d
+:END:
+#+title: Issue # 556
+#+hugo_section: issues
+#+hugo_base_dir: ../../
+
+#+author:
+
+#+macro: issue =ox-hugo= Issue #[[https://github.com/kaushalmodi/ox-hugo/issues/$1][$1]]
+
+#+begin_description
+Test the ~org-hugo-get-custom-id~ ~org-hugo-get-id
+org-hugo-get-heading-slug~ ~org-hugo-get-md5~ ~precedence set in
+~org-hugo-anchor-functions~.
+#+end_description
+
+{{{issue(556)}}}
+
+* Heading 1
+This heading's anchor will be derived off the heading string.
+** Heading 1.1
+:PROPERTIES:
+:ID:       48e6dfd4-93d9-4811-855e-c739470e83d1
+:END:
+This heading's anchor will be derived off the ~ID~.
+* Heading 2
+:PROPERTIES:
+:CUSTOM_ID: heading-xyz
+:END:
+This heading's anchor will be derived off the ~CUSTOM_ID~.
+* Heading 3
+:PROPERTIES:
+:CUSTOM_ID: heading-abc
+:ID:       04e97225-6956-4554-b812-ee0e52921c7a
+:END:
+This heading's anchor will be derived off the ~CUSTOM_ID~ as that
+takes precedence over the ~ID~.
+** Heading 3.1
+:PROPERTIES:
+:ID:       909536ed-b636-4bb9-9cc6-6a06992d8853
+:END:
+This heading's anchor will be derived off the ~ID~.
+* Heading 4
+:PROPERTIES:
+:ID:       6bc923a1-3543-440b-ace3-17c049cbbe0a
+:END:
+This heading's anchor will be derived off the ~ID~.
+* %
+This heading's anchor will be derived from /md5/ of the title as it is
+not alphanumeric.
+
+* Local Variables                                          :ARCHIVE:noexport:
+#+bind: org-hugo-anchor-functions (org-hugo-get-custom-id org-hugo-get-id org-hugo-get-heading-slug org-hugo-get-md5)
+# Local Variables:
+# org-export-allow-bind-keywords: t
+# End:

--- a/test/site/content/issues/issue-556.md
+++ b/test/site/content/issues/issue-556.md
@@ -1,0 +1,48 @@
++++
+title = "Issue # 556"
+description = """
+  Test the `org-hugo-get-custom-id` `org-hugo-get-id
+  org-hugo-get-heading-slug` `org-hugo-get-md5` `precedence set in
+  ~org-hugo-anchor-functions`.
+  """
+draft = false
++++
+
+`ox-hugo` Issue #[556](https://github.com/kaushalmodi/ox-hugo/issues/556)
+
+
+## Heading 1 {#heading-1}
+
+This heading's anchor will be derived off the heading string.
+
+
+### Heading 1.1 {#48e6dfd4-93d9-4811-855e-c739470e83d1}
+
+This heading's anchor will be derived off the `ID`.
+
+
+## Heading 2 {#heading-xyz}
+
+This heading's anchor will be derived off the `CUSTOM_ID`.
+
+
+## Heading 3 {#heading-abc}
+
+This heading's anchor will be derived off the `CUSTOM_ID` as that
+takes precedence over the `ID`.
+
+
+### Heading 3.1 {#909536ed-b636-4bb9-9cc6-6a06992d8853}
+
+This heading's anchor will be derived off the `ID`.
+
+
+## Heading 4 {#6bc923a1-3543-440b-ace3-17c049cbbe0a}
+
+This heading's anchor will be derived off the `ID`.
+
+
+## % {#0bcef9}
+
+This heading's anchor will be derived from _md5_ of the title as it is
+not alphanumeric.


### PR DESCRIPTION
Get the id *after* moving the point to the beginning of the element.

Fixes https://github.com/kaushalmodi/ox-hugo/issues/556