### PR TITLE
Auto-inject Bibliography heading if CSL HTML export is enabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           - 'snapshot'
           - '27.2'
           - '26.3'
-          - '25.3'
+          # - '25.3' # citeproc.el throws error on emacs 25.3: https://github.com/andras-simonyi/citeproc-el/issues/102
     # runs-on: ubuntu-latest
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.emacs_version == 'snapshot' }}

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -2571,6 +2571,58 @@ based citation processing to work.
 So make sure that you don't have ~:EXPORT_HUGO_PANDOC_CITATIONS: t~ in
 your post tree or ~#+hugo_pandoc_citations: t~ in your Org file!
 #+end_note
+**** Citation Processor: CSL
+The [[https://citationstyles.org/][Citations Style Language]] (CSL) defines how the citations and
+bibliographies should be exported.
+
+Using CSL is optional, and dependent on an external package
+[[https://github.com/andras-simonyi/citeproc-el][~citeproc.el~]]. By default CSL is not enabled and the citations and
+bibliographies will be exported to Markdown in plain text i.e. without
+any emphasis, hyperlinking, etc.
+
+To enable <<<CSL-formatted exports>>>:
+1. Install ~citeproc~ from [[https://melpa.org/#/citeproc][Melpa]].
+2. Add this to the top of your Org file: ~#+cite_export: csl~
+
+That's it! The Org inbuilt library ~oc-csl.el~ will autoload
+~citeproc~ when it sees that ~#+cite_export~ keyword. With CSL
+processing enabled, the citations and bibliographies will now be
+exported in HTML embedded in the exported Markdown files.
+
+Check out the [[https://blog.tecosaur.com/tmio/2021-07-31-citations.html#using-csl][/This Month in Org/ -- July 2021]] post for more
+information.
+**** Auto-injecting /Bibliography/ heading
+#+begin_mark
+If CSL-formatted exports are enabled
+#+end_mark
+, a Markdown heading named "Bibliography" will be auto-inserted above
+the /bibliography/ section. This section is exported if the Org file
+has {{{relref(~#print_bibliography:~
+keyword,#printing-bibliography)}}}.
+
+This feature is controlled by the ~org-hugo-citations-plist~
+property list variable.
+
+This property list recognizes these properties:
+
+- :bibliography-section-heading :: /(string)/ Heading to insert before
+  the bibliography section.  The default value is "Bibliography". If
+  this property is set to an empty string, the bibliography heading
+  auto-injection is not done.
+
+  Some users might choose to customize this value to
+  "References". Here's an example of how that can be done in the Emacs
+  config:
+  #+name: code__customizing_bibliography_heading
+  #+caption: Customizing bibliography heading
+  #+begin_src emacs-lisp
+  (with-eval-after-load 'ox-hugo
+    (plist-put org-hugo-citations-plist :bibliography-section-heading "References"))
+  #+end_src
+- :bibliography-section-regexp :: /(string)/ Regular expression to
+  find the beginning of the bibliography section.  The default value
+  is a regular expression that matches the ~<div
+  class="csl-bib-body">~ HTML element exported by ~citeproc.el~.
 *** Pandoc Citations
 :PROPERTIES:
 :EXPORT_FILE_NAME: pandoc-citations
@@ -2726,7 +2778,7 @@ Related: [[*Org-Cite Citations][Org-Cite Citations]] | [[https://blog.tecosaur.c
 
 [[https://github.com/jkitchin/org-ref][Org-ref]] citations can be exported to Hugo-compatible markdown via the
 [[https://github.com/andras-simonyi/citeproc-org][citeproc-org]] package. To enable this, simply install ~citeproc-org~
-from MELPA, and run the setup hook. With ~use-package~, this looks
+from Melpa, and run the setup hook. With ~use-package~, this looks
 like:
 
 #+begin_src emacs-lisp

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -83,9 +83,6 @@
 (require 'org-id)                       ;For `org-id-goto'
 (require 'org-agenda)                   ;For `org-find-top-headline'
 
-(require 'citeproc nil :noerror)        ;Load `citeproc' if installed
-(require 'oc-csl nil :noerror)          ;Load `oc-csl' if installed as this registers the `csl' processor
-
 (declare-function org-hugo-pandoc-cite--parse-citations-maybe "ox-hugo-pandoc-cite")
 
 (declare-function org-hugo--return-valid-blackfriday-extension "ox-hugo-deprecated")

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -84,6 +84,7 @@
 (require 'org-agenda)                   ;For `org-find-top-headline'
 
 (require 'citeproc nil :noerror)        ;Load `citeproc' if installed
+(require 'oc-csl nil :noerror)          ;Load `oc-csl' if installed as this registers the `csl' processor
 
 (declare-function org-hugo-pandoc-cite--parse-citations-maybe "ox-hugo-pandoc-cite")
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -577,22 +577,26 @@ Some of the inbuilt functions that can be added to this list:
   :group 'org-export-hugo
   :type '(repeat function))
 
-(defcustom org-hugo-citations-plist '(:bibliography-section-regexp "\n\n\\(.\\|\\n\\)*?<div class=\"csl-bib-body\">"
+(defcustom org-hugo-citations-plist '(:bibliography-section-heading "Bibliography"
+                                      :bibliography-section-regexp "\n\n\\(.\\|\\n\\)*?<div class=\"csl-bib-body\">"
                                       ;;                            ^^^^ blank line before the <div> block
-                                      :bibliography-section-heading "Bibliography")
+                                      )
   "Property list for storing default properties for citation exports.
 
 Properties recognized in the PLIST:
 
-- :bibliography-section-regexp :: Regular expression to mark the
-                                  beginning of Bibliography section.
-
-- :bibliography-section-heading :: Heading to insert before the Bibliography
+- :bibliography-section-heading :: Heading to insert before the bibliography
                                    section.
 
-Auto-detection of Bibliography section requires installing the
+- :bibliography-section-regexp :: Regular expression to find the
+                                  beginning of the bibliography section.
+
+Auto-detection of bibliography section requires installing the
 `citations' package from Melpa and adding `#+cite_export: csl' at
-the top of the Org file."
+the top of the Org file.
+
+If `:bibliography-section-heading' set to an empty string,
+bibliography heading auto-injection is not done."
   :group 'org-export-hugo
   :type '(plist :key-type symbol :value-type string))
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -580,7 +580,8 @@ Some of the inbuilt functions that can be added to this list:
   :group 'org-export-hugo
   :type '(repeat function))
 
-(defcustom org-hugo-citations-plist '(:bibliography-section-regexp "\n.*<div class=\"csl-bib-body\">"
+(defcustom org-hugo-citations-plist '(:bibliography-section-regexp "\n\n\\(.\\|\\n\\)*?<div class=\"csl-bib-body\">"
+                                      ;;                            ^^^^ blank line before the <div> block
                                       :bibliography-section-heading "Bibliography")
   "Property list for storing default properties for citation exports.
 
@@ -1964,7 +1965,7 @@ holding export options."
                (level-mark (make-string (+ loffset 1) ?#)))
           (setq contents (replace-regexp-in-string
                           bib-regexp
-                          (format "\n%s %s\n\\&" level-mark bib-heading) contents)))))
+                          (format "\n\n%s %s\\&" level-mark bib-heading) contents)))))
 
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
     (org-trim (concat

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -83,6 +83,8 @@
 (require 'org-id)                       ;For `org-id-goto'
 (require 'org-agenda)                   ;For `org-find-top-headline'
 
+(require 'citeproc nil :noerror)        ;Load `citeproc' if installed
+
 (declare-function org-hugo-pandoc-cite--parse-citations-maybe "ox-hugo-pandoc-cite")
 
 (declare-function org-hugo--return-valid-blackfriday-extension "ox-hugo-deprecated")

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -275,11 +275,7 @@ Fake current time: 2100/12/21 00:00:00 (arbitrary)."
         nil :nomessage :nosuffix)
 
   (with-eval-after-load 'ox
-    (add-to-list 'org-export-exclude-tags "dont_export_during_make_test")
-    ;; `citeproc.el' throws error on Emacs 25.x
-    ;; https://github.com/andras-simonyi/citeproc-el/issues/102
-    (when (version< emacs-version "26.0")
-      (add-to-list 'org-export-exclude-tags "noexport_emacs25")))
+    (add-to-list 'org-export-exclude-tags "dont_export_during_make_test"))
 
   ;; Wed Sep 04 22:23:03 EDT 2019 - kmodi
   ;; The ox-hugo tests were failing on Travis only on Emacs 24.4 and

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -110,7 +110,7 @@ Emacs installation.  If Emacs is installed using
 (when ox-hugo-test-setup-verbose
   (message "ox-hugo-tmp-dir: %s" ox-hugo-tmp-dir))
 
-(defvar ox-hugo-packages '(toc-org))
+(defvar ox-hugo-packages '(toc-org citeproc))
 (when ox-hugo-install-org-from-elpa
   ;; Fri Sep 22 18:24:19 EDT 2017 - kmodi
   ;; Install the packages in the specified order. We do not want

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -275,7 +275,11 @@ Fake current time: 2100/12/21 00:00:00 (arbitrary)."
         nil :nomessage :nosuffix)
 
   (with-eval-after-load 'ox
-    (add-to-list 'org-export-exclude-tags "dont_export_during_make_test"))
+    (add-to-list 'org-export-exclude-tags "dont_export_during_make_test")
+    ;; `citeproc.el' throws error on Emacs 25.x
+    ;; https://github.com/andras-simonyi/citeproc-el/issues/102
+    (when (version< emacs-version "26.0")
+      (add-to-list 'org-export-exclude-tags "noexport_emacs25")))
 
   ;; Wed Sep 04 22:23:03 EDT 2019 - kmodi
   ;; The ox-hugo tests were failing on Travis only on Emacs 24.4 and

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -157,7 +157,7 @@ Emacs installation.  If Emacs is installed using
                            "http"
                          "https"))
              (melpa-url (concat protocol "://melpa.org/packages/")))
-        (add-to-list 'package-archives (cons "melpa" melpa-url) :append) ;For `toc-org'
+        (add-to-list 'package-archives (cons "melpa" melpa-url) :append) ;For `toc-org', `citeproc'
         )
 
       ;; Delete element with "nongnu" car from `package-archives'.
@@ -196,7 +196,7 @@ to be installed.")
         (setq ox-hugo-missing-packages '())))
   (error "The environment variable OX_HUGO_TMP_DIR needs to be set"))
 
-(require 'org-id)
+(require 'oc-csl nil :noerror)          ;Auto-register csl processor
 (require 'ox-hugo)
 (defun org-hugo-export-all-wim-to-md ()
   (org-hugo-export-wim-to-md :all-subtrees nil nil :noerror))

--- a/test/site/content-org/citation-csl.org
+++ b/test/site/content-org/citation-csl.org
@@ -1,0 +1,23 @@
+#+title: Citation CSL
+
+#+hugo_base_dir: ../
+#+author:
+
+#+bibliography: cite/bib/orgcite.bib
+#+cite_export: csl
+
+#+filetags: org_cite csl citations bibliography
+
+#+macro: oxhugoissue =ox-hugo= Issue #[[https://github.com/kaushalmodi/ox-hugo/issues/$1][$1]]
+
+#+begin_description
+Test citation CSL using ~oc.el~ + ~citeproc.el~.
+#+end_description
+
+{{{oxhugoissue(558)}}}
+
+[cite:@OrgCitations]
+
+Below, the "Bibliography" heading will be auto-inserted.
+
+#+print_bibliography:

--- a/test/site/content-org/citation-csl.org
+++ b/test/site/content-org/citation-csl.org
@@ -6,7 +6,7 @@
 #+bibliography: cite/bib/orgcite.bib
 #+cite_export: csl
 
-#+filetags: org_cite csl citations bibliography noexport_emacs25
+#+filetags: org_cite csl citations bibliography
 
 #+macro: oxhugoissue =ox-hugo= Issue #[[https://github.com/kaushalmodi/ox-hugo/issues/$1][$1]]
 

--- a/test/site/content-org/citation-csl.org
+++ b/test/site/content-org/citation-csl.org
@@ -6,7 +6,7 @@
 #+bibliography: cite/bib/orgcite.bib
 #+cite_export: csl
 
-#+filetags: org_cite csl citations bibliography
+#+filetags: org_cite csl citations bibliography noexport_emacs25
 
 #+macro: oxhugoissue =ox-hugo= Issue #[[https://github.com/kaushalmodi/ox-hugo/issues/$1][$1]]
 

--- a/test/site/content/posts/citation-csl.md
+++ b/test/site/content/posts/citation-csl.md
@@ -1,0 +1,18 @@
++++
+title = "Citation CSL"
+description = "Test citation CSL using `oc.el` + `citeproc.el`."
+tags = ["org-cite", "csl", "citations", "bibliography"]
+draft = false
++++
+
+`ox-hugo` Issue #[558](https://github.com/kaushalmodi/ox-hugo/issues/558)
+
+(<a href="#citeproc_bib_item_1">org et al. 2021</a>)
+
+Below, the "Bibliography" heading will be auto-inserted.
+
+## Bibliography
+
+<style>.csl-entry{text-indent: -1.5em; margin-left: 1.5em;}</style><div class="csl-bib-body">
+  <div class="csl-entry"><a id="citeproc_bib_item_1"></a>org, mode, Citation Syntax, Mailing List, and Time Effort. 2021. “Elegant Citations with Org-Mode.” <i>Journal of Plain Text Formats</i> 42 (1): 2–3.</div>
+</div>

--- a/test/site/content/posts/citation-csl.md
+++ b/test/site/content/posts/citation-csl.md
@@ -1,7 +1,7 @@
 +++
 title = "Citation CSL"
 description = "Test citation CSL using `oc.el` + `citeproc.el`."
-tags = ["org-cite", "csl", "citations", "bibliography", "noexport-emacs25"]
+tags = ["org-cite", "csl", "citations", "bibliography"]
 draft = false
 +++
 

--- a/test/site/content/posts/citation-csl.md
+++ b/test/site/content/posts/citation-csl.md
@@ -1,7 +1,7 @@
 +++
 title = "Citation CSL"
 description = "Test citation CSL using `oc.el` + `citeproc.el`."
-tags = ["org-cite", "csl", "citations", "bibliography"]
+tags = ["org-cite", "csl", "citations", "bibliography", "noexport-emacs25"]
 draft = false
 +++
 


### PR DESCRIPTION
Adds new defcustom `org-hugo-citations-plist`.

Fixes https://github.com/kaushalmodi/ox-hugo/issues/558