### PR TITLE
feat: Now external file links like [[file:foo.org::* Heading]] work

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2119,12 +2119,11 @@ INFO is a plist used as a communication channel."
 	  (cond
        ((equal (org-element-type elem) 'headline)
         (setq anchor (org-hugo--get-anchor elem info)))
-       (t ;This could be the case if `search-str' is a Target link.
-        ;; But I don't know how exactly I would derive a target link's
-        ;; anchor, because for target links, the element type is a
-        ;; `paragraph', and that doesn't have any reference to the
-        ;; `target' Org element.
-        ))
+       (t
+        ;; If current point has an Org Target, get the target anchor.
+        (let ((target-elem (org-element-target-parser)))
+          (when (equal (org-element-type target-elem) 'target)
+            (setq anchor (org-blackfriday--get-target-anchor target-elem))))))
       (when (org-string-nw-p anchor)
         (setq anchor (format "#%s" anchor)))
       ;; (message "[search and get anchor DBG] anchor: %S" anchor)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2098,7 +2098,7 @@ Throw an error if no block contains REF."
 
 ORG-FILE is the file path in which the SEARCH-STR is to be searched.
 
-SEARCH-STR needs to be a non-empty string. Example values: \"*
+SEARCH-STR needs to be a non-empty string.  Example values: \"*
 Some heading\", \"#some_custom_id\".
 
 If the search fails, return \"\".

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -3651,7 +3651,7 @@ links to targets will be resolved to the containing file.
 
 - [[file:issues/issue-556.org::#heading-xyz][Link to CUSTOM_ID]]
 - [[file:issues/issue-556.org::* Heading 3][Link to a heading]]
-- [[file:issues/issue-556.org::paragraph-2][Link to an Org Target]]
+- Links to Org Targets: [[file:issues/issue-556.org::paragraph-2][here]] and [[file:issues/issue-556.org::.paragraph-3][here]]
 *** Internal links                                           :internal_links:
 Internal links point to targets in the current subtree that will be
 exported to the same Hugo post as the link source. To handle links to

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -3649,9 +3649,9 @@ to a heading with a *:CUSTOM_ID* property will be resolved to the
 appropriate location in the linked file. Links to headings and
 links to targets will be resolved to the containing file.
 
-- [[file:link-destination.org::#external-target][Link to CUSTOM_ID]]
-- [[file:link-destination.org::*external-target][Link to a heading]]
-- [[file:link-destination.org::external-target][Link to a target]]
+- [[file:issues/issue-556.org::#heading-xyz][Link to CUSTOM_ID]]
+- [[file:issues/issue-556.org::* Heading 3][Link to a heading]]
+- [[file:issues/issue-556.org::paragraph-2][Link to an Org Target]]
 *** Internal links                                           :internal_links:
 Internal links point to targets in the current subtree that will be
 exported to the same Hugo post as the link source. To handle links to
@@ -3693,19 +3693,19 @@ resolved to the containing post.
 :ID:       8e65ff86-3f9a-48ef-9b43-751a2e8a9372
 :END:
 <<internal target link>>
-*** Link destination
+** Link destination
 :PROPERTIES:
 :CUSTOM_ID: link-destination
 :EXPORT_FILE_NAME: link-destination
 :ID:       1e5e0bcd-caea-40ad-a75b-e488634c2678
 :END:
-**** External target
+*** External target
 :PROPERTIES:
 :CUSTOM_ID: external-target
 :ID:       de0df718-f9b4-4449-bb0a-eb4402fa5fcb
 :END:
 <<external-target>>
-**** External target with *bold* and /italic/
+*** External target with *bold* and /italic/
 ** Url encoding in links                              :escaping:url:encoding:
 :PROPERTIES:
 :EXPORT_FILE_NAME: url-encoding-in-links

--- a/test/site/content-org/issues/issue-542.org
+++ b/test/site/content-org/issues/issue-542.org
@@ -20,6 +20,18 @@ Test links to headings whose anchors are derived from org-id's.
 - [[id:04e97225-6956-4554-b812-ee0e52921c7a][Link]] to a heading that has both CUSTOM_ID and ID set.
 - [[id:909536ed-b636-4bb9-9cc6-6a06992d8853][Link]] to a heading that has only the ID set.
 
+
+- [[file:issue-556.org::* Heading 1][Link]] to a heading without CUSTOM_ID or ID properties.
+- [[file:issue-556.org::* Heading 2][Link]] to a heading with only the CUSTOM_ID property set.
+- [[file:issue-556.org::* Heading 3.1][Link]] to a heading with only the ID property set.
+- [[file:issue-556.org::* Heading 3][Link]] to a heading with both CUSTOM_ID and ID properties set.
+
+
+- [[file:issue-556.org::#heading-abc][Link]] to a heading using CUSTOM_ID where the heading has both
+  CUSTOM_ID and ID properties set.
+- [[file:issue-556.org::#heading-xyz][Link]] to a heading using CUSTOM_ID where the heading has only the
+  CUSTOM_ID property set.
+
 * Local Variables                                          :ARCHIVE:noexport:
 #+bind: org-hugo-anchor-functions (org-hugo-get-custom-id org-hugo-get-id org-hugo-get-heading-slug org-hugo-get-md5)
 # Local Variables:

--- a/test/site/content-org/issues/issue-556.org
+++ b/test/site/content-org/issues/issue-556.org
@@ -1,5 +1,5 @@
 :PROPERTIES:
-:ID:       31c61d47-0afc-4d5c-9b60-6c154a1c518d
+:ID:       68b23d25-827c-49a5-9855-09ac63dc6db3
 :END:
 #+title: Issue # 556
 #+hugo_section: issues

--- a/test/site/content-org/issues/issue-556.org
+++ b/test/site/content-org/issues/issue-556.org
@@ -57,6 +57,9 @@ paragraph one
 <<paragraph-2>>
 paragraph two
 
+<<.paragraph-3>>
+paragraph three
+
 * Local Variables                                          :ARCHIVE:noexport:
 #+bind: org-hugo-anchor-functions (org-hugo-get-custom-id org-hugo-get-id org-hugo-get-heading-slug org-hugo-get-md5)
 # Local Variables:

--- a/test/site/content-org/issues/issue-556.org
+++ b/test/site/content-org/issues/issue-556.org
@@ -51,6 +51,11 @@ This heading's anchor will be derived off the ~ID~.
 * %
 This heading's anchor will be derived from /md5/ of the title as it is
 not alphanumeric.
+* Org Target
+paragraph one
+
+<<paragraph-2>>
+paragraph two
 
 * Local Variables                                          :ARCHIVE:noexport:
 #+bind: org-hugo-anchor-functions (org-hugo-get-custom-id org-hugo-get-id org-hugo-get-heading-slug org-hugo-get-md5)

--- a/test/site/content/issues/issue-542.md
+++ b/test/site/content/issues/issue-542.md
@@ -9,3 +9,17 @@ draft = false
 
 -   [Link]({{< relref "issue-556.md#heading-abc" >}}) to a heading that has both CUSTOM_ID and ID set.
 -   [Link]({{< relref "issue-556.md#909536ed-b636-4bb9-9cc6-6a06992d8853" >}}) to a heading that has only the ID set.
+
+<!--listend-->
+
+-   [Link]({{< relref "issue-556#31c61d47-0afc-4d5c-9b60-6c154a1c518d" >}}) to a heading without CUSTOM_ID or ID properties.
+-   [Link]({{< relref "issue-556#heading-xyz" >}}) to a heading with only the CUSTOM_ID property set.
+-   [Link]({{< relref "issue-556#31c61d47-0afc-4d5c-9b60-6c154a1c518d" >}}) to a heading with only the ID property set.
+-   [Link]({{< relref "issue-556#heading-abc" >}}) to a heading with both CUSTOM_ID and ID properties set.
+
+<!--listend-->
+
+-   [Link]({{< relref "issue-556#heading-abc" >}}) to a heading using CUSTOM_ID where the heading has both
+    CUSTOM_ID and ID properties set.
+-   [Link]({{< relref "issue-556#heading-xyz" >}}) to a heading using CUSTOM_ID where the heading has only the
+    CUSTOM_ID property set.

--- a/test/site/content/issues/issue-542.md
+++ b/test/site/content/issues/issue-542.md
@@ -12,9 +12,9 @@ draft = false
 
 <!--listend-->
 
--   [Link]({{< relref "issue-556#31c61d47-0afc-4d5c-9b60-6c154a1c518d" >}}) to a heading without CUSTOM_ID or ID properties.
+-   [Link]({{< relref "issue-556#heading-1" >}}) to a heading without CUSTOM_ID or ID properties.
 -   [Link]({{< relref "issue-556#heading-xyz" >}}) to a heading with only the CUSTOM_ID property set.
--   [Link]({{< relref "issue-556#31c61d47-0afc-4d5c-9b60-6c154a1c518d" >}}) to a heading with only the ID property set.
+-   [Link]({{< relref "issue-556#909536ed-b636-4bb9-9cc6-6a06992d8853" >}}) to a heading with only the ID property set.
 -   [Link]({{< relref "issue-556#heading-abc" >}}) to a heading with both CUSTOM_ID and ID properties set.
 
 <!--listend-->

--- a/test/site/content/issues/issue-556.md
+++ b/test/site/content/issues/issue-556.md
@@ -47,3 +47,11 @@ This heading's anchor will be derived off the `ID`.
 
 This heading's anchor will be derived from _md5_ of the title as it is
 not alphanumeric.
+
+
+## Org Target {#org-target}
+
+paragraph one
+
+<span class="org-target" id="org-target--paragraph-2"></span>
+paragraph two

--- a/test/site/content/issues/issue-556.md
+++ b/test/site/content/issues/issue-556.md
@@ -55,3 +55,6 @@ paragraph one
 
 <span class="org-target" id="org-target--paragraph-2"></span>
 paragraph two
+
+<span class="org-target" id="paragraph-3"></span>
+paragraph three

--- a/test/site/content/posts/links-outside-the-same-post.md
+++ b/test/site/content/posts/links-outside-the-same-post.md
@@ -16,7 +16,7 @@ links to targets will be resolved to the containing file.
 
 -   [Link to CUSTOM_ID]({{< relref "issue-556#heading-xyz" >}})
 -   [Link to a heading]({{< relref "issue-556#heading-abc" >}})
--   [Link to an Org Target]({{< relref "issue-556" >}})
+-   Links to Org Targets: [here]({{< relref "issue-556#org-target--paragraph-2" >}}) and [here]({{< relref "issue-556#paragraph-3" >}})
 
 
 ## Internal links <span class="tag"><span class="internal_links">internal-links</span></span> {#internal-links}

--- a/test/site/content/posts/links-outside-the-same-post.md
+++ b/test/site/content/posts/links-outside-the-same-post.md
@@ -14,9 +14,9 @@ to a heading with a **:CUSTOM_ID** property will be resolved to the
 appropriate location in the linked file. Links to headings and
 links to targets will be resolved to the containing file.
 
--   [Link to CUSTOM_ID]({{< relref "link-destination#external-target" >}})
--   [Link to a heading]({{< relref "link-destination" >}})
--   [Link to a target]({{< relref "link-destination" >}})
+-   [Link to CUSTOM_ID]({{< relref "issue-556#heading-xyz" >}})
+-   [Link to a heading]({{< relref "issue-556#heading-abc" >}})
+-   [Link to an Org Target]({{< relref "issue-556#d41d8c" >}})
 
 
 ## Internal links <span class="tag"><span class="internal_links">internal-links</span></span> {#internal-links}
@@ -69,14 +69,3 @@ resolved to the containing post.
 ## Internal target {#internal-target}
 
 <span class="org-target" id="org-target--internal-target-link"></span>
-
-
-## Link destination {#link-destination}
-
-
-### External target {#external-target}
-
-<span class="org-target" id="org-target--external-target"></span>
-
-
-### External target with **bold** and _italic_ {#external-target-with-bold-and-italic}

--- a/test/site/content/posts/links-outside-the-same-post.md
+++ b/test/site/content/posts/links-outside-the-same-post.md
@@ -16,7 +16,7 @@ links to targets will be resolved to the containing file.
 
 -   [Link to CUSTOM_ID]({{< relref "issue-556#heading-xyz" >}})
 -   [Link to a heading]({{< relref "issue-556#heading-abc" >}})
--   [Link to an Org Target]({{< relref "issue-556#d41d8c" >}})
+-   [Link to an Org Target]({{< relref "issue-556" >}})
 
 
 ## Internal links <span class="tag"><span class="internal_links">internal-links</span></span> {#internal-links}


### PR DESCRIPTION
Earlier, only [[file:foo.org::#custom_id]] worked.