### PR TITLE
Pass html attr using code block attr

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -532,14 +532,14 @@ style tag."
          (attr-str (org-blackfriday--make-attribute-string attr))
          (ret contents))
     (when (org-string-nw-p attr-str)
-      (let ((class (plist-get attr :class))
+      (let ((first-class (car (split-string (plist-get attr :class))))
             (style-str ""))
-        (when class
+        (when first-class
           (let* ((css-props (org-export-read-attribute :attr_css elem))
                  (css-props-str (org-blackfriday--make-css-property-string css-props)))
             (when (org-string-nw-p css-props-str)
               (setq style-str (format "<style>.%s { %s }</style>\n\n"
-                                      class css-props-str)))))
+                                      first-class css-props-str)))))
 
         (setq ret (concat style-str
                           (if contents

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -509,7 +509,9 @@ those specified classes.
 Returns an empty string if either #+attr_html or #+attr_css are
 not used, or if a class name is not specified in #+attr_html."
   (let* ((html-attr (org-export-read-attribute :attr_html elem))
-         (first-class (car (split-string (plist-get html-attr :class))))
+         (class (plist-get html-attr :class))
+         (first-class (when (stringp class)
+                        (car (split-string class))))
          (style-str ""))
     (when first-class
       (let* ((css-props (org-export-read-attribute :attr_css elem))

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -497,6 +497,28 @@ This function is adapted from `org-html--make-attribute-string'."
                            "\"" "&quot;" (org-html-encode-plain-text item))))
                (setcar ret (format "%s: %s; " key value))))))))
 
+;;;; Get CSS string
+(defun org-blackfriday--get-style-str (elem)
+  "Get HTML style tag string for ELEM.
+
+If #+attr_html is used to specify one or more classes for ELEM
+and if #+attr_css is also used, then an inline style string is
+returned such that it applies the specified CSS to the first of
+those specified classes.
+
+Returns an empty string if either #+attr_html or #+attr_css are
+not used, or if a class name is not specified in #+attr_html."
+  (let* ((html-attr (org-export-read-attribute :attr_html elem))
+         (first-class (car (split-string (plist-get html-attr :class))))
+         (style-str ""))
+    (when first-class
+      (let* ((css-props (org-export-read-attribute :attr_css elem))
+             (css-props-str (org-blackfriday--make-css-property-string css-props)))
+        (when (org-string-nw-p css-props-str)
+          (setq style-str (format "<style>.%s { %s }</style>\n\n"
+                                  first-class css-props-str)))))
+    style-str))
+
 ;;;; Wrap with HTML attributes
 (defun org-blackfriday--div-wrap-maybe (elem contents info)
   "Wrap the CONTENTS with HTML div tags.
@@ -506,46 +528,38 @@ INFO is a plist used as a communication channel.
 The div wrapping is done only if HTML attributes are set for the
 ELEM Org element using #+attr_html.
 
-If #+attr_css is also used, and if a class is specified in
-#+attr_html, then an inline style is also inserted that applies
-the specified CSS to that class.
+If #+attr_css is also used, and if one or more classes are
+specified in #+attr_html, then an inline style is also inserted
+that applies the specified CSS to the first of those specified
+classes.
 
 If CONTENTS is nil, and #+attr_css is used, return only the HTML
 style tag."
   (let* ((elem-type (org-element-type elem))
-         (attr (let ((attr1 (org-export-read-attribute :attr_html elem)))
-                 (when (equal elem-type 'paragraph)
-                   ;; Remove "target" and "rel" attributes from the
-                   ;; list of a paragraph's HTML attributes as they
-                   ;; would be meant for links inside the paragraph
-                   ;; instead of the paragraph itself.
-                   (plist-put attr1 :target nil)
-                   (plist-put attr1 :rel nil)
-                   ;; Remove other attributes from the list of a
-                   ;; paragraph's HTML attributes which would be meant
-                   ;; for the inline images inside that paragraph.
-                   (plist-put attr1 :src nil)
-                   (plist-put attr1 :alt nil)
-                   (plist-put attr1 :height nil)
-                   (plist-put attr1 :width nil))
-                 attr1))
-         (attr-str (org-blackfriday--make-attribute-string attr))
+         (html-attr (let ((attr1 (org-export-read-attribute :attr_html elem)))
+                      (when (equal elem-type 'paragraph)
+                        ;; Remove "target" and "rel" attributes from the
+                        ;; list of a paragraph's HTML attributes as they
+                        ;; would be meant for links inside the paragraph
+                        ;; instead of the paragraph itself.
+                        (plist-put attr1 :target nil)
+                        (plist-put attr1 :rel nil)
+                        ;; Remove other attributes from the list of a
+                        ;; paragraph's HTML attributes which would be meant
+                        ;; for the inline images inside that paragraph.
+                        (plist-put attr1 :src nil)
+                        (plist-put attr1 :alt nil)
+                        (plist-put attr1 :height nil)
+                        (plist-put attr1 :width nil))
+                      attr1))
+         (html-attr-str (org-blackfriday--make-attribute-string html-attr))
          (ret contents))
-    (when (org-string-nw-p attr-str)
-      (let ((first-class (car (split-string (plist-get attr :class))))
-            (style-str ""))
-        (when first-class
-          (let* ((css-props (org-export-read-attribute :attr_css elem))
-                 (css-props-str (org-blackfriday--make-css-property-string css-props)))
-            (when (org-string-nw-p css-props-str)
-              (setq style-str (format "<style>.%s { %s }</style>\n\n"
-                                      first-class css-props-str)))))
-
-        (setq ret (concat style-str
-                          (if contents
-                              (format "<div %s>%s\n\n%s\n</div>"
-                                      attr-str (org-blackfriday--extra-div-hack info) contents))
-                          ""))))
+    (when (org-string-nw-p html-attr-str)
+      (setq ret (concat (org-blackfriday--get-style-str elem)
+                        (if contents
+                            (format "<div %s>%s\n\n%s\n</div>"
+                                    html-attr-str (org-blackfriday--extra-div-hack info) contents))
+                        "")))
     ret))
 
 ;;;; Sanitize URL

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2953,18 +2953,22 @@ nil and,
              (src-code (org-hugo--escape-hugo-shortcode
                         (org-export-format-code-default src-block info)
                         lang))
-             code-attr-str
+             (html-attr (org-export-read-attribute :attr_html src-block))
+             (code-attr-str (org-html--make-attribute-string html-attr))
              src-code-wrap
              ret)
         ;; (message "ox-hugo src [dbg] line-num-p: %S" line-num-p)
         ;; (message "ox-hugo src [dbg] parameters: %S" parameters)
         ;; (message "ox-hugo src [dbg] code refs: %S" code-refs)
+        ;; (message "ox-hugo src [dbg] code-attr-str: %S" code-attr-str)
 
         (when (or linenos-style line-num-p)
           ;; Default "linenos" style set to "table" if linenos-style
           ;; is nil.
           (setq linenos-style (or linenos-style "table"))
-          (setq code-attr-str (format "linenos=%s" linenos-style))
+          (if (org-string-nw-p code-attr-str)
+              (setq code-attr-str (format "%s, linenos=%s" code-attr-str linenos-style))
+            (setq code-attr-str (format "linenos=%s" linenos-style)))
           (let ((linenostart-str (and ;Extract the start line number of the src block
                                   (string-match "\\`\\s-*\\([0-9]+\\)\\s-\\{2\\}" src-code)
                                   (match-string-no-properties 1 src-code))))
@@ -2991,7 +2995,7 @@ nil and,
 
         (unless use-highlight-sc
           (plist-put info :md-code src-code)
-          (plist-put info :md-code-attr code-attr-str))
+          (plist-put info :md-code-attr (org-string-nw-p code-attr-str)))
 
         (setq src-code-wrap
               (if use-highlight-sc
@@ -3002,10 +3006,8 @@ nil and,
                             lang hl-attr src-code))
                 (org-blackfriday-src-block src-block nil info)))
 
-        (setq ret (org-blackfriday--div-wrap-maybe
-                   src-block
-                   (concat src-anchor src-code-wrap caption-html)
-                   info))
+        (setq ret (concat (org-blackfriday--get-style-str src-block)
+                          src-anchor src-code-wrap caption-html))
         ret)))))
 
 ;;;; Special Block

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2012,6 +2012,23 @@ Some text.
 #+end_src
 
 Some more text.
+
+#+attr_css: :color blue
+#+attr_html: :class blue w-40
+#+begin_src goat
+┌─────┐       ┌───┐
+│Alice│       │Bob│
+└──┬──┘       └─┬─┘
+   │            │
+   │ Hello Bob! │
+   │───────────>│
+   │            │
+   │Hello Alice!│
+   │<───────────│
+┌──┴──┐       ┌─┴─┐
+│Alice│       │Bob│
+└─────┘       └───┘
+#+end_src
 ** Coderef                                 :coderef:annotation:example_block:
 :PROPERTIES:
 :EXPORT_FILE_NAME: coderef

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2300,7 +2300,7 @@ Line 3
 
 Some more text.
 
-#+attr_html: :class heavy
+#+attr_html: :class heavy :title some code block
 #+attr_css: :font-weight bold
 #+begin_example -n
 This is an example

--- a/test/site/content/posts/example-blocks-with-attr-html.md
+++ b/test/site/content/posts/example-blocks-with-attr-html.md
@@ -8,24 +8,18 @@ Some text.
 
 <style>.indent-block { padding-left: 50px;  }</style>
 
-<div class="indent-block">
-
-```text
+```text { class="indent-block" }
 This is an example
 Line 2
 Line 3
 ```
-</div>
 
 Some more text.
 
 <style>.heavy { font-weight: bold;  }</style>
 
-<div class="heavy">
-
-```text { linenos=table, linenostart=1 }
+```text { class="heavy" title="some code block", linenos=table, linenostart=1 }
 This is an example
 Line 2
 Line 3
 ```
-</div>

--- a/test/site/content/posts/org-babel-results.md
+++ b/test/site/content/posts/org-babel-results.md
@@ -75,9 +75,7 @@ echo "ABC\nDEF\nGHI\nJKL\nMNO\nPQR\nSTU\nVWX\nYZ0\n123\n456\n789"
 
 <style>.results-example-block { color: green;  }</style>
 
-<div class="results-example-block">
-
-```text
+```text { class="results-example-block" }
 ABC
 DEF
 GHI
@@ -91,6 +89,5 @@ YZ0
 456
 789
 ```
-</div>
 
 Above results block will be in <span class="underline">green</span> text.

--- a/test/site/content/posts/source-blocks-with-attr-html.md
+++ b/test/site/content/posts/source-blocks-with-attr-html.md
@@ -8,13 +8,27 @@ Some text.
 
 <style>.indent-block { padding-left: 50px;  }</style>
 
-<div class="indent-block">
-
-```emacs-lisp
+```emacs-lisp { class="indent-block" }
 (message (mapconcat #'identity
                     '("Hello," "how" "are" "you?")
                     " "))
 ```
-</div>
 
 Some more text.
+
+<style>.blue { color: blue;  }</style>
+
+```goat { class="blue w-40" }
+┌─────┐       ┌───┐
+│Alice│       │Bob│
+└──┬──┘       └─┬─┘
+   │            │
+   │ Hello Bob! │
+   │───────────>│
+   │            │
+   │Hello Alice!│
+   │<───────────│
+┌──┴──┐       ┌─┴─┐
+│Alice│       │Bob│
+└─────┘       └───┘
+```


### PR DESCRIPTION
If `#+attr_html:` is used above src blocks to specify the HTML attributes for that block, pass those to the code block within the curly braces for attributes.

Before:

````html
<div <HTML_ATTR>>

```LANG
CODE
```

</div>
````

Now:

````html
```LANG { <HTML_ATTR> }
CODE
```
````
