### PR TITLE
Add multi-lang support for Bibliography/References heading

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -1718,6 +1718,9 @@ See the [[https://orgmode.org/manual/Table-of-Contents.html][Table of Contents]]
 /Note that =ox-hugo= does not support =#+toc: listings= and =#+toc:
 tables=./
 **** "Table of Contents" heading
+:PROPERTIES:
+:CUSTOM_ID: toc-heading
+:END:
 The "Table of Contents" heading is inserted as a plain HTML ~div~
 element. Users can customize the looks of that ~div~ by setting CSS
 rules for ~.ox-hugo-toc .heading~.
@@ -2583,6 +2586,9 @@ exported in HTML embedded in the exported Markdown files.
 Check out the [[https://blog.tecosaur.com/tmio/2021-07-31-citations.html#using-csl][/This Month in Org/ -- July 2021]] post for more
 information.
 **** Auto-inserting /Bibliography/ heading
+:PROPERTIES:
+:CUSTOM_ID: bibliography-heading
+:END:
 #+begin_mark
 If CSL-formatted exports are enabled
 #+end_mark
@@ -4081,6 +4087,29 @@ This special feature allows you to create an HTML anchor anywhere in
 your document which you might then refer from a different post by
 using something like the {{{relref(~relref~ Org
 macro,shortcodes#relref-org-macro)}}}.
+*** Multi-lingual Support
+:PROPERTIES:
+:EXPORT_FILE_NAME: multi-lingual-support
+:END:
+#+begin_description
+Support for translation of some ~ox-hugo~ inserted strings based on
+~org-export-translate~ machinery designed in ~ox.el~.
+#+end_description
+~ox-hugo~ relies on the ~org-export-dictionary~ variable from the core
+Org Export library ~ox.el~ to derive translated strings for these:
+
+- Source block caption prefix /"Code Snippet"/
+- Figure caption prefix /"Figure"/
+- Table caption prefix /"Table"/
+- Table of contents {{{titleref(Table of
+  Contents#toc-heading,heading)}}} /"Table of Contents"/
+- Bibliography {{{titleref(Org Cite
+  Citations#bibliography-heading,heading)}}} /"References"/
+
+The translation language is detected from the ~#+language:~ keyword
+present in the Org file or the ~:EXPORT_LANGUAGE:~ property in the
+post subtree. For reference, see [[https://orgmode.org/manual/Export-Settings.html#index-LANGUAGE_002c-keyword][~LANGUAGE~ in the Export Settings]]
+section of the Org manual.
 ** Meta
 :PROPERTIES:
 :EXPORT_HUGO_MENU: :menu "7.meta"

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -2586,7 +2586,7 @@ information.
 #+begin_mark
 If CSL-formatted exports are enabled
 #+end_mark
-, a Markdown heading named "Bibliography" will be auto-inserted above
+, a Markdown heading named "References" will be auto-inserted above
 the /bibliography/ section. This section is exported if the Org file
 has {{{relref(~#print_bibliography:~
 keyword,#printing-bibliography)}}}.
@@ -2600,20 +2600,20 @@ property list variable.
 This property list recognizes these properties:
 
 - :bibliography-section-heading :: /(string)/ Heading to insert before
-  the bibliography section.  The default value is "Bibliography".
+  the bibliography section.  The default value is "References".
 
   Some users might choose to customize this value to
-  "References". Here's an example of how that can be done in the Emacs
-  config:
+  "Bibliography". Here's an example of how that can be done in the
+  Emacs config:
   #+name: code__customizing_bibliography_heading
   #+caption: Customizing bibliography heading
   #+begin_src emacs-lisp
   (with-eval-after-load 'ox-hugo
-    (plist-put org-hugo-citations-plist :bibliography-section-heading "References"))
+    (plist-put org-hugo-citations-plist :bibliography-section-heading "Bibliography"))
   #+end_src
 
-  If this property is set to an empty string, the bibliography heading
-  auto-insertion is not done.
+  If this property is set to an empty string, this heading will not be
+  auto-inserted.
   #+name: code__bibliography_no_heading
   #+caption: Disabling bibliography heading insertion
   #+begin_src emacs-lisp
@@ -2644,7 +2644,7 @@ Minimal example with ~org-cite~ citations:
 
 [cite:@SomeCitation]
 
-Below, the "Bibliography" heading will be auto-inserted.
+Below, the "References" heading will be auto-inserted.
 
 #+print_bibliography:
 #+end_src
@@ -2675,7 +2675,7 @@ that."
     (add-to-list 'org-export-before-parsing-hook #'my/org-ref-process-buffer--html)))
 #+end_src
 **** Auto-inserting /Bibliography/ heading
-A Markdown heading named "Bibliography" will be auto-inserted above
+A Markdown heading named "References" will be auto-inserted above
 the ~org-ref~ ~[[bibliography:..]]~ link, which is typically present
 at the end of a post.
 
@@ -2694,7 +2694,7 @@ Minimal example with ~org-ref~ citations:
 
 [[cite:&SomeCitation]]
 
-Below, the "Bibliography" heading will be auto-inserted.
+Below, the "References" heading will be auto-inserted.
 
 [[bibliography:/path/to/file.bib]]
 #+end_src

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -583,7 +583,7 @@ Some of the inbuilt functions that can be added to this list:
   :group 'org-export-hugo
   :type '(repeat function))
 
-(defcustom org-hugo-citations-plist '(:bibliography-section-heading "Bibliography"
+(defcustom org-hugo-citations-plist '(:bibliography-section-heading "References"
                                       :bibliography-section-regexp "\n\n<style>\\(.\\|\n\\)*?<div class=\"csl-bib-body\">"
                                       ;;                            ^^^^ blank line before the <style> ..
                                       ;;                                          .. <div class="csl-bib-body"> block

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1969,7 +1969,8 @@ holding export options."
     ;; Auto-inject Bibliography heading.
     (let ((bib-heading (org-string-nw-p (plist-get org-hugo-citations-plist :bibliography-section-heading))))
       (when (and bib-heading (featurep 'citeproc))
-        (let* ((bib-regexp (plist-get org-hugo-citations-plist :bibliography-section-regexp))
+        (let* ((bib-heading (org-blackfriday--translate nil info bib-heading))
+               (bib-regexp (plist-get org-hugo-citations-plist :bibliography-section-regexp))
                (loffset (string-to-number
                          (or (org-entry-get nil "EXPORT_HUGO_LEVEL_OFFSET" :inherit)
                              (plist-get info :hugo-level-offset))))

--- a/test/site/content-org/citation-csl.org
+++ b/test/site/content-org/citation-csl.org
@@ -20,7 +20,7 @@ Test citation CSL using ~oc.el~ + ~citeproc.el~.
 
 [cite:@AdaptiveVNF]
 
-Below, the "Bibliography" heading will be auto-inserted.
+Below, the "References" heading will be auto-inserted.
 
 #+print_bibliography:
 

--- a/test/site/content-org/citation-csl.org
+++ b/test/site/content-org/citation-csl.org
@@ -10,6 +10,10 @@
 
 #+macro: oxhugoissue =ox-hugo= Issue #[[https://github.com/kaushalmodi/ox-hugo/issues/$1][$1]]
 
+* Citation CSL
+:PROPERTIES:
+:EXPORT_FILE_NAME: citation-csl
+:END:
 #+begin_description
 Test citation CSL using ~oc.el~ + ~citeproc.el~.
 #+end_description
@@ -23,7 +27,26 @@ Test citation CSL using ~oc.el~ + ~citeproc.el~.
 Below, the "References" heading will be auto-inserted.
 
 #+print_bibliography:
+* Citation CSL (Turkish)                                           :language:
+:PROPERTIES:
+:EXPORT_FILE_NAME: citation-csl-tr
+:EXPORT_LANGUAGE: tr
+:END:
+#+begin_description
+Test auto-translated Bibliography heading insertion for citations
+using ~oc.el~ + ~citeproc.el~.
+#+end_description
 
+{{{oxhugoissue(574)}}}
+
+[cite:@OrgCitations]
+
+Below, the ~#+language:~ keyword or ~:EXPORT_LANGUAGE:~ set language
+will be used to translate "References" and that heading will be
+auto-inserted.
+
+#+print_bibliography:
+* Local Variables                                                   :ARCHIVE:
 # Local Variables:
 # org-cite-csl-styles-dir: "./cite/csl/"
 # End:

--- a/test/site/content/posts/citation-csl-tr.md
+++ b/test/site/content/posts/citation-csl-tr.md
@@ -1,0 +1,26 @@
++++
+title = "Citation CSL (Turkish)"
+description = """
+  Test auto-translated Bibliography heading insertion for citations
+  using `oc.el` + `citeproc.el`.
+  """
+tags = ["org-cite", "csl", "citations", "bibliography", "language"]
+draft = false
++++
+
+`ox-hugo` Issue #[574](https://github.com/kaushalmodi/ox-hugo/issues/574)
+
+<a href="#citeproc_bib_item_1">[1]</a>
+
+Below, the `#+language:` keyword or `:EXPORT_LANGUAGE:` set language
+will be used to translate "References" and that heading will be
+auto-inserted.
+
+## Referanslar
+
+<style>.csl-left-margin{float: left; padding-right: 0em;}
+ .csl-right-inline{margin: 0 0 0 1em;}</style><div class="csl-bib-body">
+  <div class="csl-entry"><a id="citeproc_bib_item_1"></a>
+    <div class="csl-left-margin">[1]</div><div class="csl-right-inline">m. org, C. Syntax, M. List, and T. Effort, “Elegant citations with org-mode,” <i>Journal of plain text formats</i>, vol. 42, no. 1, pp. 2–3, 2021.</div>
+  </div>
+</div>

--- a/test/site/content/posts/citation-csl.md
+++ b/test/site/content/posts/citation-csl.md
@@ -11,9 +11,9 @@ draft = false
 
 <a href="#citeproc_bib_item_2">[2]</a>
 
-Below, the "Bibliography" heading will be auto-inserted.
+Below, the "References" heading will be auto-inserted.
 
-## Bibliography
+## References
 
 <style>.csl-left-margin{float: left; padding-right: 0em;}
  .csl-right-inline{margin: 0 0 0 1em;}</style><div class="csl-bib-body">

--- a/test/site/content/posts/citation-org-ref.md
+++ b/test/site/content/posts/citation-org-ref.md
@@ -9,7 +9,7 @@ draft = false
 
 (<a href="#citeproc_bib_item_1">Org et al., 2021</a>)
 
-## Bibliography
+## References
 
 <style>.csl-entry{text-indent: -1.5em; margin-left: 1.5em;}</style><div class="csl-bib-body">
   <div class="csl-entry"><a id="citeproc_bib_item_1"></a>org, m., Syntax, C., List, M., &#38; Effort, T. (2021). Elegant citations with org-mode. <i>Journal of Plain Text Formats</i>, <i>42</i>(1), 2–3.</div>


### PR DESCRIPTION
The "References" string is consistent with the dictionary key
available in `org-export-dictionary` in ox.el, and also the default
heading used in `org-hugo-pandoc-cite-references-heading`.