### PR TITLE
Improve inline src blocks

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2452,7 +2452,7 @@ Escape Hugo shortcodes if present in this element's value."
                 (org-element-property :value inline-src-block)
                 lang)))
     (org-element-put-property inline-src-block :value code)
-    (org-md-verbatim inline-src-block nil nil)))
+    (format "<code class=\"inline-src language-%s\" data-lang=\"%s\">%s</code>" lang lang code)))
 
 ;;;; Keyword
 (defun org-hugo-keyword (keyword contents info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2444,8 +2444,15 @@ holding export options."
 
 ;;;; Inline Src Block
 (defun org-hugo-inline-src-block (inline-src-block _contents _info)
-  "Transcode INLINE-SRC-BLOCK object into Hugo-compatible Markdown format."
-  (org-md-verbatim inline-src-block nil nil))
+  "Transcode INLINE-SRC-BLOCK object into Hugo-compatible Markdown format.
+
+Escape Hugo shortcodes if present in this element's value."
+  (let* ((lang (org-element-property :language inline-src-block))
+         (code (org-hugo--escape-hugo-shortcode
+                (org-element-property :value inline-src-block)
+                lang)))
+    (org-element-put-property inline-src-block :value code)
+    (org-md-verbatim inline-src-block nil nil)))
 
 ;;;; Keyword
 (defun org-hugo-keyword (keyword contents info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2444,7 +2444,7 @@ holding export options."
 
 ;;;; Inline Src Block
 (defun org-hugo-inline-src-block (inline-src-block _contents _info)
-  "Transcode INLINE-SRC-BLOCK object into Hugo-compatible Markdown format.
+  "Transcode INLINE-SRC-BLOCK object into HTML.
 
 Escape Hugo shortcodes if present in this element's value."
   (let* ((lang (org-element-property :language inline-src-block))
@@ -2452,7 +2452,8 @@ Escape Hugo shortcodes if present in this element's value."
                 (org-element-property :value inline-src-block)
                 lang)))
     (org-element-put-property inline-src-block :value code)
-    (format "<code class=\"inline-src language-%s\" data-lang=\"%s\">%s</code>" lang lang code)))
+    (format "<code class=\"inline-src language-%s\" data-lang=\"%s\">%s</code>"
+            lang lang code)))
 
 ;;;; Keyword
 (defun org-hugo-keyword (keyword contents info)

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2164,6 +2164,12 @@ src_emacs-lisp[:exports none]{(message "Hello 4")} {{{results(=Hello 4=)}}}
 - md :: src_md[:exports code]{{{< some_shortcode "foo" >}}}
 - org :: src_org[:exports code]{{{% some_shortcode "foo" %}}}
 - go-html-template :: src_go-html-template[:exports code]{{{< some_shortcode "foo" >}}}
+** COMMENT Wrapping inline source block in a list item
+As of <2022-03-01 Tue>, below snippet exports incorrectly due to a bug
+in Org element parsing in Org mode. The issue was [[https://lists.gnu.org/r/emacs-orgmode/2022-03/msg00008.html][reported on the
+mailing list today]].
+- abcdefg abcdefg abcdefg abcdefg src_org[:exports code]{[[abc
+  def][bar]]}.
 * Formatting                                                     :formatting:
 ** General
 :PROPERTIES:

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2164,6 +2164,38 @@ src_emacs-lisp[:exports none]{(message "Hello 4")} {{{results(=Hello 4=)}}}
 - md :: src_md[:exports code]{{{< some_shortcode "foo" >}}}
 - org :: src_org[:exports code]{{{% some_shortcode "foo" %}}}
 - go-html-template :: src_go-html-template[:exports code]{{{< some_shortcode "foo" >}}}
+** Using custom CSS for inline src blocks
+{{{oxhugoissue(638)}}}
+
+CSS used here:
+#+begin_src html :noweb-ref inline_src_css
+<style>
+    code.inline-src.language-nim::before {
+        color: initial;
+        content: "｢";
+    }
+    code.inline-src.language-nim::after {
+        color: initial;
+        content: "｣";
+    }
+</style>
+#+end_src
+
+#+begin_export html
+<style>
+    code.inline-src.language-nim::before {
+        color: initial;
+        content: "｢";
+    }
+    code.inline-src.language-nim::after {
+        color: initial;
+        content: "｣";
+    }
+</style>
+#+end_export
+
+In Nim, src_nim[:exports code]{echo "hello"} will print
+{{{results(/hello/)}}}.
 ** COMMENT Wrapping inline source block in a list item
 As of <2022-03-01 Tue>, below snippet exports incorrectly due to a bug
 in Org element parsing in Org mode. The issue was [[https://lists.gnu.org/r/emacs-orgmode/2022-03/msg00008.html][reported on the

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2160,6 +2160,10 @@ src_emacs-lisp[:exports both]{(message "Hello 3")} {{{results(=Hello 3=)}}}
 src_emacs-lisp[:exports none]{(message "Hello 4")}
 #+end_src
 src_emacs-lisp[:exports none]{(message "Hello 4")} {{{results(=Hello 4=)}}}
+** Escape Hugo shortcodes
+- md :: src_md[:exports code]{{{< some_shortcode "foo" >}}}
+- org :: src_org[:exports code]{{{% some_shortcode "foo" %}}}
+- go-html-template :: src_go-html-template[:exports code]{{{< some_shortcode "foo" >}}}
 * Formatting                                                     :formatting:
 ** General
 :PROPERTIES:

--- a/test/site/content/posts/inline-code-blocks.md
+++ b/test/site/content/posts/inline-code-blocks.md
@@ -48,3 +48,15 @@ src_emacs-lisp[:exports both]{(message "Hello 3")}
 ```org
 src_emacs-lisp[:exports none]{(message "Hello 4")}
 ```
+
+
+## Escape Hugo shortcodes {#escape-hugo-shortcodes}
+
+md
+: `{{</* some_shortcode "foo" */>}}`
+
+org
+: `{{%/* some_shortcode "foo" */%}}`
+
+go-html-template
+: `{{</* some_shortcode "foo" */>}}`

--- a/test/site/content/posts/inline-code-blocks.md
+++ b/test/site/content/posts/inline-code-blocks.md
@@ -31,7 +31,7 @@ src_emacs-lisp[:exports results]{(message "Hello 1")}
 src_emacs-lisp[:exports code]{(message "Hello 2")}
 ```
 
-`(message "Hello 2")`
+<code class="inline-src language-emacs-lisp" data-lang="emacs-lisp">(message "Hello 2")</code>
 
 
 ## Both code and results {#both-code-and-results}
@@ -40,7 +40,7 @@ src_emacs-lisp[:exports code]{(message "Hello 2")}
 src_emacs-lisp[:exports both]{(message "Hello 3")}
 ```
 
-`(message "Hello 3")` `Hello 3`
+<code class="inline-src language-emacs-lisp" data-lang="emacs-lisp">(message "Hello 3")</code> `Hello 3`
 
 
 ## None! {#none}
@@ -53,10 +53,44 @@ src_emacs-lisp[:exports none]{(message "Hello 4")}
 ## Escape Hugo shortcodes {#escape-hugo-shortcodes}
 
 md
-: `{{</* some_shortcode "foo" */>}}`
+: <code class="inline-src language-md" data-lang="md">{{</* some_shortcode "foo" */>}}</code>
 
 org
-: `{{%/* some_shortcode "foo" */%}}`
+: <code class="inline-src language-org" data-lang="org">{{%/* some_shortcode "foo" */%}}</code>
 
 go-html-template
-: `{{</* some_shortcode "foo" */>}}`
+: <code class="inline-src language-go-html-template" data-lang="go-html-template">{{</* some_shortcode "foo" */>}}</code>
+
+
+## Using custom CSS for inline src blocks {#using-custom-css-for-inline-src-blocks}
+
+`ox-hugo` Issue #[638](https://github.com/kaushalmodi/ox-hugo/issues/638)
+
+CSS used here:
+
+```html
+<style>
+    code.inline-src.language-nim::before {
+        color: initial;
+        content: "｢";
+    }
+    code.inline-src.language-nim::after {
+        color: initial;
+        content: "｣";
+    }
+</style>
+```
+
+<style>
+    code.inline-src.language-nim::before {
+        color: initial;
+        content: "｢";
+    }
+    code.inline-src.language-nim::after {
+        color: initial;
+        content: "｣";
+    }
+</style>
+
+In Nim, <code class="inline-src language-nim" data-lang="nim">echo "hello"</code> will print
+_hello_.


### PR DESCRIPTION
- Auto-escape Hugo shortcodes
- Exports HTML `code` elements with classes instead of plain Markdown code. This allows the user to style the inline src code differently using CSS -- Fixes https://github.com/kaushalmodi/ox-hugo/issues/638.