### PR TITLE
Source blocks with line numbers: Change `linenos` value to `true`

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -1215,15 +1215,23 @@ number annotation" test case in the {{{ox-hugo-test-file}}}.
 :PROPERTIES:
 :CUSTOM_ID: linenos
 :END:
-When line numbers are enabled, by default the "table" style is used
-for line numbers. This is specified using the [[https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode][=linenos= argument to
-the =highlight= shortcode]].
+The value of ~linenos~ (Hugo's default value or the site-global value
+set in its ~config.toml~) can be overridden per source block using the
+~:linenos~ parameter in that source block's header.
 
-This default can be overridden using the =:linenos= parameter in the
-source block header.
+#+name: tab__linenos_values
+#+caption: Possible values of ~:linenos~
+|------------------+-----------------------------------------------------------------------------------------------------|
+| ~:linenos~ value | Description                                                                                         |
+|------------------+-----------------------------------------------------------------------------------------------------|
+| ~false~          | Disable line numbers.                                                                               |
+| ~true~           | Enable line numbers with Hugo's default value of [[https://gohugo.io/functions/highlight/#options][~lineNumbersInTable~]].                              |
+| ~inline~         | Enable line numbers where the line numbers and code are rendered in HTML ~<div>~ and ~<span>~ tags. |
+| ~table~          | Enable line numbers where the line numbers and code are rendered in HTML tables.                    |
+|------------------+-----------------------------------------------------------------------------------------------------|
 
 *Example usage*: If a user has enabled the line numbers by default by
-using something like this in the site's =config.toml=:
+adding this in their site's =config.toml=:
 
 #+begin_src toml
 [markup]
@@ -1231,8 +1239,8 @@ using something like this in the site's =config.toml=:
     lineNos = true
 #+end_src
 
-, they can disable printing of line numbers for selected source blocks
-by adding =:linenos false= to their headers.
+, they can disable line numbers for selected source blocks by adding
+~:linenos false~ to their headers.
 
 #+begin_src org
 ,#+begin_src emacs-lisp :linenos false
@@ -1241,10 +1249,37 @@ by adding =:linenos false= to their headers.
 ,#+end_src
 #+end_src
 
-- Valid values of ~linenos~ :: ~table~ (default), ~true~, ~false~,
-  ~inline~
+/The ~:linenos~ header arg works for example blocks too./
+***** Line numbers in HTML table
+The source block or code block rendering is done by Hugo using the
+[[https://github.com/alecthomas/chroma][chroma]] syntax highlighter. When the line numbers are enabled, the line
+numbers and code blocks can be rendered either in HTML tables
+(~lineNumbersInTable = true~) or in the ~div~ and ~span~ tags
+(~lineNumbersInTable = false~). See Hugo's default value of this
+config variable [[https://gohugo.io/getting-started/configuration-markup#highlight][here]].
 
-/The same =:linenos= header arg works for example blocks too./
+To render the line numbers and code blocks in HTML tables regardless
+of Hugo's default value, add this to your site's ~config.toml~:
+
+#+name: code__line_numbers_in_table
+#+caption: Render line numbers and code blocks in HTML tables
+#+begin_src conf-toml
+[markup]
+  [markup.highlight]
+    lineNumbersInTable = true
+#+end_src
+
+Similarly, to override the rendering of line numbers and code blocks
+to happen in ~<div>~ and ~<span>~ tags, add this to your site's
+~config.toml~:
+
+#+name: code__line_numbers_in_divs_and_spans
+#+caption: Render line numbers and code blocks in HTML ~<div>~ and ~<span>~ tags
+#+begin_src conf-toml
+[markup]
+  [markup.highlight]
+    lineNumbersInTable = false
+#+end_src
 **** Highlight Lines
 Implementing this feature was interesting, because while Org doesn't
 have a syntax to enable highlighting only specific lines, Hugo

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2847,7 +2847,7 @@ nil), and if any of these is true:
   - Highlight certains lines in the code block (if the :hl_lines
     parameter is used).
   - Set the `linenos' argument to the value passed by :linenos
-    (defaults to `table').
+    (defaults to `true').
   - Coderefs are used.
 
 Note: If using a Hugo version older than v0.60.0, the user
@@ -2957,9 +2957,8 @@ their Hugo site's config."
             (setq code-attr-str (org-html--make-attribute-string html-attr))))
 
         (when (or linenos-style line-num-p)
-          ;; Default "linenos" style set to "table" if linenos-style
-          ;; is nil.
-          (setq linenos-style (or linenos-style "table"))
+          ;; Set "linenos" to "true" if linenos-style is nil.
+          (setq linenos-style (or linenos-style "true"))
           (if (org-string-nw-p code-attr-str)
               (setq code-attr-str (format "%s, linenos=%s" code-attr-str linenos-style))
             (setq code-attr-str (format "linenos=%s" linenos-style)))

--- a/test/site/content/posts/coderef.md
+++ b/test/site/content/posts/coderef.md
@@ -25,7 +25,7 @@ parenthesis.
 
 ### Default line nums with coderef labels {#default-line-nums-with-coderef-labels}
 
-```emacs-lisp { linenos=table, anchorlinenos=true, lineanchors=org-coderef--c1cbed }
+```emacs-lisp { linenos=true, anchorlinenos=true, lineanchors=org-coderef--c1cbed }
 (save-excursion                 (sc)
    (goto-char (point-min))      (jump)
 ```
@@ -36,7 +36,7 @@ point-min.
 
 ### Default line nums without coderef labels {#default-line-nums-without-coderef-labels}
 
-```emacs-lisp { linenos=table, anchorlinenos=true, lineanchors=org-coderef--ea1413 }
+```emacs-lisp { linenos=true, anchorlinenos=true, lineanchors=org-coderef--ea1413 }
 (save-excursion
    (goto-char (point-min))
 ```
@@ -47,7 +47,7 @@ point-min.
 
 ### Custom line nums without coderef labels {#custom-line-nums-without-coderef-labels}
 
-```emacs-lisp { linenos=table, linenostart=20, anchorlinenos=true, lineanchors=org-coderef--cc4270 }
+```emacs-lisp { linenos=true, linenostart=20, anchorlinenos=true, lineanchors=org-coderef--cc4270 }
 (save-excursion
    (goto-char (point-min))
 ```
@@ -58,7 +58,7 @@ point-min.
 
 ### Custom line nums without coderef labels and with highlighting {#custom-line-nums-without-coderef-labels-and-with-highlighting}
 
-```emacs-lisp { linenos=table, linenostart=20, hl_lines=["2"], anchorlinenos=true, lineanchors=org-coderef--a1ac71 }
+```emacs-lisp { linenos=true, linenostart=20, hl_lines=["2"], anchorlinenos=true, lineanchors=org-coderef--a1ac71 }
 (save-excursion
    (goto-char (point-min))
 ```
@@ -71,7 +71,7 @@ point-min.
 In line [1](#org-coderef--4489bc-1) we remember the current position. [Line 2](#org-coderef--4489bc-2) jumps to
 point-min.
 
-```emacs-lisp { linenos=table, anchorlinenos=true, lineanchors=org-coderef--4489bc }
+```emacs-lisp { linenos=true, anchorlinenos=true, lineanchors=org-coderef--4489bc }
 (save-excursion
    (goto-char (point-min))
 ```
@@ -79,7 +79,7 @@ point-min.
 
 ## Example block {#example-block}
 
-```text { linenos=table, linenostart=20, anchorlinenos=true, lineanchors=org-coderef--942ea6 }
+```text { linenos=true, linenostart=20, anchorlinenos=true, lineanchors=org-coderef--942ea6 }
 (save-excursion
    (goto-char (point-min))
 ```

--- a/test/site/content/posts/example-block-with-line-numbers.md
+++ b/test/site/content/posts/example-block-with-line-numbers.md
@@ -9,7 +9,7 @@ draft = false
 
 ## Default new line number start {#default-new-line-number-start}
 
-```text { linenos=table, linenostart=1 }
+```text { linenos=true, linenostart=1 }
 line 1
  line 2
 ```
@@ -24,7 +24,7 @@ bar
 
 ## Specify new line number start {#specify-new-line-number-start}
 
-```text { linenos=table, linenostart=20 }
+```text { linenos=true, linenostart=20 }
 line 20
 line 21
 ```
@@ -32,7 +32,7 @@ line 21
 
 ## Default continued line numbers {#default-continued-line-numbers}
 
-```text { linenos=table, linenostart=22 }
+```text { linenos=true, linenostart=22 }
  line 22
 line 23
 ```
@@ -40,7 +40,7 @@ line 23
 
 ## Specify continued line numbers jump {#specify-continued-line-numbers-jump}
 
-```text { linenos=table, linenostart=33 }
+```text { linenos=true, linenostart=33 }
 line 33
 line 34
 ```

--- a/test/site/content/posts/example-blocks-with-attr-html-blackfriday.md
+++ b/test/site/content/posts/example-blocks-with-attr-html-blackfriday.md
@@ -25,7 +25,7 @@ Some more text.
 <div class="heavy">
   <div></div>
 
-{{< highlight text "linenos=table, linenostart=1" >}}
+{{< highlight text "linenos=true, linenostart=1" >}}
 This is an example
 Line 2
 Line 3

--- a/test/site/content/posts/example-blocks-with-attr-html.md
+++ b/test/site/content/posts/example-blocks-with-attr-html.md
@@ -18,7 +18,7 @@ Some more text.
 
 <style>.heavy { font-weight: bold;  }</style>
 
-```text { class="heavy" title="some code block", linenos=table, linenostart=1 }
+```text { class="heavy" title="some code block", linenos=true, linenostart=1 }
 This is an example
 Line 2
 Line 3

--- a/test/site/content/posts/source-block-indented.md
+++ b/test/site/content/posts/source-block-indented.md
@@ -97,34 +97,34 @@ there.
 
 -   List item 1
 
-    ```emacs-lisp { linenos=table, linenostart=1 }
+    ```emacs-lisp { linenos=true, linenostart=1 }
     (message "I am in list at level-1 indentation")
     ```
 
     -   List item 1.1
 
-        ```emacs-lisp { linenos=table, linenostart=1 }
+        ```emacs-lisp { linenos=true, linenostart=1 }
         (message "I am in list at level-2 indentation")
         ```
 
         -   List item 1.1.1
 
-            ```emacs-lisp { linenos=table, linenostart=1 }
+            ```emacs-lisp { linenos=true, linenostart=1 }
             (message "I am in list at level-3 indentation")
             ```
     -   List item 2.1
 
-        ```emacs-lisp { linenos=table, linenostart=1 }
+        ```emacs-lisp { linenos=true, linenostart=1 }
         (message "I am in list back at level-2 indentation")
         ```
 -   List item 2
 
-    ```emacs-lisp { linenos=table, linenostart=1 }
+    ```emacs-lisp { linenos=true, linenostart=1 }
     (message "I am in list back at level-1 indentation")
     ```
 
 <!--listend-->
 
-```emacs-lisp { linenos=table, linenostart=1 }
+```emacs-lisp { linenos=true, linenostart=1 }
 (message "And now I am at level-0 indentation")
 ```

--- a/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
+++ b/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
@@ -26,7 +26,7 @@ should **not** be expanded.. they should be visible verbatim.
 Here, the `-n` switch is added to the Org source block to enable line
 numbering.
 
-```md { linenos=table, linenostart=1 }
+```md { linenos=true, linenostart=1 }
 {{</* figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" */>}}
 {{%/* figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" */%}}
 ```

--- a/test/site/content/posts/source-block-with-highlighting-blackfriday.md
+++ b/test/site/content/posts/source-block-with-highlighting-blackfriday.md
@@ -81,7 +81,7 @@ A workaround is below.. **use line numbers too!**.
 
 #### Output {#output}
 
-{{< highlight emacs-lisp "linenos=table, linenostart=7, hl_lines=1 3-5" >}}
+{{< highlight emacs-lisp "linenos=true, linenostart=7, hl_lines=1 3-5" >}}
 (message "This is line 7 in code, but line 1 for highlighting reference")
 (message "This is line 8 in code, but line 2 for highlighting reference")
 (message "This is line 9 in code, but line 3 for highlighting reference")
@@ -110,7 +110,7 @@ A workaround is below.. **use line numbers too!**.
 
 #### Output {#output}
 
-{{< highlight emacs-lisp "linenos=table, linenostart=1, hl_lines=1 3-5" >}}
+{{< highlight emacs-lisp "linenos=true, linenostart=1, hl_lines=1 3-5" >}}
 (message "This is line 1")
 (message "This is line 2")
 (message "This is line 3")

--- a/test/site/content/posts/source-block-with-highlighting.md
+++ b/test/site/content/posts/source-block-with-highlighting.md
@@ -96,7 +96,7 @@ Note 2
 
 #### Output {#output}
 
-```emacs-lisp { linenos=table, linenostart=7, hl_lines=["1","3-5"] }
+```emacs-lisp { linenos=true, linenostart=7, hl_lines=["1","3-5"] }
 (message "This is line 7 in code, but line 1 for highlighting reference")
 (message "This is line 8 in code, but line 2 for highlighting reference")
 (message "This is line 9 in code, but line 3 for highlighting reference")
@@ -125,7 +125,7 @@ Note 2
 
 #### Output {#output}
 
-```emacs-lisp { linenos=table, linenostart=1, hl_lines=["1","3-5"] }
+```emacs-lisp { linenos=true, linenostart=1, hl_lines=["1","3-5"] }
 (message "This is line 1")
 (message "This is line 2")
 (message "This is line 3")

--- a/test/site/content/posts/source-block-with-line-numbers-blackfriday.md
+++ b/test/site/content/posts/source-block-with-line-numbers-blackfriday.md
@@ -26,7 +26,7 @@ draft = false
 
 #### Output {#output}
 
-{{< highlight emacs-lisp "linenos=table, linenostart=1" >}}
+{{< highlight emacs-lisp "linenos=true, linenostart=1" >}}
 ;; this will export with line number 1 (default)
 (message "This is line 2")
 {{< /highlight >}}
@@ -47,7 +47,7 @@ draft = false
 
 #### Output {#output}
 
-{{< highlight emacs-lisp "linenos=table, linenostart=20" >}}
+{{< highlight emacs-lisp "linenos=true, linenostart=20" >}}
 ;; this will export with line number 20
 (message "This is line 21")
 {{< /highlight >}}
@@ -68,7 +68,7 @@ draft = false
 
 #### Output {#output}
 
-{{< highlight emacs-lisp "linenos=table, linenostart=22" >}}
+{{< highlight emacs-lisp "linenos=true, linenostart=22" >}}
 ;; This will be listed as line 22
 (message "This is line 23")
 {{< /highlight >}}
@@ -89,7 +89,7 @@ draft = false
 
 #### Output {#output}
 
-{{< highlight emacs-lisp "linenos=table, linenostart=33" >}}
+{{< highlight emacs-lisp "linenos=true, linenostart=33" >}}
 ;; This will be listed as line 33
 (message "This is line 34")
 {{< /highlight >}}

--- a/test/site/content/posts/source-block-with-line-numbers.md
+++ b/test/site/content/posts/source-block-with-line-numbers.md
@@ -26,7 +26,7 @@ draft = false
 
 #### Output {#output}
 
-```emacs-lisp { linenos=table, linenostart=1 }
+```emacs-lisp { linenos=true, linenostart=1 }
 ;; this will export with line number 1 (default)
 (message "This is line 2")
 ```
@@ -47,7 +47,7 @@ draft = false
 
 #### Output {#output}
 
-```emacs-lisp { linenos=table, linenostart=20 }
+```emacs-lisp { linenos=true, linenostart=20 }
 ;; this will export with line number 20
 (message "This is line 21")
 ```
@@ -68,7 +68,7 @@ draft = false
 
 #### Output {#output}
 
-```emacs-lisp { linenos=table, linenostart=22 }
+```emacs-lisp { linenos=true, linenostart=22 }
 ;; This will be listed as line 22
 (message "This is line 23")
 ```
@@ -89,7 +89,7 @@ draft = false
 
 #### Output {#output}
 
-```emacs-lisp { linenos=table, linenostart=33 }
+```emacs-lisp { linenos=true, linenostart=33 }
 ;; This will be listed as line 33
 (message "This is line 34")
 ```

--- a/test/site/content/posts/verse-for-indentation.md
+++ b/test/site/content/posts/verse-for-indentation.md
@@ -56,7 +56,7 @@ removed when translating to Markdown.
 
 ## Corner cases {#corner-cases}
 
-```org { linenos=table, linenostart=0 }
+```org { linenos=true, linenostart=0 }
 #+begin_verse
 
 >Line 1 above was empty. So the first =>= seen on this line is removed.
@@ -84,7 +84,7 @@ in the final output, they can use `>>` instead.. **only for that first
 instance**. The below Verse block is same as above except that the
 first `>` is retained in the final output.
 
-```org { linenos=table, linenostart=0 }
+```org { linenos=true, linenostart=0 }
 #+begin_verse
 
 >>Line 1 above was empty. So *only* the first =>= seen on this line is removed.

--- a/test/site/content/posts/ws-trimming-around-special-blocks.md
+++ b/test/site/content/posts/ws-trimming-around-special-blocks.md
@@ -107,7 +107,7 @@ line 2
 
 exports with `<div>` tags by default:
 
-```html { linenos=table, linenostart=1 }
+```html { linenos=true, linenostart=1 }
 line 1
 
 <div class="foo">
@@ -145,7 +145,7 @@ line 2
 
 will export to:
 
-```html { linenos=table, linenostart=1 }
+```html { linenos=true, linenostart=1 }
 line 1 <span class="foo">abc def</span> line 2
 ```
 


### PR DESCRIPTION
Earlier the line number style was hard-coded to "table" style. By setting `linenos` to `true`, the user can now choose to either use the "table" style of "divs/spans" style by setting a Hugo config variable in their site's `config.toml`.

The "div/spans" style was improved in a recent PR to chroma in https://github.com/alecthomas/chroma/pull/571, which got integrated into Hugo v0.93.0.