### PR TITLE
Wrap embedded SVG images with captions in figure tags

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2310,15 +2310,13 @@ and rewrite link paths to make blogging more seamless."
                                              (replace-regexp-in-string
                                               "<!DOCTYPE svg[^>]+>" ""
                                               svg-contents))))
-                   (caption-html (if (not caption)
-                                     ""
-                                   (format (concat "\n\n<div class=\"figure-caption\">\n\n"
-                                                   "  %s\n"
-                                                   "</div>")
-                                           caption))))
+                   (svg-html (if caption
+                                 (format "<figure>\n%s\n<figcaption>\n\n  %s\n</figcaption>\n</figure>"
+                                         svg-contents-sanitized caption)
+                               svg-contents-sanitized)))
               ;; (message "[org-hugo-link DBG] svg contents: %s" svg-contents)
               ;; (message "[org-hugo-link DBG] svg contents sanitized: %s" svg-contents-sanitized)
-              (concat svg-contents-sanitized caption-html))
+              svg-html)
           (let* ((path (org-hugo--attachment-rewrite-maybe raw-path info))
                  (inline-image (not (org-html-standalone-image-p useful-parent info)))
                  (source (if link-is-url

--- a/test/site/content/issues/470/index.md
+++ b/test/site/content/issues/470/index.md
@@ -18,6 +18,7 @@ With the `DOCTYPE` tag removed, the browser doesn't throw any error
 (below is the SVG from that issue.. seems like it's just blank. But
 you will be able to see when you view this page's source).
 
+<figure>
 <svg width="100%"
 height="100%" viewBox="0 0 1485 440" version="1.1"
 xmlns="http://www.w3.org/2000/svg"
@@ -26,8 +27,8 @@ xmlns:serif="http://www.serif.com/"
 style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
 </svg>
 
-
-<div class="figure-caption">
+<figcaption>
 
   <span class="figure-number">Figure 1: </span>SVG from Issue 470
-</div>
+</figcaption>
+</figure>

--- a/test/site/content/posts/inlined-svg.md
+++ b/test/site/content/posts/inlined-svg.md
@@ -12,6 +12,7 @@ draft = false
 
 Introduce a new `:inlined t` HTML attribute.
 
+<figure>
 <svg
 xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -49,11 +50,11 @@ style="stroke:#A80036;stroke-width:1.5;" x1="81.5" x2="81.5"
 y1="83.9688" y2="103.9688"/><polygon fill="#A80036"
 points="77.5,93.9688,81.5,103.9688,85.5,93.9688,81.5,97.9688"
 style="stroke:#A80036;stroke-width:1.0;"/></g></svg>
-
-<div class="figure-caption">
+<figcaption>
 
   <span class="figure-number">Figure 1: </span>An SVG with **hyperlinks** -- generated using PlantUML
-</div>
+</figcaption>
+</figure>
 
 
 ## Captioned source block followed by an inlined SVG {#captioned-source-block-followed-by-an-inlined-svg}


### PR DESCRIPTION
Before:

    <svg>SVG</svg>
    <div class="figure-caption">CAPTION</div>

After this commit:

    <figure>
      <svg>SVG</svg>
      <figcaption>CAPTION</figcaption>
    </figure>

Fixes https://github.com/kaushalmodi/ox-hugo/issues/579.