### PR TITLE
Fix broken links export options parsing

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1979,20 +1979,10 @@ Return nil if none of the above are true."
          bundle slug)
      ;; (message "[org-hugo--heading-get-slug DBG] EXPORT_FILE_NAME: %S" file)
      (when file
-       ;; (message "buffer : %S" (current-buffer))
-       ;; (message "point min : %S" (point-min))
-       ;; (message "point max : %S" (point-max))
        (setq bundle (let* ((elem-pval (org-hugo--get-elem-with-prop :EXPORT_HUGO_BUNDLE))
                            (pval (when elem-pval
                                    (cdr elem-pval))))
                       pval))
-       ;; (setq bundle (org-string-nw-p (or (org-export-get-node-property :EXPORT_HUGO_BUNDLE heading :inherited)
-       ;;                                   (plist-get info :hugo-bundle)
-       ;;                                   (cdr (org-hugo--get-elem-with-prop :EXPORT_HUGO_BUNDLE)))))
-
-       ;; (message "[org-hugo--heading-get-slug DBG] EXPORT_HUGO_BUNDLE: %S" bundle)
-       ;; (message "[org-hugo--heading-get-slug DBG] point %S" (point))
-       ;; (message "[org-hugo--heading-get-slug DBG] bundle 2: %S" (cdr (org-hugo--get-elem-with-prop :EXPORT_HUGO_BUNDLE)))
 
        (cond
         ;; Leaf or branch bundle landing page.

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4495,7 +4495,13 @@ links."
                                             (condition-case err
                                                 (org-export-resolve-fuzzy-link el info)
                                               (org-link-broken
-                                               (unless (plist-get info :with-broken-links)
+                                               (unless (or (plist-get info :with-broken-links)
+                                                           ;; Parse the `:EXPORT_OPTIONS' property if set
+                                                           ;; in a parent heading.
+                                                           (plist-get
+                                                            (org-export--parse-option-keyword
+                                                             (cdr (org-hugo--get-elem-with-prop :EXPORT_OPTIONS)))
+                                                            :with-broken-links))
                                                  (user-error "Unable to resolve link: %S" (nth 1 err))))))
                                         (org-export-resolve-id-link el (org-export--collect-tree-properties ast info))))
                          (source-path (org-hugo--heading-get-slug el info :inherit-export-file-name))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1910,11 +1910,14 @@ This function will never return nil."
                    "")))
     (substring (md5 title) 0 hash-len)))
 
-(defun org-hugo--get-elem-with-prop (prop &optional _info)
+(defun org-hugo--get-elem-with-prop (prop &optional pom _info)
   "Find the first element with PROP property in the current tree.
 
 PROP is a property symbol with a : prefix, example:
 `:EXPORT_FILE_NAME'.
+
+Optional argument POM is the position or marker from which the
+upward search for PROP should begin.
 
 Return a cons of type (ELEM . PVAL) where ELEM is the element
 containing the property PROP and PVAL is the property's value.
@@ -1926,13 +1929,17 @@ versions for the issue that `org-element-at-point' does not
 return an element with all the inherited properties.  That issue
 is fixed in Org main branch at least as of 2022-03-17."
   (org-with-wide-buffer
+   ;; (message (format "[search prop DBG] point 1 : %S" (point)))
+   (when pom
+     (goto-char pom))
+   ;; (message (format "[search prop DBG] point 2 : %S" (point)))
    (org-back-to-heading-or-point-min :invisible-ok)
    (let ((elem (org-element-at-point))
          (level t)
          pval)
      (catch :found
        (while elem
-         ;; (message (format "[search prop DBG] elem : %S" elem ))
+         ;; (message (format "[search prop DBG] prop %S, elem : %S" prop elem))
          (setq pval (org-element-property prop elem))
          ;; (message "[search prop DBG] level %S, pval %S" level pval)
          (when (or pval (null level))
@@ -1973,7 +1980,7 @@ INFO is a plist used as a communication channel.
 Return nil if none of the above are true."
   (org-with-wide-buffer
    (let ((heading-begin (org-element-property :begin heading)))
-     (when (numberp heading-begin)
+     (when heading-begin
        (goto-char heading-begin)))
    (let ((file (org-string-nw-p (org-export-get-node-property :EXPORT_FILE_NAME heading inherit-export-file-name)))
          bundle slug)
@@ -4489,7 +4496,10 @@ links."
                                                            ;; in a parent heading.
                                                            (plist-get
                                                             (org-export--parse-option-keyword
-                                                             (or (cdr (org-hugo--get-elem-with-prop :EXPORT_OPTIONS)) ""))
+                                                             (or (cdr (org-hugo--get-elem-with-prop
+                                                                       :EXPORT_OPTIONS
+                                                                       (org-element-property :begin el)))
+                                                                 ""))
                                                             :with-broken-links))
                                                  (user-error "Unable to resolve link: %S" (nth 1 err))))))
                                         (org-export-resolve-id-link el (org-export--collect-tree-properties ast info))))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4477,7 +4477,6 @@ links."
               (let ((type (org-element-property :type el)))
                 (when (member type '("custom-id" "id" "fuzzy"))
                   (let* ((raw-link (org-element-property :raw-link el))
-
                          (destination (if (string= type "fuzzy")
                                           (progn
                                             ;; Derived from ox.el -> `org-export-data'.  If a broken link is seen
@@ -4490,7 +4489,7 @@ links."
                                                            ;; in a parent heading.
                                                            (plist-get
                                                             (org-export--parse-option-keyword
-                                                             (cdr (org-hugo--get-elem-with-prop :EXPORT_OPTIONS)))
+                                                             (or (cdr (org-hugo--get-elem-with-prop :EXPORT_OPTIONS)) ""))
                                                             :with-broken-links))
                                                  (user-error "Unable to resolve link: %S" (nth 1 err))))))
                                         (org-export-resolve-id-link el (org-export--collect-tree-properties ast info))))

--- a/test/ert/telement.el
+++ b/test/ert/telement.el
@@ -111,5 +111,33 @@
 <point>"
               (cdr (org-hugo--get-elem-with-prop :EXPORT_HUGO_SECTION))))))
 
+(ert-deftest test-elem/starting-position ()
+  "Test property lookup by specifying the starting position."
+
+  ;; Here, the needed property is not found because the starting
+  ;; position for search is set to the beginning of the buffer.
+  (should
+   (equal nil
+          (org-test-with-parsed-data
+              "
+* Heading 1<point>
+:PROPERTIES:
+:EXPORT_OPTIONS: toc:t
+:END:"
+            (cdr (org-hugo--get-elem-with-prop :EXPORT_OPTIONS 1)))))
+
+  ;; Here, the needed property *is* found because the starting
+  ;; position for search is set correctly, and that overrides the init
+  ;; position set by <point> in this test.
+  (should
+   (string= "toc:t"
+            (org-test-with-parsed-data
+                "<point>
+* Heading 2
+:PROPERTIES:
+:EXPORT_OPTIONS: toc:t
+:END:"
+              (cdr (org-hugo--get-elem-with-prop :EXPORT_OPTIONS 2))))))
+
 
 (provide 'telement)

--- a/test/site/content-org/issues/issue-587-2.org
+++ b/test/site/content-org/issues/issue-587-2.org
@@ -3,11 +3,6 @@
 #+author:
 #+macro: issue ~ox-hugo~ Issue #[[https://github.com/kaushalmodi/ox-hugo/issues/$1][$1]]
 
-# Tue Mar 15 13:26:37 EDT 2022 - kmodi
-# Workaround: "#+options: broken-links:t" works, but the
-# ":EXPORT_OPTIONS: broken-links:t" property does not work for now.
-#+options: broken-links:t
-
 * Allow broken links (Subtree based export)                    :broken_links:
 :PROPERTIES:
 :EXPORT_FILE_NAME: issue-587-subtree-based-export


### PR DESCRIPTION
This fix was possible after the AST looping was moved outside the
`with-temp-buffer` construct: https://github.com/kaushalmodi/ox-hugo/pull/595

Fixes https://github.com/kaushalmodi/ox-hugo/issues/587