### PR TITLE
fix: Elapsed time was being printed as a negative value on GHA

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4849,8 +4849,7 @@ The optional argument NOERROR is passed to
                         ;; EXPORT_FILE_NAME property is not
                         ;; empty.
                         "EXPORT_FILE_NAME<>\"\"")))
-           (let* ((finish-time (current-time))
-                  (elapsed-time (float-time (time-subtract finish-time start-time)))
+           (let* ((elapsed-time (float-time (time-since start-time)))
                   (avg-time (/ elapsed-time org-hugo--subtree-count)))
              (message "[ox-hugo] Exported %d subtree%s from %s in %0.3fs (%0.3fs avg)"
                       org-hugo--subtree-count

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4849,7 +4849,8 @@ The optional argument NOERROR is passed to
                         ;; EXPORT_FILE_NAME property is not
                         ;; empty.
                         "EXPORT_FILE_NAME<>\"\"")))
-           (let* ((elapsed-time (float-time (time-since start-time)))
+           (let* ((finish-time (current-time))
+                  (elapsed-time (float-time (time-subtract finish-time start-time)))
                   (avg-time (/ elapsed-time org-hugo--subtree-count)))
              (message "[ox-hugo] Exported %d subtree%s from %s in %0.3fs (%0.3fs avg)"
                       org-hugo--subtree-count

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -267,10 +267,13 @@ to be installed.")
   ;; tests work.
   (defun ox-hugo-test/current-time-override (&rest args)
     "Hard-code the 'current time' so that the lastmod tests are reproducible.
+
+`ox-hugo' uses `org-current-time' to determine the \"lastmod\" value.
+
 Fake current time: 2100/12/21 00:00:00 (arbitrary)."
     (encode-time 0 0 0 21 12 2100))
-  (advice-add 'current-time :override #'ox-hugo-test/current-time-override)
-  ;; (advice-remove 'current-time #'ox-hugo-test/current-time-override)
+  (advice-add 'org-current-time :override #'ox-hugo-test/current-time-override)
+  ;; (advice-remove 'org-current-time #'ox-hugo-test/current-time-override)
 
   ;; issue # 272
   (load (expand-file-name "test/issue-272-chkbox-items-to-front-matter.el"


### PR DESCRIPTION
Unable to reproduce that issue locally.