### PR TITLE
fix #606

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4476,8 +4476,8 @@ subtree-number being exported.
               (if all-subtrees
                   (progn
                     (setq org-hugo--subtree-count (1+ org-hugo--subtree-count))
-                    (message (format "[ox-hugo] %d/ Exporting `%s' .." org-hugo--subtree-count title)))
-                (message (format "[ox-hugo] Exporting `%s' .." title)))
+                    (message "[ox-hugo] %d/ Exporting `%s' .." org-hugo--subtree-count title))
+                (message "[ox-hugo] Exporting `%s' .." title))
               ;; Get the current subtree coordinates for
               ;; auto-calculation of menu item weight, page or
               ;; taxonomy weights ..

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -634,6 +634,14 @@ Test the case where the title contains only the date, making it look
 like a Hugo TOML date field.
 #+end_description
 {{{oxhugoissue(350)}}}
+** Awesome title with % symbol
+:PROPERTIES:
+:EXPORT_FILE_NAME: post-title-percent-symbol
+:EXPORT_DATE: 2017-07-24
+:END:
+Testing a post with a percent symbol in the title.
+*** Sub-heading with % symbol
+Sub-heading also exported correctly
 * Excluded post                                                    :noexport:
 :PROPERTIES:
 :EXPORT_FILE_NAME: excluded-post

--- a/test/site/content/posts/post-title-percent-symbol.md
+++ b/test/site/content/posts/post-title-percent-symbol.md
@@ -1,0 +1,13 @@
++++
+title = "Awesome title with % symbol"
+date = 2017-07-24
+tags = ["title"]
+draft = false
++++
+
+Testing a post with a percent symbol in the title.
+
+
+## Sub-heading with % symbol {#sub-heading-with-symbol}
+
+Sub-heading also exported correctly


### PR DESCRIPTION
`message` already accepts the format string, which is used in the code above, so there's no reason to call `format`