### PR TITLE
feat: Export info: links correctly

### DIFF
--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -3781,6 +3781,16 @@ Below links are invalid, they are there just for test purpose.
 
 - [[https://jira.example.com/issues/?jql=(project=MYPRJ)AND(assignee=currentUser())][A dummy Jira JQL link]]
 - [[https://jira.example.com/issues/?jql=(project=MYPRJ)AND(assignee=currentUser())AND(labels in (foo))][A dummy Jira JQL link with spaces]]
+** Links to Info manual nodes                                          :info:
+:PROPERTIES:
+:EXPORT_FILE_NAME: links-to-info-manual-nodes
+:END:
+#+begin_description
+Test links to Info manual nodes.
+#+end_description
+- Link to an Org Info manual node: [[info:org#Search Options]]
+- Link to an Emacs Info manual node: [[info:emacs#Point]]
+- Link to an Emacs Lisp Info manual node: [[info:elisp#Lambda Expressions]]
 * Equations                                                       :equations:
 ** MathJax                                                          :mathjax:
 *** Inline equations

--- a/test/site/content/posts/coderef.md
+++ b/test/site/content/posts/coderef.md
@@ -8,7 +8,7 @@ tags = ["src-block", "coderef", "annotation", "example-block"]
 draft = false
 +++
 
-See [info:org#Literal Examples](org#Literal%20Examples).
+See [info:org#Literal Examples](https://www.gnu.org/software/emacs/manual/html_mono/org.html#Literal_002520Examples).
 
 In literal examples, Org interprets strings like `(ref:name)` as
 labels, and use them as targets for special hyperlinks like

--- a/test/site/content/posts/links-to-info-manual-nodes.md
+++ b/test/site/content/posts/links-to-info-manual-nodes.md
@@ -1,0 +1,10 @@
++++
+title = "Links to Info manual nodes"
+description = "Test links to Info manual nodes."
+tags = ["links", "info"]
+draft = false
++++
+
+-   Link to an Org Info manual node: [org#Search Options](https://www.gnu.org/software/emacs/manual/html_mono/org.html#Search-Options)
+-   Link to an Emacs Info manual node: [emacs#Point](https://www.gnu.org/software/emacs/manual/html_mono/emacs.html#Point)
+-   Link to an Emacs Lisp Info manual node: [elisp#Lambda Expressions](https://www.gnu.org/software/emacs/manual/html_mono/elisp.html#Lambda-Expressions)


### PR DESCRIPTION
Export `[[info:..]]` links to online Info manual links.