### PR TITLE
fix!: html validation: Do not export <style> elements above TOC

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -1803,6 +1803,17 @@ tries to get the "summary you mean". This partial is used by the
 /Note that you would need to use the =summary_minus_toc.html= partial
 wherever you do not intend to have TOC included in the summary (for
 example, in the Opengraph =og:description= meta tag)./
+**** Hiding bullets when TOC has numbered headings
+Add this to the CSS to hide bullets in table of contents when the
+headings are numbered. Export options set like ~#+options: toc:t
+num:t~ will cause this.
+
+#+begin_src css
+/* Hide bullets in TOC when headings are numbered. */
+.toc.has-section-numbers ul {
+  list-style: none;
+}
+#+end_src
 *** Table Styling
 :PROPERTIES:
 :EXPORT_FILE_NAME: table-styling

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1048,37 +1048,34 @@ contents according to the current heading."
                      (replace-regexp-in-string "\n\\{2,\\}" "\n" toc-items))))
     ;; (message "[ox-hugo build-toc DBG] toc-items:%s" toc-items)
     (when toc-items
-      (concat (when (string-match-p "^\\s-*\\-\\s-<span class=\"section\\-num\"" toc-items)
-                ;; Hide the bullets if section numbers are present for
-                ;; even one heading.
-                (concat "<style>\n"
-                        "  .ox-hugo-toc ul {\n"
-                        "    list-style: none;\n"
-                        "  }\n"
-                        "</style>\n"))
-              (format "<div class=\"ox-hugo-toc toc%s\">\n"
-                      (if local
-                          " local"
-                        ""))
-              (unless (org-hugo--plist-get-true-p info :hugo-goldmark)
-                "<div></div>\n") ;This is a nasty workaround till Hugo/Blackfriday support
-              toc-heading    ;wrapping Markdown in HTML div's.
-              "\n"
-              toc-items ;https://github.com/kaushalmodi/ox-hugo/issues/93
-              "\n\n"
-              "</div>\n"
-              ;; Special comment that can be use to filter out the TOC
-              ;; from .Summary in Hugo templates.
-              ;;
-              ;;     {{ $summary_splits := split .Summary "<!--endtoc-->" }}
-              ;;     {{ if eq (len $summary_splits) 2 }}
-              ;;         <!-- If that endtoc special comment is present, output only the part after that comment as Summary. -->
-              ;;         {{ index $summary_splits 1 | safeHTML }}
-              ;;     {{ else }}
-              ;;         <!-- Print the whole Summary if endtoc special comment is not found. -->
-              ;;         {{ .Summary }}
-              ;;     {{ end }}
-              "<!--endtoc-->\n"))))
+      (let ((toc-classes '("toc" "ox-hugo-toc"))
+            ;; `has-section-numbers' is non-nil if section numbers are
+            ;; present for even one heading.
+            (has-section-numbers (string-match-p "^\\s-*\\-\\s-<span class=\"section\\-num\"" toc-items)))
+        (when has-section-numbers
+          (push "has-section-numbers" toc-classes))
+        (when local
+          (push "local" toc-classes))
+        (concat (format "<div class=\"%s\">\n" (string-join (reverse toc-classes) " "))
+                (unless (org-hugo--plist-get-true-p info :hugo-goldmark)
+                  "<div></div>\n") ;This is a nasty workaround till Hugo/Blackfriday support
+                toc-heading    ;wrapping Markdown in HTML div's.
+                "\n"
+                toc-items ;https://github.com/kaushalmodi/ox-hugo/issues/93
+                "\n\n"
+                "</div>\n"
+                ;; Special comment that can be use to filter out the TOC
+                ;; from .Summary in Hugo templates.
+                ;;
+                ;;     {{ $summary_splits := split .Summary "<!--endtoc-->" }}
+                ;;     {{ if eq (len $summary_splits) 2 }}
+                ;;         <!-- If that endtoc special comment is present, output only the part after that comment as Summary. -->
+                ;;         {{ index $summary_splits 1 | safeHTML }}
+                ;;     {{ else }}
+                ;;         <!-- Print the whole Summary if endtoc special comment is not found. -->
+                ;;         {{ .Summary }}
+                ;;     {{ end }}
+                "<!--endtoc-->\n")))))
 
 ;;;; Escape Hugo shortcode
 (defun org-hugo--escape-hugo-shortcode (code lang)

--- a/test/site/content/dir-locals-test/dir-locals-test.md
+++ b/test/site/content/dir-locals-test/dir-locals-test.md
@@ -7,12 +7,7 @@ draft: false
 creator: "Dummy creator string"
 ---
 
-<style>
-  .ox-hugo-toc ul {
-    list-style: none;
-  }
-</style>
-<div class="ox-hugo-toc toc">
+<div class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 

--- a/test/site/content/posts/link-to-headings-by-name.md
+++ b/test/site/content/posts/link-to-headings-by-name.md
@@ -4,12 +4,7 @@ tags = ["links", "internal-links", "toc", "headings", "export-option"]
 draft = false
 +++
 
-<style>
-  .ox-hugo-toc ul {
-    list-style: none;
-  }
-</style>
-<div class="ox-hugo-toc toc">
+<div class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 

--- a/test/site/content/posts/post-with-export-options-toc-1-num-onlytoc.md
+++ b/test/site/content/posts/post-with-export-options-toc-1-num-onlytoc.md
@@ -4,12 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<style>
-  .ox-hugo-toc ul {
-    list-style: none;
-  }
-</style>
-<div class="ox-hugo-toc toc">
+<div class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 

--- a/test/site/content/posts/post-with-export-options-toc-2-num-t.md
+++ b/test/site/content/posts/post-with-export-options-toc-2-num-t.md
@@ -4,12 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<style>
-  .ox-hugo-toc ul {
-    list-style: none;
-  }
-</style>
-<div class="ox-hugo-toc toc">
+<div class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 

--- a/test/site/content/posts/post-with-export-options-toc-t-num-onlytoc.md
+++ b/test/site/content/posts/post-with-export-options-toc-t-num-onlytoc.md
@@ -4,12 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<style>
-  .ox-hugo-toc ul {
-    list-style: none;
-  }
-</style>
-<div class="ox-hugo-toc toc">
+<div class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 

--- a/test/site/content/posts/post-with-export-options-toc-t-num-t.md
+++ b/test/site/content/posts/post-with-export-options-toc-t-num-t.md
@@ -4,12 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<style>
-  .ox-hugo-toc ul {
-    list-style: none;
-  }
-</style>
-<div class="ox-hugo-toc toc">
+<div class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 


### PR DESCRIPTION
`<style>` elements are not allowed inside <article> HTML elements. It is
very likely that the TOC + post content would be wrapped in an
`<article>` element, and in those cases, the HTML Validator will throw
an error like:

> Element style not allowed as child of element article in this
> context.

The breaking change will be seen only when both toc and section
numbering is enabled. The 'breakage' is visual -- that the numbered
headings in the TOCs will have the unordered list bullets.

To fix it, add this to the CSS:

```
.toc.has-section-numbers ul {
  list-style: none;
}
```