### PR TITLE
feat!: Use semantic HTML <nav> element to wrap table of contents

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1056,14 +1056,14 @@ contents according to the current heading."
           (push "has-section-numbers" toc-classes))
         (when local
           (push "local" toc-classes))
-        (concat (format "<div class=\"%s\">\n" (string-join (reverse toc-classes) " "))
+        (concat (format "<nav class=\"%s\">\n" (string-join (reverse toc-classes) " "))
                 (unless (org-hugo--plist-get-true-p info :hugo-goldmark)
-                  "<div></div>\n") ;This is a nasty workaround till Hugo/Blackfriday support
+                  "<nav></nav>\n") ;This is a nasty workaround till Hugo/Blackfriday support
                 toc-heading    ;wrapping Markdown in HTML div's.
                 "\n"
                 toc-items ;https://github.com/kaushalmodi/ox-hugo/issues/93
                 "\n\n"
-                "</div>\n"
+                "</nav>\n"
                 ;; Special comment that can be use to filter out the TOC
                 ;; from .Summary in Hugo templates.
                 ;;

--- a/test/site/content/dir-locals-test/dir-locals-test.md
+++ b/test/site/content/dir-locals-test/dir-locals-test.md
@@ -7,14 +7,14 @@ draft: false
 creator: "Dummy creator string"
 ---
 
-<div class="ox-hugo-toc toc has-section-numbers">
+<nav class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 
 - <span class="section-num">1</span> [Variables set in <kbd>.dir-locals.el</kbd>](#variables-set-in-dot-dir-locals-dot-el)
 - <span class="section-num">2</span> [Test text](#test-text)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/link-to-headings-by-name.md
+++ b/test/site/content/posts/link-to-headings-by-name.md
@@ -4,7 +4,7 @@ tags = ["links", "internal-links", "toc", "headings", "export-option"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc has-section-numbers">
+<nav class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 
@@ -16,7 +16,7 @@ draft = false
 - [Zeta 103 which has **some** _markup_](#zeta-103-which-has-some-markup)
     - [Links (no descriptions) to headings with section numbers](#links--no-descriptions--to-headings-with-section-numbers)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/no-toc-in-summary-with-more.md
+++ b/test/site/content/posts/no-toc-in-summary-with-more.md
@@ -4,14 +4,14 @@ tags = ["export-option", "toc", "summary", "endtoc", "more"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
 - [`ox-hugo`'s Solution](#ox-hugo-s-solution)
 - [Snippet](#snippet)
 
-</div>
+</nav>
 <!--endtoc-->
 
 By default, Hugo will dump everything at the beginning of a post into

--- a/test/site/content/posts/no-toc-in-summary-without-more.md
+++ b/test/site/content/posts/no-toc-in-summary-without-more.md
@@ -4,14 +4,14 @@ tags = ["export-option", "toc", "summary", "endtoc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
 - [`ox-hugo`'s Solution](#ox-hugo-s-solution)
 - [Snippet](#snippet)
 
-</div>
+</nav>
 <!--endtoc-->
 
 By default, Hugo will dump everything at the beginning of a post into

--- a/test/site/content/posts/post-with-export-options-toc-1-num-onlytoc.md
+++ b/test/site/content/posts/post-with-export-options-toc-1-num-onlytoc.md
@@ -4,7 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc has-section-numbers">
+<nav class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 
@@ -12,7 +12,7 @@ draft = false
 - <span class="section-num">2</span> [Post sub-heading 2](#post-sub-heading-2)
 - <span class="section-num">3</span> [Post sub-heading 3](#post-sub-heading-3)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/post-with-export-options-toc-2-num-nil.md
+++ b/test/site/content/posts/post-with-export-options-toc-2-num-nil.md
@@ -4,7 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
@@ -18,7 +18,7 @@ draft = false
 - [Post sub-heading 3](#post-sub-heading-3)
     - [Post sub-heading 3.1](#post-sub-heading-3-dot-1)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/post-with-export-options-toc-2-num-t.md
+++ b/test/site/content/posts/post-with-export-options-toc-2-num-t.md
@@ -4,7 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc has-section-numbers">
+<nav class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 
@@ -18,7 +18,7 @@ draft = false
 - <span class="section-num">3</span> [Post sub-heading 3](#post-sub-heading-3)
     - <span class="section-num">3.1</span> [Post sub-heading 3.1](#post-sub-heading-3-dot-1)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/post-with-export-options-toc-t-num-nil.md
+++ b/test/site/content/posts/post-with-export-options-toc-t-num-nil.md
@@ -4,7 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
@@ -22,7 +22,7 @@ draft = false
 - [Post sub-heading 3](#post-sub-heading-3)
     - [Post sub-heading 3.1](#post-sub-heading-3-dot-1)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/post-with-export-options-toc-t-num-onlytoc.md
+++ b/test/site/content/posts/post-with-export-options-toc-t-num-onlytoc.md
@@ -4,7 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc has-section-numbers">
+<nav class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 
@@ -22,7 +22,7 @@ draft = false
 - <span class="section-num">3</span> [Post sub-heading 3](#post-sub-heading-3)
     - <span class="section-num">3.1</span> [Post sub-heading 3.1](#post-sub-heading-3-dot-1)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/post-with-export-options-toc-t-num-t.md
+++ b/test/site/content/posts/post-with-export-options-toc-t-num-t.md
@@ -4,7 +4,7 @@ tags = ["export-option", "toc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc has-section-numbers">
+<nav class="ox-hugo-toc toc has-section-numbers">
 
 <div class="heading">Table of Contents</div>
 
@@ -22,7 +22,7 @@ draft = false
 - <span class="section-num">3</span> [Post sub-heading 3](#post-sub-heading-3)
     - <span class="section-num">3.1</span> [Post sub-heading 3.1](#post-sub-heading-3-dot-1)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/post-with-toc-keyword-2.md
+++ b/test/site/content/posts/post-with-toc-keyword-2.md
@@ -4,7 +4,7 @@ tags = ["keyword", "toc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
@@ -18,7 +18,7 @@ draft = false
 - [Post sub-heading 3](#post-sub-heading-3)
     - [Post sub-heading 3.1](#post-sub-heading-3-dot-1)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/post-with-toc-keyword-6.md
+++ b/test/site/content/posts/post-with-toc-keyword-6.md
@@ -4,7 +4,7 @@ tags = ["keyword", "toc"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
@@ -22,7 +22,7 @@ draft = false
 - [Post sub-heading 3](#post-sub-heading-3)
     - [Post sub-heading 3.1](#post-sub-heading-3-dot-1)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/toc-local.md
+++ b/test/site/content/posts/toc-local.md
@@ -11,7 +11,7 @@ draft = false
 
 Below, TOC is exported with only level-1 headings in this post.
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
@@ -19,20 +19,20 @@ Below, TOC is exported with only level-1 headings in this post.
 - [Post sub-heading 2](#post-sub-heading-2)
 - [Post sub-heading 3](#post-sub-heading-3)
 
-</div>
+</nav>
 <!--endtoc-->
 
 Below exported TOC should look the same as above even when it's
 generated using the `local` param as it is at the root level of this
 post.
 
-<div class="ox-hugo-toc toc local">
+<nav class="ox-hugo-toc toc local">
 
 - [Post sub-heading 1](#post-sub-heading-1)
 - [Post sub-heading 2](#post-sub-heading-2)
 - [Post sub-heading 3](#post-sub-heading-3)
 
-</div>
+</nav>
 <!--endtoc-->
 
 
@@ -41,13 +41,13 @@ post.
 Below, TOC is exported with only level-1 headings **relative to** this
 "Post sub-heading 1" section.
 
-<div class="ox-hugo-toc toc local">
+<nav class="ox-hugo-toc toc local">
 
 - [Post sub-heading 1.1](#post-sub-heading-1-dot-1)
 - [Post sub-heading 1.2](#post-sub-heading-1-dot-2)
 - [Post sub-heading 1.3](#post-sub-heading-1-dot-3)
 
-</div>
+</nav>
 <!--endtoc-->
 
 
@@ -74,7 +74,7 @@ Below, TOC is exported with only level-1 headings **relative to** this
 Below, TOC is exported with only up to level-2 headings **relative to**
 this "Post sub-heading 2.2" section.
 
-<div class="ox-hugo-toc toc local">
+<nav class="ox-hugo-toc toc local">
 
 - [Post sub-heading 2.2.1](#post-sub-heading-2-dot-2-dot-1)
 - [Post sub-heading 2.2.2](#post-sub-heading-2-dot-2-dot-2)
@@ -82,7 +82,7 @@ this "Post sub-heading 2.2" section.
     - [Post sub-heading 2.2.3.1](#post-sub-heading-2-dot-2-dot-3-dot-1)
     - [Post sub-heading 2.2.3.2](#post-sub-heading-2-dot-2-dot-3-dot-2)
 
-</div>
+</nav>
 <!--endtoc-->
 
 
@@ -97,12 +97,12 @@ this "Post sub-heading 2.2" section.
 Below, TOC is exported with only level-1 headings **relative to** this
 "Post sub-heading 2.2.3" section.
 
-<div class="ox-hugo-toc toc local">
+<nav class="ox-hugo-toc toc local">
 
 - [Post sub-heading 2.2.3.1](#post-sub-heading-2-dot-2-dot-3-dot-1)
 - [Post sub-heading 2.2.3.2](#post-sub-heading-2-dot-2-dot-3-dot-2)
 
-</div>
+</nav>
 <!--endtoc-->
 
 

--- a/test/site/content/posts/toc-target.md
+++ b/test/site/content/posts/toc-target.md
@@ -13,14 +13,14 @@ draft = false
 
 ### landing page {#landing-page}
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
 - [landing page](#landing-page)
 - [first subsection in Reading](#first-subsection-in-reading)
 
-</div>
+</nav>
 <!--endtoc-->
 
 
@@ -43,12 +43,12 @@ draft = false
 
 ### Another section {#another-section}
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
 - [Heading A](#heading-a)
 - [Heading B](#heading-b)
 
-</div>
+</nav>
 <!--endtoc-->

--- a/test/site/content/posts/toc-with-todo-disabled.md
+++ b/test/site/content/posts/toc-with-todo-disabled.md
@@ -8,7 +8,7 @@ tags = ["export-option", "toc", "todo", "disable"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
@@ -16,7 +16,7 @@ draft = false
 - [Something to do](#something-to-do)
 - [Something done](#something-done)
 
-</div>
+</nav>
 <!--endtoc-->
 
 <style>

--- a/test/site/content/posts/toc-with-todo-enabled.md
+++ b/test/site/content/posts/toc-with-todo-enabled.md
@@ -8,7 +8,7 @@ tags = ["export-option", "toc", "todo", "enable"]
 draft = false
 +++
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
@@ -16,7 +16,7 @@ draft = false
 - [<span class="org-todo todo TODO">TODO</span> Something to do](#something-to-do)
 - [<span class="org-todo done DONE">DONE</span> Something done](#something-done)
 
-</div>
+</nav>
 <!--endtoc-->
 
 <style>

--- a/test/site/content/real-examples/nn-intro.md
+++ b/test/site/content/real-examples/nn-intro.md
@@ -14,7 +14,7 @@ Disclaimer
 
 ---
 
-<div class="ox-hugo-toc toc">
+<nav class="ox-hugo-toc toc">
 
 <div class="heading">Table of Contents</div>
 
@@ -35,7 +35,7 @@ Disclaimer
     - [代价函数：交叉熵](#代价函数-交叉熵)
     - [规范化](#规范化)
 
-</div>
+</nav>
 <!--endtoc-->
 
 神经网络相关基本知识笔记


### PR DESCRIPTION
There's a small chance that the user might need to tweak their site
CSS for this change.

- [ ] Do not default to `nav` element. The TOC looks weird based on how some CSS libraries render the `nav` tags (see below). It's possible that that's the issue with that CSS library. But it would be good to not break rendering on any sites by leaving the TOC default element to the currently used `div`. Instead may be add a way to customize the TOC element.

---

### `nav` elements with nested `ul`/`li` elements rendered by [`mvp.css`](https://github.com/andybrewer/mvp/)

![image](https://user-images.githubusercontent.com/3578197/161987449-ed9339ee-9cd9-46ff-b794-ec4cb0d57ea8.png)
