### PR TITLE
feat: Better HTML target for info: links

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -890,13 +890,24 @@ https://git.savannah.gnu.org/cgit/emacs/org-mode.git/commit/?id=6b2a7cb20b357e73
   (let* ((parts (split-string path "#\\|::"))
          (manual (car parts))
          (node (or (nth 1 parts) "Top"))
+         (title (format "Emacs Lisp: (info \\\"(%s) %s\\\")" manual node))
          (desc (or desc
-                   (format "%s Info: %s" (capitalize manual) node))))
+                   (if (string= node "Top")
+                       (format "%s Info" (capitalize manual))
+                     (format "%s Info: %s" (capitalize manual) node))))
+         ;; `link' below is mostly derived from the code in
+         ;; `org-info-map-html-url'.
+         (link (cond ((member manual org-info-emacs-documents)
+                          (let* ((base-url "https://www.gnu.org/software/emacs/manual/html_node")
+                                 (node-url (if (string= node "Top")
+                                               "index.html"
+                                             (concat (org-info--expand-node-name node) ".html"))))
+                            (format "%s/%s/%s" base-url manual node-url)))
+                         ((cdr (assoc manual org-info-other-documents)))
+                         (t
+                          (concat manual ".html")))))
     (when (member format '(md hugo))
-      (format "[%s](%s#%s)"
-              desc
-              (org-info-map-html-url manual)
-              (org-info--expand-node-name node)))))
+      (format "[%s](%s \"%s\")" desc link title))))
 
 (defun org-hugo--before-export-function (subtreep)
   "Function to be run before an ox-hugo export.

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2058,7 +2058,7 @@ Support anchoring the source and example block lines using Org coderef
 links.
 #+end_description
 
-See [[info:org#Literal%20Examples][info:org#Literal Examples]].
+See [[info:org#Literal Examples]].
 
 In literal examples, Org interprets strings like ~(ref:name)~ as
 labels, and use them as targets for special hyperlinks like
@@ -3789,6 +3789,7 @@ Below links are invalid, they are there just for test purpose.
 Test links to Info manual nodes.
 #+end_description
 - Link to an Org Info manual node: [[info:org#Search Options]]
+- Links to Top nodes of manuals: [[info:emacs#Top]] | [[info:org#Top]]
 - Link to an Emacs Info manual node: [[info:emacs#Point]] (same link but
   with a custom description: [[info:emacs#Point][🛈 Emacs: Point]])
 - Link to an Emacs Lisp Info manual node: [[info:elisp#Lambda Expressions]]

--- a/test/site/content/posts/coderef.md
+++ b/test/site/content/posts/coderef.md
@@ -8,7 +8,7 @@ tags = ["src-block", "coderef", "annotation", "example-block"]
 draft = false
 +++
 
-See [info:org#Literal Examples](https://www.gnu.org/software/emacs/manual/html_mono/org.html#Literal_002520Examples).
+See [Org Info: Literal Examples](https://www.gnu.org/software/emacs/manual/html_node/org/Literal-Examples.html "Emacs Lisp: (info \"(org) Literal Examples\")").
 
 In literal examples, Org interprets strings like `(ref:name)` as
 labels, and use them as targets for special hyperlinks like

--- a/test/site/content/posts/links-to-info-manual-nodes.md
+++ b/test/site/content/posts/links-to-info-manual-nodes.md
@@ -5,7 +5,8 @@ tags = ["links", "info"]
 draft = false
 +++
 
--   Link to an Org Info manual node: [Org Info: Search Options](https://www.gnu.org/software/emacs/manual/html_mono/org.html#Search-Options)
--   Link to an Emacs Info manual node: [Emacs Info: Point](https://www.gnu.org/software/emacs/manual/html_mono/emacs.html#Point) (same link but
-    with a custom description: [🛈 Emacs: Point](https://www.gnu.org/software/emacs/manual/html_mono/emacs.html#Point))
--   Link to an Emacs Lisp Info manual node: [Elisp Info: Lambda Expressions](https://www.gnu.org/software/emacs/manual/html_mono/elisp.html#Lambda-Expressions)
+-   Link to an Org Info manual node: [Org Info: Search Options](https://www.gnu.org/software/emacs/manual/html_node/org/Search-Options.html "Emacs Lisp: (info \"(org) Search Options\")")
+-   Links to Top nodes of manuals: [Emacs Info](https://www.gnu.org/software/emacs/manual/html_node/emacs/index.html "Emacs Lisp: (info \"(emacs) Top\")") | [Org Info](https://www.gnu.org/software/emacs/manual/html_node/org/index.html "Emacs Lisp: (info \"(org) Top\")")
+-   Link to an Emacs Info manual node: [Emacs Info: Point](https://www.gnu.org/software/emacs/manual/html_node/emacs/Point.html "Emacs Lisp: (info \"(emacs) Point\")") (same link but
+    with a custom description: [🛈 Emacs: Point](https://www.gnu.org/software/emacs/manual/html_node/emacs/Point.html "Emacs Lisp: (info \"(emacs) Point\")"))
+-   Link to an Emacs Lisp Info manual node: [Elisp Info: Lambda Expressions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Lambda-Expressions.html "Emacs Lisp: (info \"(elisp) Lambda Expressions\")")


### PR DESCRIPTION
- HTML targets are now individual pages for the nodes instead of an anchor
  in a single page HTML manual.

  Before : https://www.gnu.org/software/emacs/manual/html_mono/emacs.html#Browse_002dURL

  After  : https://www.gnu.org/software/emacs/manual/html_node/emacs/Browse_002dURL.html

- Add the elisp for opening the same Info node in Emacs in link's
  `title` attribute.

- Do not add "Top" in the default info: description used (if user
  doesn't provide one) if the node is "Top".

This change is based on few suggestions by Max Nikulin in
https://lists.gnu.org/r/emacs-orgmode/2022-04/msg00162.html.