### PR TITLE
feat!: Use tomelr for TOML front-matter generation

### DIFF
--- a/ox-hugo-deprecated.el
+++ b/ox-hugo-deprecated.el
@@ -17,6 +17,17 @@
 
 ;;; Code:
 
+;; Silence byte-compiler
+(defvar org-hugo--date-time-regexp)
+(defvar org-hugo--subtree-coord)
+(declare-function org-string-nw-p "org-macs")
+(declare-function org-hugo--calc-weight "ox-hugo")
+(declare-function org-hugo-slug "ox-hugo")
+(declare-function org-hugo--front-matter-value-booleanize "ox-hugo")
+(declare-function org-hugo--delim-str-to-list "ox-hugo")
+(declare-function org-hugo--parse-property-arguments "ox-hugo")
+;;
+
 (make-obsolete-variable 'org-hugo-blackfriday-options nil "Hugo has switched to use Goldmark as the default Markdown parser since v0.60." "Jan 15, 2022")
 (make-obsolete-variable 'org-hugo-blackfriday-extensions nil "Hugo has switched to use Goldmark as the default Markdown parser since v0.60." "Jan 15, 2022")
 

--- a/ox-hugo-deprecated.el
+++ b/ox-hugo-deprecated.el
@@ -103,7 +103,327 @@ Example: If EXT is \"hardlinebreak\",
     (unless ret
       (user-error "Invalid Blackfriday extension name %S, see `org-hugo-blackfriday-extensions'"
                   ext))
-    (org-hugo--quote-string ret)))
+    (org-hugo--yaml-quote-string ret)))
+
+;;; YAML Support
+(defun org-hugo--yaml-quote-string (val &optional prefer-no-quotes)
+  "Wrap VAL with quotes as appropriate.
+
+VAL can be a string, symbol, number or nil.
+
+VAL is returned as-it-is under the following cases:
+- It is a number.
+- It is a string and is already wrapped with double quotes.
+- It is a string and it's value is \"true\" or \"false\".
+- It is a string representing a date.
+- It is a string representing an integer or float.
+
+If VAL is nil or an empty string, a quoted empty string \"\" is
+returned.
+
+If optional argument PREFER-NO-QUOTES is non-nil, return the VAL
+as-it-is if it's a string with just alphanumeric characters."
+  (cond
+   ((null val)                          ;nil
+    val)
+   ((numberp val)
+    val)
+   ((symbolp val)
+    (format "\"%s\"" (symbol-name val)))
+   ((stringp val)
+    (cond
+     ((org-string-nw-p val)            ;If `val' is a non-empty string
+      (cond
+       ((or (and (string= (substring val 0 1) "\"") ;First char is literally a "
+                 (string= (substring val -1) "\"")) ;Last char is literally a "
+            (and prefer-no-quotes ;If quotes are not preferred and `val' is only alpha-numeric
+                 (string-match-p "\\`[a-zA-Z0-9]+\\'" val))
+            ;; or if it an integer that can be stored in the system as
+            ;; a fixnum.  For example, if `val' is
+            ;; "10040216507682529280" that needs more than 64 bits to
+            ;; be stored as a signed integer, it will be automatically
+            ;; stored as a float.  So (integerp (string-to-number
+            ;; val)) will return nil [or `fixnump' instead of
+            ;; `integerp' in Emacs 27 or newer]
+            ;; https://github.com/toml-lang/toml#integer Integer
+            ;; examples: 7, +7, -7, 7_000
+            (and (string-match-p "\\`[+-]?[[:digit:]_]+\\'" val)
+                 (if (functionp #'fixnump) ;`fixnump' and `bignump' get introduced in Emacs 27.x
+                     (fixnump (string-to-number val))
+                   (integerp (string-to-number val)))) ;On older Emacsen, `integerp' behaved the same as the new `fixnump'
+            (string= "true" val)
+            (string= "false" val)
+            ;; or if it is a date (date, publishDate, expiryDate, lastmod)
+            (string-match-p org-hugo--date-time-regexp val)
+            ;; or if it is a float
+            ;; https://github.com/toml-lang/toml#float
+            ;; Float examples (decimals): 7.8, +7.8, -7.8
+            (string-match-p "\\`[+-]?[[:digit:]_]+\\.[[:digit:]_]+\\'" val)
+            ;; Float examples (exponentials): 7e-8, -7E+8, 1.7e-05
+            (string-match-p "\\`[+-]?[[:digit:]_]+\\(\\.[[:digit:]_]+\\)*[eE][+-]?[[:digit:]_]+\\'" val)
+            ;; Special float values (infinity/NaN)
+            ;; Looks like Hugo is not supporting these.. Tue Mar 20 18:05:40 EDT 2018 - kmodi
+            ;; (let ((case-fold-search nil))
+            ;;   (string-match-p "\\`[+-]?\\(inf\\|nan\\)\\'" val))
+            )
+        val)
+       ((string-match-p "\n" val)       ;Multi-line string
+        ;; The indentation of the multi-line string is needed only for the
+        ;; YAML format.  But the same is done for TOML too just for better
+        ;; presentation.
+        (setq val (replace-regexp-in-string "^" "  " val))
+
+        ;; https://yaml-multiline.info/
+        ;;
+        ;;     |             |foo : >
+        ;;     |abc          |  abc
+        ;;     |       >>>   |
+        ;;     |def          |
+        ;;     |             |  def
+        ;;
+        ;; In Org, a single blank line is used to start a new
+        ;; paragraph. In the YAML multi-line string, that needs to
+        ;; be 2 blank lines.
+        (setq val (replace-regexp-in-string "\n[[:blank:]]*\n" "\n\n\n" val))
+        (format ">\n%s" val))
+       (t                                       ;Single-line string
+        ;; Below 2 replacements are order-dependent.. first escape the
+        ;; backslashes, then escape the quotes with backslashes.
+
+        ;; Escape the backslashes (for both TOML and YAML).
+        (setq val (replace-regexp-in-string "\\\\" "\\\\\\\\" val))
+        ;; Escape the double-quotes.
+        (setq val (replace-regexp-in-string "\"" "\\\\\""  val))
+        (concat "\"" val "\""))))
+     (t                                 ;If `val' is any empty string
+      "\"\"")))
+   (t                            ;Return empty string if anything else
+    "\"\"")))
+
+(defun org-hugo--get-yaml-list-string (key list)
+  "Return KEY's LIST value as a YAML list, represented as a string.
+
+KEY is a string and LIST is a list where an element can be a
+symbol, number or a non-empty string.  Examples:
+
+  \(\"abc\" \"def\")   -> \"[\\\"abc\\\", \\\"def\\\"]\"."
+  (concat "["
+          (mapconcat #'identity
+                     (mapcar (lambda (v)
+                               (org-hugo--yaml-quote-string
+                                (cond
+                                 ((symbolp v)
+                                  (symbol-name v))
+                                 ((numberp v)
+                                  (number-to-string v))
+                                 ((org-string-nw-p v)
+                                  v)
+                                 (t
+                                  (user-error "Invalid element %S in `%s' value %S" v key list)))))
+                             list)
+                     ", ")
+          "]"))
+
+(defun org-hugo--gen-yaml-front-matter (data)
+  "Generate Hugo front-matter in YAML format, and return that string.
+
+DATA is an alist of the form \((KEY1 . VAL1) (KEY2 . VAL2) .. \),
+where KEY is a symbol and VAL is a string."
+  (let ((sep "---\n")
+        (sign ":")
+        (front-matter "")
+        (indent (make-string 2 ? ))
+        (nested-string "")
+        (menu-string "")
+        (res-string ""))
+    (dolist (pair data)
+      (let ((key (symbol-name (car pair)))
+            (value (cdr pair)))
+        ;; (message "[hugo fm key value DBG] %S %S" key value)
+        (unless (or (null value) ;Skip writing front-matter variables whose value is nil
+                    (and (stringp value) ;or an empty string.
+                         (string= "" value)))
+          ;; In TOML/YAML, the value portion needs to be wrapped in
+          ;; double quotes.
+          ;; TOML example:
+          ;;     title = "My Post"
+          ;; YAML example:
+          ;;     title: "My Post"
+          (cond
+           ((string= key "menu")
+            (unless (listp value)
+              (user-error (concat "The `menu' front-matter did not get the expected "
+                                  "list value; probably because HUGO_MENU was not "
+                                  "used to set its value.\n"
+                                  "Usage examples: \":EXPORT_HUGO_MENU: :menu main\" or "
+                                  "\"#+hugo_menu: :menu main\"")))
+            ;; Menu name needs to be non-nil to insert menu info in front-matter.
+            (when (assoc 'menu value)
+              (let* ((menu-alist value)
+                     ;; Menu entry string might need to be quoted if
+                     ;; it contains spaces, for example.
+                     (menu-entry (org-hugo--yaml-quote-string (cdr (assoc 'menu menu-alist)) :prefer-no-quotes))
+                     (menu-entry-str "")
+                     (menu-value-str ""))
+                ;; Auto-set menu identifier if not already set by user.
+                (unless (assoc 'identifier menu-alist)
+                  (let ((title (cdr (assoc 'title data))))
+                    (push `(identifier . ,(org-hugo-slug title)) menu-alist)))
+
+                ;; Auto-set menu weight if not already set by user.
+                (unless (assoc 'weight menu-alist)
+                  (when org-hugo--subtree-coord
+                    (push `(weight . ,(org-hugo--calc-weight)) menu-alist)))
+
+                ;; (message "[menu alist DBG] = %S" menu-alist)
+                (when menu-entry
+                  (setq menu-entry-str (prog1
+                                           (format "menu%s\n%s%s%s\n"
+                                                   sign indent menu-entry sign)
+                                         (setq indent (concat indent indent)))) ;Double the indent for next use
+                  (dolist (menu-pair menu-alist)
+                    (let ((menu-key (symbol-name (car menu-pair)))
+                          (menu-value (cdr menu-pair)))
+                      ;; (message "menu DBG: %S %S %S" menu-entry menu-key menu-value)
+                      (unless (string= "menu" menu-key)
+                        (when menu-value
+                          ;; Cannot skip quote wrapping for values of keys inside menu.
+                          ;; Attempting to do:
+                          ;;   [menu.foo]
+                          ;;     parent = main
+                          ;;     # parent = "main" # But this works
+                          ;; gives this error:
+                          ;; ERROR 2017/07/21 10:56:07 failed to parse page metadata
+                          ;; for "singles/post-draft.md": Near line 10 (last key parsed
+                          ;; 'menu.foo.parent'): expected value but found "main" instead.
+                          (setq menu-value (org-hugo--yaml-quote-string menu-value))
+                          (setq menu-value-str
+                                (concat menu-value-str
+                                        (format "%s%s%s %s\n"
+                                                indent menu-key sign menu-value)))))))
+                  (setq menu-string (concat menu-entry-str menu-value-str))))))
+           ((string= key "resources")
+            (unless (listp value)
+              (user-error (concat "The `resources' front-matter did not get the expected "
+                                  "list value; probably because HUGO_RESOURCES was not "
+                                  "used to set its value.\n"
+                                  "Usage examples: \":EXPORT_HUGO_RESOURCES: :src \"my-image.png\" :title \"My Image\" "
+                                  "or \"#+hugo_resources: :src \"my-image.png\" :title \"My Image\"")))
+            (when value
+              (dolist (res-alist value)
+                (let ((res-entry-str "")
+                      (res-value-str "")
+                      res-src-present
+                      res-param-str)
+                  (setq res-entry-str
+                        ;; For YAML, this string
+                        ;; needs to be inserted
+                        ;; only once.
+                        (if (org-string-nw-p res-string)
+                            ""
+                          (format "resources%s\n" sign)))
+                  (dolist (res-pair res-alist)
+                    ;; (message "[resources DBG] res-pair: %S" res-pair)
+                    (let* ((res-key (symbol-name (car res-pair)))
+                           (res-value (cdr res-pair)))
+                      ;; (message "[resources DBG]: %S %S" res-key res-value)
+                      (cond ((string= res-key "params")
+                             (setq indent (make-string 4 ? ))
+                             (setq res-param-str (format "  %s%s\n" res-key sign))
+                             (dolist (param-pair res-value) ;res-value would be an alist of params
+                               (let ((param-key (symbol-name (car param-pair)))
+                                     (param-value (cdr param-pair))
+                                     param-value-str)
+                                 ;; (message "[resources DBG] param-key: %S" param-key)
+                                 ;; (message "[resources DBG] param-value: %S" param-value)
+                                 (setq param-value-str (if (listp param-value)
+                                                           (org-hugo--get-yaml-list-string param-key param-value)
+                                                         (org-hugo--yaml-quote-string param-value)))
+                                 (setq res-param-str
+                                       (concat res-param-str
+                                               (format "%s%s%s %s\n"
+                                                       indent param-key sign param-value-str)))))
+                             ;; (message "[resources params DBG] %s" res-param-str)
+                             )
+                            (t
+                             (when (string= res-key "src")
+                               (setq res-src-present t))
+                             (if (string= res-key "src")
+                                 (setq indent "- ")
+                               (setq indent "  "))
+                             (setq res-value (org-hugo--yaml-quote-string res-value))
+                             (setq res-value-str
+                                   (concat res-value-str
+                                           (format "%s%s%s %s\n"
+                                                   indent res-key sign res-value)))))))
+                  (unless res-src-present
+                    (user-error "`src' must be set for the `resources'"))
+                  (setq res-string (concat res-string res-entry-str res-value-str res-param-str))))))
+           (;; Front-matter with nested map values: blackfriday, custom front-matter.
+            ;; Only 1 level of nesting is supported.
+            (and (listp value) ;Example value: '((legs . 4) ("eyes" . 2) (friends . (poo boo)))
+                 (eq 0 (cl-count-if (lambda (el) ;Check if value is a list of lists (or conses)
+                                      (not (listp el)))
+                                    value)))
+            (let ((nested-parent-key key)
+                  (nested-alist value)
+                  (nested-parent-key-str "")
+                  (nested-keyval-str ""))
+              ;; (message "[nested entry DBG] = %s" nested-parent-key)
+              ;; (message "[nested alist DBG] = %S" nested-alist)
+              (setq nested-parent-key-str (format "%s%s\n" nested-parent-key sign))
+              (dolist (nested-pair nested-alist)
+                (unless (consp nested-pair)
+                  (user-error "Ox-hugo: Custom front-matter values with nested maps need to be an alist of conses"))
+                ;; (message "[nested pair DBG] = %S" nested-pair)
+                (let* ((nested-key (car nested-pair))
+                       (nested-key (cond
+                                    ((symbolp nested-key)
+                                     (symbol-name nested-key))
+                                    (t
+                                     nested-key)))
+                       (nested-value (cdr nested-pair))
+                       (nested-value (cond
+                                      ((and nested-value
+                                            (listp nested-value))
+                                       (if (and (string= nested-parent-key "blackfriday")
+                                                (or (string= nested-key "extensions")
+                                                    (string= nested-key "extensionsmask")))
+                                           (org-hugo--get-yaml-list-string
+                                            nested-key
+                                            (mapcar #'org-hugo--return-valid-blackfriday-extension
+                                                    nested-value))
+                                         (org-hugo--get-yaml-list-string nested-key nested-value)))
+                                      ((null nested-value)
+                                       "false")
+                                      ((equal nested-value 't)
+                                       "true")
+                                      (t
+                                       (org-hugo--yaml-quote-string nested-value)))))
+                  ;; (message "nested DBG: %S KEY %S->%S VALUE %S->%S" nested-parent-key
+                  ;;          (car nested-pair) nested-key
+                  ;;          (cdr nested-pair) nested-value)
+                  (when nested-value
+                    (setq nested-keyval-str
+                          (concat nested-keyval-str
+                                  (format "%s%s%s %s\n"
+                                          indent nested-key sign nested-value))))))
+              (when (org-string-nw-p nested-keyval-str)
+                (setq nested-string (concat nested-string nested-parent-key-str
+                                            nested-keyval-str)))))
+           (t
+            (setq front-matter
+                  (concat front-matter
+                          (format "%s%s %s\n"
+                                  key
+                                  sign
+                                  (cond (;; Tags, categories, keywords, aliases,
+                                         ;; custom front-matter which are lists.
+                                         (listp value)
+                                         (org-hugo--get-yaml-list-string key value))
+                                        (t
+                                         (org-hugo--yaml-quote-string value nil)))))))))))
+    (concat sep front-matter nested-string menu-string res-string sep)))
 
 
 (provide 'ox-hugo-deprecated)

--- a/ox-hugo-pandoc-cite.el
+++ b/ox-hugo-pandoc-cite.el
@@ -378,6 +378,10 @@ References:
          (csl (cdr (assoc 'csl data)))
          (nocite (cdr (assoc 'nocite data))))
     (push "---" yaml)
+    (when link-citations
+      (push (format "link-citations: %s"
+                    (org-hugo--front-matter-value-booleanize link-citations))
+            yaml))
     (when csl
       (push (format "csl: %S" csl) yaml))
     (when nocite
@@ -388,13 +392,9 @@ References:
                              nocite)
                      ", "))
             yaml))
-    (when link-citations
-      (push (format "link-citations: %s"
-                    (org-hugo--front-matter-value-booleanize link-citations))
-            yaml))
-    (push "---" yaml)
+    (push "---\n" yaml)
     ;; (message "[org-hugo-pandoc-cite--meta-data-generator DBG] yaml: %S" yaml)
-    (string-join yaml "\n")))
+    (string-join (nreverse yaml) "\n")))
 
 
 (provide 'ox-hugo-pandoc-cite)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -85,6 +85,7 @@
 (require 'org-id)                       ;For `org-id-find'
 
 (declare-function org-hugo-pandoc-cite--parse-citations-maybe "ox-hugo-pandoc-cite")
+(declare-function org-hugo-pandoc-cite--meta-data-generator "ox-hugo-pandoc-cite")
 
 (require 'ox-hugo-deprecated)
 
@@ -3927,8 +3928,10 @@ INFO is a plist used as a communication channel."
         ;; Pandoc parses fields like csl and nocite from YAML
         ;; front-matter.  So create the `org-hugo--fm-yaml'
         ;; front-matter in YAML format just for Pandoc.
-        (setq org-hugo--fm-yaml (org-hugo--gen-yaml-front-matter data))
+        (setq org-hugo--fm-yaml
+              (org-hugo-pandoc-cite--meta-data-generator data))
       (setq org-hugo--fm-yaml ret))
+    ;; (message "org-hugo--fm-yaml: %s" org-hugo--fm-yaml)
     ret))
 
 (defun org-hugo--calc-weight ()

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -3933,7 +3933,7 @@ INFO is a plist used as a communication channel."
           (setq org-hugo--fm-yaml
                 (org-hugo-pandoc-cite--meta-data-generator data)))
       (setq org-hugo--fm-yaml ret))
-    ;; (message "org-hugo--fm-yaml: %s" org-hugo--fm-yaml)
+    ;; (message "org-hugo--fm-yaml: `%s'" org-hugo--fm-yaml)
     ret))
 
 (defun org-hugo--calc-weight ()

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -3925,11 +3925,13 @@ INFO is a plist used as a communication channel."
     (setq ret (org-hugo--gen-front-matter data fm-format))
     (if (and (string= "toml" fm-format)
              (org-hugo--pandoc-citations-enabled-p info))
-        ;; Pandoc parses fields like csl and nocite from YAML
-        ;; front-matter.  So create the `org-hugo--fm-yaml'
-        ;; front-matter in YAML format just for Pandoc.
-        (setq org-hugo--fm-yaml
-              (org-hugo-pandoc-cite--meta-data-generator data))
+        (progn
+          ;; Pandoc parses fields like csl and nocite from YAML
+          ;; front-matter.  So create the `org-hugo--fm-yaml'
+          ;; front-matter in YAML format just for Pandoc.
+          (require 'ox-hugo-pandoc-cite)
+          (setq org-hugo--fm-yaml
+                (org-hugo-pandoc-cite--meta-data-generator data)))
       (setq org-hugo--fm-yaml ret))
     ;; (message "org-hugo--fm-yaml: %s" org-hugo--fm-yaml)
     ret))

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -110,7 +110,7 @@ Emacs installation.  If Emacs is installed using
 (when ox-hugo-test-setup-verbose
   (message "ox-hugo-tmp-dir: %s" ox-hugo-tmp-dir))
 
-(defvar ox-hugo-packages '(toc-org citeproc org-ref))
+(defvar ox-hugo-packages '(toc-org citeproc org-ref tomelr))
 (when ox-hugo-install-org-from-elpa
   ;; Fri Sep 22 18:24:19 EDT 2017 - kmodi
   ;; Install the packages in the specified order. We do not want

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -160,6 +160,12 @@ Emacs installation.  If Emacs is installed using
         (add-to-list 'package-archives (cons "melpa" melpa-url) :append) ;For `toc-org', `citeproc'
         )
 
+      ;; Workaround for this error on GHA when using Emacs 26.3:
+      ;;   signal(file-error ("https://elpa.gnu.org/packages/tomelr-0.2.2.tar" "Bad Request"))
+      (when (version< emacs-version "27.0")
+        ;; https://lists.gnu.org/archive/html/help-gnu-emacs/2020-01/msg00162.html
+        (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))
+
       ;; Delete element with "nongnu" car from `package-archives'.
       (setq package-archives (delq (assoc "nongnu" package-archives) package-archives))
 

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7556,7 +7556,7 @@ the ~.Permalink~ and ~.RelPermalink~ get set to ~""~.
 *** _build: Don't render or list this page   :dont_render:dont_list:headless:
 :PROPERTIES:
 :EXPORT_FILE_NAME: do-not-render-or-list
-:EXPORT_HUGO_CUSTOM_FRONT_MATTER: :_build '((render . nil) (list . nil))
+:EXPORT_HUGO_CUSTOM_FRONT_MATTER: :_build '((render . false) (list . false))
 :END:
 #+begin_description
 Do not render or list this page.

--- a/test/site/content-org/keyword-collection.org
+++ b/test/site/content-org/keyword-collection.org
@@ -60,6 +60,7 @@
 #+hugo_outputs: json
 
 # Resources
+#+hugo_resources: :src "*.png" :name "my-cool-image-:counter" :title "The Image #:counter"
 #+hugo_resources: :src "*.png" :animals '(dog cat "penguin" "mountain gorilla")
 #+hugo_resources: :strings-symbols '("abc" def "two words")
 #+hugo_resources: :integers '(123 -5 17 1_234)
@@ -67,7 +68,6 @@
 #+hugo_resources: :booleans '(true false)
 #+hugo_resources: :foo bar
 #+hugo_resources: :src "image-4.png" :title "The Fourth Image"
-#+hugo_resources: :src "*.png" :name "my-cool-image-:counter" :title "The Image #:counter"
 #+hugo_resources: :src "*.png" :byline "bep"
 #+hugo_resources: :src "*.jpg" :title "JPEG Image #:counter"
 

--- a/test/site/content-org/single-posts/post-toml.org
+++ b/test/site/content-org/single-posts/post-toml.org
@@ -2,7 +2,7 @@
 #+author:
 #+date: 2017-07-20
 
-#+filetags: single toml "cross-link" @cat1 @cat2
+#+filetags: single toml cross-link @cat1 @cat2
 
 #+hugo_base_dir: ../../
 #+hugo_section: singles

--- a/test/site/content/posts/custom-front-matter-multiple-lines.md
+++ b/test/site/content/posts/custom-front-matter-multiple-lines.md
@@ -8,6 +8,7 @@ baz = "zoo"
 alpha = 1
 beta = "two words"
 gamma = 10
+empty_string = ""
 +++
 
 From [**(org) Property Syntax**](https://orgmode.org/manual/Property-Syntax.html):

--- a/test/site/content/posts/custom-front-matter-with-nested-maps-toml.md
+++ b/test/site/content/posts/custom-front-matter-with-nested-maps-toml.md
@@ -12,7 +12,6 @@ draft = false
   caption = "stay hungry, stay foolish"
 [collection]
   animals = ["dog", "cat", "penguin", "mountain gorilla"]
-  nothing = false
   nonnil = true
   strings-symbols = ["abc", "def", "two words"]
   integers = [123, -5, 17, 1_234]

--- a/test/site/content/posts/hugo-keyword.md
+++ b/test/site/content/posts/hugo-keyword.md
@@ -1,6 +1,8 @@
 +++
 title = "Hugo keyword"
-description = "Stuff followed the `#+hugo:` exports as-is except when it is \"more\""
+description = """
+  Stuff followed the `#+hugo:` exports as-is except when it is "more"
+  """
 tags = ["body", "keyword", "hugo"]
 draft = false
 +++

--- a/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-1.md
+++ b/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-1.md
@@ -1,7 +1,8 @@
 +++
 title = "Post with menu 1 (HUGO_MENU as keyword)"
 draft = false
-[menu."auto weight"]
-  weight = 1001
-  identifier = "post-with-menu-1-hugo-menu-as-keyword"
+[menu]
+  [menu."auto weight"]
+    weight = 1001
+    identifier = "post-with-menu-1-hugo-menu-as-keyword"
 +++

--- a/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-2.md
+++ b/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-2.md
@@ -1,7 +1,8 @@
 +++
 title = "Post with menu 2 (HUGO_MENU as keyword)"
 draft = false
-[menu."auto weight"]
-  weight = 1002
-  identifier = "post-with-menu-2-hugo-menu-as-keyword"
+[menu]
+  [menu."auto weight"]
+    weight = 1002
+    identifier = "post-with-menu-2-hugo-menu-as-keyword"
 +++

--- a/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-3.md
+++ b/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-3.md
@@ -1,7 +1,8 @@
 +++
 title = "Post with menu 3 (HUGO_MENU as keyword)"
 draft = false
-[menu."auto weight"]
-  weight = 1003
-  identifier = "post-with-menu-3-hugo-menu-as-keyword"
+[menu]
+  [menu."auto weight"]
+    weight = 1003
+    identifier = "post-with-menu-3-hugo-menu-as-keyword"
 +++

--- a/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-4.md
+++ b/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-4.md
@@ -1,7 +1,8 @@
 +++
 title = "Post with menu 4 (HUGO_MENU as keyword)"
 draft = false
-[menu."auto weight"]
-  weight = 1004
-  identifier = "post-with-menu-4-hugo-menu-as-keyword"
+[menu]
+  [menu."auto weight"]
+    weight = 1004
+    identifier = "post-with-menu-4-hugo-menu-as-keyword"
 +++

--- a/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-5.md
+++ b/test/site/content/posts/hugo-menu-as-keyword-post-with-menu-5.md
@@ -1,7 +1,8 @@
 +++
 title = "Post with menu 5 (HUGO_MENU as keyword)"
 draft = false
-[menu."auto weight"]
-  weight = 1005
-  identifier = "post-with-menu-5-hugo-menu-as-keyword"
+[menu]
+  [menu."auto weight"]
+    weight = 1005
+    identifier = "post-with-menu-5-hugo-menu-as-keyword"
 +++

--- a/test/site/content/posts/keyword-collection.md
+++ b/test/site/content/posts/keyword-collection.md
@@ -31,16 +31,16 @@ booleans = [true, false]
   image = "projects/Readingabook.jpg"
   caption = "stay hungry, stay foolish"
 [collection]
-  nothing = false
   nonnil = true
   animals = ["dog", "cat", "penguin", "mountain gorilla"]
   strings-symbols = ["abc", "def", "two words"]
   integers = [123, -5, 17, 1_234]
   floats = [12.3, -5.0, -1.7e-05]
   booleans = [true, false]
-[menu.foo]
-  identifier = "keyword-collection"
-  weight = 10
+[menu]
+  [menu.foo]
+    identifier = "keyword-collection"
+    weight = 10
 [[resources]]
   src = "*.png"
   name = "my-cool-image-:counter"

--- a/test/site/content/posts/menu-alist-meta-data-toml-override-full.md
+++ b/test/site/content/posts/menu-alist-meta-data-toml-override-full.md
@@ -3,9 +3,10 @@ title = "Overriding menu properties completely"
 date = 2017-07-18
 tags = ["menu"]
 draft = false
-[menu.test]
-  identifier = "overriding-menu-properties-completely"
-  weight = 50
+[menu]
+  [menu.test]
+    identifier = "overriding-menu-properties-completely"
+    weight = 50
 +++
 
 For this post, we see that no menu properties are inherited from the

--- a/test/site/content/posts/menu-alist-meta-data-toml-override-partial.md
+++ b/test/site/content/posts/menu-alist-meta-data-toml-override-partial.md
@@ -3,10 +3,11 @@ title = "Overriding few menu properties"
 date = 2017-07-18
 tags = ["menu"]
 draft = false
-[menu."something here"]
-  parent = "posts"
-  weight = 10
-  identifier = "ov-partial"
+[menu]
+  [menu."something here"]
+    parent = "posts"
+    weight = 10
+    identifier = "ov-partial"
 +++
 
 For this post, we should see just the menu _weight_ and _identifier_

--- a/test/site/content/posts/menu-meta-data-yaml.md
+++ b/test/site/content/posts/menu-meta-data-yaml.md
@@ -5,9 +5,9 @@ tags: ["menu", "yaml"]
 draft: false
 menu:
   main:
-    identifier: "yaml-menu-override"
-    weight: 25
     parent: "posts"
+    weight: 25
+    identifier: "yaml-menu-override"
 ---
 
 Testing the addition of _menu_ meta data to the YAML front

--- a/test/site/content/posts/menu-title-property.md
+++ b/test/site/content/posts/menu-title-property.md
@@ -2,10 +2,11 @@
 title = "Menu Title property"
 tags = ["menu", "title"]
 draft = false
-[menu.test]
-  weight = 3003
-  identifier = "menu-title-property"
-  title = "Page title for menu"
+[menu]
+  [menu.test]
+    weight = 3003
+    identifier = "menu-title-property"
+    title = "Page title for menu"
 +++
 
 The `title` property for menu entries was introduced in Hugo v0.32 in

--- a/test/site/content/posts/post-description-quotes.md
+++ b/test/site/content/posts/post-description-quotes.md
@@ -1,6 +1,10 @@
 +++
-title = "Description meta-data with \"quoted text\""
-description = "Some description with \"quoted text\""
+title = """
+  Description meta-data with "quoted text"
+  """
+description = """
+  Some description with "quoted text"
+  """
 date = 2017-07-24
 tags = ["front-matter", "description"]
 draft = false

--- a/test/site/content/posts/post-title-quotes.md
+++ b/test/site/content/posts/post-title-quotes.md
@@ -1,5 +1,7 @@
 +++
-title = "Awesome title with \"quoted text\""
+title = """
+  Awesome title with "quoted text"
+  """
 date = 2017-07-24
 tags = ["title"]
 draft = false

--- a/test/site/content/posts/post-with-menu-1.md
+++ b/test/site/content/posts/post-with-menu-1.md
@@ -3,7 +3,8 @@ title = "Post with menu 1"
 date = 2017-07-20
 tags = ["menu"]
 draft = false
-[menu."auto weight"]
-  weight = 4001
-  identifier = "post-with-menu-1"
+[menu]
+  [menu."auto weight"]
+    weight = 4001
+    identifier = "post-with-menu-1"
 +++

--- a/test/site/content/posts/post-with-menu-2.md
+++ b/test/site/content/posts/post-with-menu-2.md
@@ -3,7 +3,8 @@ title = "Post with menu 2"
 date = 2017-07-20
 tags = ["menu"]
 draft = false
-[menu."auto weight"]
-  weight = 4002
-  identifier = "post-with-menu-2"
+[menu]
+  [menu."auto weight"]
+    weight = 4002
+    identifier = "post-with-menu-2"
 +++

--- a/test/site/content/posts/post-with-menu-3.md
+++ b/test/site/content/posts/post-with-menu-3.md
@@ -3,7 +3,8 @@ title = "Post with menu 3"
 date = 2017-07-20
 tags = ["menu"]
 draft = false
-[menu."auto weight"]
-  weight = 4003
-  identifier = "post-with-menu-3"
+[menu]
+  [menu."auto weight"]
+    weight = 4003
+    identifier = "post-with-menu-3"
 +++

--- a/test/site/content/posts/post-with-menu-4.md
+++ b/test/site/content/posts/post-with-menu-4.md
@@ -3,7 +3,8 @@ title = "Post with menu 4"
 date = 2017-07-20
 tags = ["menu"]
 draft = false
-[menu."auto weight"]
-  weight = 4004
-  identifier = "post-with-menu-4"
+[menu]
+  [menu."auto weight"]
+    weight = 4004
+    identifier = "post-with-menu-4"
 +++

--- a/test/site/content/posts/post-with-menu-5.md
+++ b/test/site/content/posts/post-with-menu-5.md
@@ -3,7 +3,8 @@ title = "Post with menu 5"
 date = 2017-07-20
 tags = ["menu"]
 draft = false
-[menu."auto weight"]
-  weight = 4005
-  identifier = "post-with-menu-5"
+[menu]
+  [menu."auto weight"]
+    weight = 4005
+    identifier = "post-with-menu-5"
 +++

--- a/test/site/content/posts/replace-both-tags-and-categories-keys.md
+++ b/test/site/content/posts/replace-both-tags-and-categories-keys.md
@@ -1,5 +1,7 @@
 +++
-title = "Replace both \"tags\" and \"categories\" keys"
+title = """
+  Replace both "tags" and "categories" keys
+  """
 keywords = ["front-matter", "keys", "replace", "tags", "categories"]
 cats = ["test-cat-x"]
 draft = false

--- a/test/site/content/posts/replace-description-with-summary.md
+++ b/test/site/content/posts/replace-description-with-summary.md
@@ -1,5 +1,7 @@
 +++
-title = "Replace \"description\" with \"summary\""
+title = """
+  Replace "description" with "summary"
+  """
 summary = """
   This should be rendered as `.Summary` in Hugo v0.55+. For only Hugo
   versions, this will front-matter can be retrieved only as

--- a/test/site/content/posts/replace-only-categories-key.md
+++ b/test/site/content/posts/replace-only-categories-key.md
@@ -1,5 +1,7 @@
 +++
-title = "Replace only \"categories\" key"
+title = """
+  Replace only "categories" key
+  """
 tags = ["front-matter", "keys", "replace", "categories"]
 cats = ["test-cat-x"]
 draft = false

--- a/test/site/content/posts/replace-only-linktitle-key.md
+++ b/test/site/content/posts/replace-only-linktitle-key.md
@@ -1,6 +1,10 @@
 +++
-title = "Replace only \"linkTitle\" key"
-linktitle = "Replace only \"linkTitle\" key"
+title = """
+  Replace only "linkTitle" key
+  """
+linktitle = """
+  Replace only "linkTitle" key
+  """
 tags = ["front-matter", "keys", "replace", "linktitle"]
 draft = false
 +++

--- a/test/site/content/posts/replace-only-tags-key.md
+++ b/test/site/content/posts/replace-only-tags-key.md
@@ -1,5 +1,7 @@
 +++
-title = "Replace only \"tags\" key"
+title = """
+  Replace only "tags" key
+  """
 keywords = ["front-matter", "keys", "replace", "tags"]
 draft = false
 +++

--- a/test/site/content/posts/title-with-just-date-chars.md
+++ b/test/site/content/posts/title-with-just-date-chars.md
@@ -1,5 +1,5 @@
 +++
-title = "2020-04-19"
+title = 2020-04-19
 description = """
   Test the case where the title contains only the date, making it look
   like a Hugo TOML date field.

--- a/test/site/content/root-level-content-section-set-to-slash.md
+++ b/test/site/content/root-level-content-section-set-to-slash.md
@@ -1,5 +1,7 @@
 +++
-title = "Setting EXPORT_HUGO_SECTION to \"/\""
+title = """
+  Setting EXPORT_HUGO_SECTION to "/"
+  """
 description = "Case where `EXPORT_HUGO_SECTION` is set to `/`."
 tags = ["section", "root-level"]
 draft = false

--- a/test/site/content/search.md
+++ b/test/site/content/search.md
@@ -5,10 +5,11 @@ outputs = ["html", "json"]
 draft = false
 [sitemap]
   priority = 0.1
-[menu."0.search"]
-  weight = 2001
-  identifier = "search"
-  title = "Click to Search"
+[menu]
+  [menu."0.search"]
+    weight = 2001
+    identifier = "search"
+    title = "Click to Search"
 +++
 
 Results from static site search implemented using _Fusejs_, _jquery_

--- a/test/site/content/singles/post-draft.md
+++ b/test/site/content/singles/post-draft.md
@@ -4,10 +4,11 @@ date = 2017-07-20
 tags = ["single", "toml"]
 categories = ["cat1", "cat2"]
 draft = true
-[menu.foo]
-  identifier = "single-post-but-draft"
-  parent = "main"
-  weight = 10
+[menu]
+  [menu.foo]
+    identifier = "single-post-but-draft"
+    parent = "main"
+    weight = 10
 +++
 
 This is a single post. You do not need to set the `EXPORT_FILE_NAME`

--- a/test/site/content/singles/post-toml.md
+++ b/test/site/content/singles/post-toml.md
@@ -5,10 +5,11 @@ date = 2017-07-20
 tags = ["single", "toml", "cross-link"]
 categories = ["cat1", "cat2"]
 draft = false
-[menu.foo]
-  parent = "main"
-  weight = 10
-  identifier = "single-toml"
+[menu]
+  [menu.foo]
+    parent = "main"
+    weight = 10
+    identifier = "single-toml"
 +++
 
 This is a single post. You do not need to set the `EXPORT_FILE_NAME`

--- a/test/site/content/writing-hugo-blog-in-org-file-export.md
+++ b/test/site/content/writing-hugo-blog-in-org-file-export.md
@@ -12,9 +12,10 @@ baz = "zoo"
 alpha = 1
 beta = "two words"
 gamma = 10
-[menu.main]
-  identifier = "writing-hugo-blog-in-org-file-export"
-  weight = 2001
+[menu]
+  [menu.main]
+    identifier = "writing-hugo-blog-in-org-file-export"
+    weight = 2001
 +++
 
 ## First heading within the post {#first-heading-within-the-post}

--- a/test/site/content/writing-hugo-blog-in-org-subtree-export.md
+++ b/test/site/content/writing-hugo-blog-in-org-subtree-export.md
@@ -12,9 +12,10 @@ baz = "zoo"
 alpha = 1
 beta = "two words"
 gamma = 10
-[menu.main]
-  weight = 2001
-  identifier = "writing-hugo-blog-in-org"
+[menu]
+  [menu.main]
+    weight = 2001
+    identifier = "writing-hugo-blog-in-org"
 +++
 
 ## First heading within the post {#first-heading-within-the-post}


### PR DESCRIPTION
Move YAML generation logic to ox-hugo-deprecated.el.

NOTE: At some point, YAML generation support will be removed entirely.

**Minor breaking changes:**
- Empty strings are not considered as nil.
- Nil is not considered as TOML false. A key with nil value
  means that it doesn't need to be exported to TOML.

Cosmetic changes:
- Multi-line strings are auto-generated if the string contains double
  quotes.