### PR TITLE
fix!: Export Org Verse blocks in div tags instead of p tags

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -1519,7 +1519,7 @@ contextual information."
                (lambda (m)
                  (org-html--make-string (length m) "&nbsp;"))
                ret))
-         (ret (format "<p class=\"verse\">\n\n%s\n</p>" ret)))
+         (ret (format "<div class=\"verse\">\n\n%s\n</div>" ret)))
     ret))
 
 

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -4542,6 +4542,17 @@ Testing quote blocks in numbered lists, just because this came up on
 To preserve the line breaks, indentation and blank lines in a region,
 but otherwise use normal formatting, you can use the /verse/
 construct, which can also be used to format poetry -- [[https://orgmode.org/manual/Paragraphs.html][Reference]].
+
+#+begin_export html
+<style>
+  .verse {
+    color: red;
+  }
+</style>
+#+end_export
+
+/Below verse should render in red./
+
 #+begin_verse
 Great clouds overhead
 Tiny black birds rise and fall

--- a/test/site/content/posts/consecutive-verses.md
+++ b/test/site/content/posts/consecutive-verses.md
@@ -5,7 +5,7 @@ tags = ["verse"]
 draft = false
 +++
 
-<p class="verse">
+<div class="verse">
 
 Tyger Tyger, burning bright,<br />
 In the forests of the night;<br />
@@ -19,17 +19,17 @@ What the hand, dare seize the fire?<br />
 <br />
 &nbsp;&nbsp;&nbsp;-- "The Tyger" _by_ William Blake<br />
 
-</p>
+</div>
 
-<p class="verse">
+<div class="verse">
 
 Some parts can be **bold**<br />
 &nbsp;&nbsp;Some can be `monospace`<br />
 &nbsp;&nbsp;&nbsp;&nbsp;Some can be _italic_ too.<br />
 
-</p>
+</div>
 
-<p class="verse">
+<div class="verse">
 
 What is this life if, full of care,<br />
 We have no time to stand and stare.<br />
@@ -42,4 +42,4 @@ Where squirrels hide their nuts in grass.<br />
 <br />
 &nbsp;&nbsp;&nbsp;-- "Leisure" _by_ William Henry Davis<br />
 
-</p>
+</div>

--- a/test/site/content/posts/one-verse.md
+++ b/test/site/content/posts/one-verse.md
@@ -9,7 +9,15 @@ To preserve the line breaks, indentation and blank lines in a region,
 but otherwise use normal formatting, you can use the _verse_
 construct, which can also be used to format poetry -- [Reference](https://orgmode.org/manual/Paragraphs.html).
 
-<p class="verse">
+<style>
+  .verse {
+    color: red;
+  }
+</style>
+
+_Below verse should render in red._
+
+<div class="verse">
 
 Great clouds overhead<br />
 Tiny black birds rise and fall<br />
@@ -17,4 +25,4 @@ Snow covers Emacs<br />
 <br />
 &nbsp;&nbsp;&nbsp;&nbsp;-- AlexSchroeder<br />
 
-</p>
+</div>

--- a/test/site/content/posts/verse-for-indentation.md
+++ b/test/site/content/posts/verse-for-indentation.md
@@ -6,11 +6,11 @@ draft = false
 
 Some text before indented text.
 
-<p class="verse">
+<div class="verse">
 
 &nbsp;&nbsp;&nbsp;&nbsp;Text indented by 4 spaces<br />
 
-</p>
+</div>
 
 Org removes indentation from the first line of the text block even in
 a Verse block. To get around that, the trick is to use the `>`
@@ -23,35 +23,35 @@ removed when translating to Markdown.
 
 -   More indentation than in the above example:
 
-    <p class="verse">
+    <div class="verse">
 
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Text indented by 8 spaces<br />
 
-    </p>
+    </div>
 -   Leading blank line followed by indented text:
 
-    <p class="verse">
+    <div class="verse">
 
     <br />
     &nbsp;&nbsp;&nbsp;&nbsp;Text indented by 4 spaces<br />
 
-    </p>
+    </div>
 -   Indented text followed by a trailing blank line:
 
-    <p class="verse">
+    <div class="verse">
 
     &nbsp;&nbsp;&nbsp;&nbsp;Text indented by 4 spaces<br />
     <br />
 
-    </p>
+    </div>
 -   Using tab characters for indentation; each tab character still
     constitutes for one `&nbsp;` in HTML.
 
-    <p class="verse">
+    <div class="verse">
 
     &nbsp;&nbsp;&nbsp;&nbsp;Text indented by 4 tab characters<br />
 
-    </p>
+    </div>
 
 
 ## Corner cases {#corner-cases}
@@ -69,7 +69,7 @@ Line 5 has this > charcter in-between and is retained.
 Only the **first** `>` character immediately following spaces and empty
 lines will be removed:
 
-<p class="verse">
+<div class="verse">
 
 <br />
 Line 1 above was empty. So the first `>` seen on this line is removed.<br />
@@ -77,7 +77,7 @@ Line 3 had no `>` char.<br />
 &gt; ← See that this `>` on line 4 is retained even at the beginning of the line.<br />
 Line 5 has this &gt; charcter in-between and is retained.<br />
 
-</p>
+</div>
 
 If someone really wants to have `>` as the first non-blank character
 in the final output, they can use `>>` instead.. **only for that first
@@ -94,7 +94,7 @@ Line 5 has this > charcter in-between and is retained.
 #+end_verse
 ```
 
-<p class="verse">
+<div class="verse">
 
 <br />
 &gt;Line 1 above was empty. So **only** the first `>` seen on this line is removed.<br />
@@ -102,4 +102,4 @@ Line 3 had no `>` char.<br />
 &gt; ← See that this `>` on line 4 is retained even at the beginning of the line.<br />
 Line 5 has this &gt; charcter in-between and is retained.<br />
 
-</p>
+</div>


### PR DESCRIPTION
This change is required so that CSS rules for .verse class **actually
work**. So while this is technically a breaking change, this change
actually fixes the CSS for .verse which never worked earlier.

Fixes https://github.com/kaushalmodi/ox-hugo/issues/633.

*User Action*:

  CSS required to style the verse blocks before this fix:

      p.verse + p {
        ..
      }

  CSS required after this fix:

      .verse {
        ..
      }

@pdcawley