### PR TITLE
Improvements in date parsing from LOGBOOK drawers

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -876,8 +876,9 @@ Also see the [[*Custom Front-matter Parameters][Custom Front-matter Parameters]]
   4. =#+date:= keyword
 - Precedence for =lastmod= parsing ::
   1. Last (second or later) transition to a /DONE/ state recorded in
-     =:LOGBOOK:= (see {{{titleref(Drawers#logbook-dates,Dates parsed
-     from ~:LOGBOOK:~ drawers)}}})
+     =:LOGBOOK:=, or timestamp of the last added note (see
+     {{{titleref(Drawers#logbook-dates,Dates parsed from ~:LOGBOOK:~
+     drawers)}}})
   2. =lastmod= set automatically if =:EXPORT_HUGO_AUTO_SET_LASTMOD: t=
      *and* if it's not derived from the =:LOGBOOK:= drawer.
   3. =EXPORT_HUGO_LASTMOD= subtree property or =#+hugo_lastmod:= keyword
@@ -4410,10 +4411,8 @@ state changed or under the heading where the ~org-add-note~ command
   ~org-done-keywords~ values[fn:15] i.e. transition to /DONE/ state.
 - ~lastmod~ :: This front-matter variable is updated with the
   timestamp associated with the *last* TODO state transition to the
-  /DONE/ state.
-
-  Note that if only one transition to the /DONE/ state was recorded,
-  then this front-matter variable remains unset.
+  /DONE/ state, or with the *last* added note (whichever is the
+  latest).
 
 #+begin_note
 The ~date~ and ~lastmod~ values parsed from the ~:LOGBOOK:~ drawer

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1846,7 +1846,8 @@ holding contextual information."
                             (when to-state
                               (push `(to_state . ,to-state) logbook-entry)
                               ;; (message "[ox-hugo logbook DBG] org-done-keywords: %S" org-done-keywords)
-                              (when (member to-state org-done-keywords)
+                              (when (and (null sub-heading) ;Parse dates from only the toplevel LOGBOOK drawer.
+                                         (member to-state org-done-keywords))
                                 ;; The first parsed TODO state change entry will be the
                                 ;; latest one, and `:logbook-date' would already have
                                 ;; been set to that.  So if `:logbook-lastmod' is not set,
@@ -1872,8 +1873,9 @@ holding contextual information."
                             ;; note's timestamp.
                             ;; *This always works because the newest state change or note
                             ;; entry is always put to the top of the LOGBOOK.*
-                            (unless (plist-get info :logbook-lastmod)
-                              (plist-put info :logbook-lastmod timestamp))))
+                            (unless sub-heading ;Parse dates from only the toplevel LOGBOOK drawer.
+                              (unless (plist-get info :logbook-lastmod)
+                                (plist-put info :logbook-lastmod timestamp)))))
 
                          (t
                           (user-error "LOGBOOK drawer entry is neither a state change, nor a note."))))

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7313,6 +7313,12 @@ This test removes the ~foo~ front-matter key from the exported file
 :EXPORT_FILE_NAME: parsing-notes-from-logbook
 :END:
 :LOGBOOK:
+- Note taken on [2022-05-12 Thu 08:13] \\
+  Another update to the post. This update timestamp should update the
+  ~lastmod~.
+- State "DONE"       from "TEST__TODO" <2022-05-10 Tue 08:13>
+- State "TODO"       from "DRAFT"      <2022-05-08 Sun 06:13>
+- State "DRAFT"      from "DONE"       <2022-05-06 Fri 04:12>
 - Note taken on [2022-05-04 Wed 13:15] \\
   This new note added last should be the first element of the
   ~[[logbook.notes]]~ TOML table array.
@@ -7366,6 +7372,8 @@ note first in the TOML table array to the oldest note at the last.
 #+begin_description
 Parse notes from LOGBOOK drawers in top-level and nested headings.
 #+end_description
+The ~lastmod~ field is not set for this post (even if it has a note
+with timestamp) because this post is not marked as DONE.
 **** Sub-heading
 :LOGBOOK:
 - Note taken on [2022-05-11 Wed 12:18] \\

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -7384,6 +7384,27 @@ with timestamp) because this post is not marked as DONE.
 - Note taken on [2022-05-11 Wed 17:12] \\
   Another note in a different sub heading.
 :END:
+*** DONE Post marked as DONE with LOGBOOK Notes in nested headings  :lastmod:
+:PROPERTIES:
+:EXPORT_FILE_NAME: logbook-done-post-with-notes-in-sub-headings
+:END:
+:LOGBOOK:
+- State "DONE"       from "DRAFT"      <2022-05-01 Sun 08:49>
+- State "DRAFT"      from "TODO"       <2022-04-17 Sun 08:49>
+- State "TODO"       from              <2022-04-01 Fri 08:48>
+:END:
+#+begin_description
+Parse notes from LOGBOOK drawers in top-level and nested headings.
+#+end_description
+The ~lastmod~ field is not set for this post (even if it has a note
+with timestamp) because this post is not marked as DONE.
+**** Sub-heading
+:LOGBOOK:
+- Note taken on [2022-05-12 Thu 08:49] \\
+  This LOGBOOK note was added in a sub-heading *after* the post was
+  marked DONE, but this note's timestamp should not affect the post's
+  ~lastmod~ field (because this is not the toplevel LOGBOOK drawer).
+:END:
 ** Extra Front-matter tests                        :extra:verbatim:src_block:
 *** Extra Front-matter
 :PROPERTIES:

--- a/test/site/content/posts/logbook-done-post-with-notes-in-sub-headings.md
+++ b/test/site/content/posts/logbook-done-post-with-notes-in-sub-headings.md
@@ -1,0 +1,23 @@
++++
+title = "Post marked as DONE with LOGBOOK Notes in nested headings"
+description = "Parse notes from LOGBOOK drawers in top-level and nested headings."
+date = 2022-05-01T08:49:00+00:00
+layout = "alternate-single"
+tags = ["front-matter", "notes", "logbook", "lastmod"]
+draft = false
+[logbook]
+  [logbook.Sub-heading]
+    [[logbook.Sub-heading.notes]]
+      timestamp = 2022-05-12T08:49:00+00:00
+      note = """
+  This LOGBOOK note was added in a sub-heading **after** the post was
+  marked DONE, but this note's timestamp should not affect the post's
+  `lastmod` field (because this is not the toplevel LOGBOOK drawer).
+  """
++++
+
+The `lastmod` field is not set for this post (even if it has a note
+with timestamp) because this post is not marked as DONE.
+
+
+## Sub-heading {#sub-heading}

--- a/test/site/content/posts/logbook-notes-in-nested-headings.md
+++ b/test/site/content/posts/logbook-notes-in-nested-headings.md
@@ -19,6 +19,10 @@ draft = false
       note = "Note in the top-heading LOGBOOK drawer"
 +++
 
+The `lastmod` field is not set for this post (even if it has a note
+with timestamp) because this post is not marked as DONE.
+
+
 ## Sub-heading {#sub-heading}
 
 

--- a/test/site/content/posts/parsing-notes-from-logbook.md
+++ b/test/site/content/posts/parsing-notes-from-logbook.md
@@ -6,10 +6,17 @@ description = """
   """
 date = 2018-09-06T11:25:00+00:00
 layout = "alternate-single"
+lastmod = 2022-05-12T08:13:00+00:00
 tags = ["front-matter", "notes", "logbook"]
 draft = false
 [logbook]
   [logbook._toplevel]
+    [[logbook._toplevel.notes]]
+      timestamp = 2022-05-12T08:13:00+00:00
+      note = """
+  Another update to the post. This update timestamp should update the
+  `lastmod`.
+  """
     [[logbook._toplevel.notes]]
       timestamp = 2022-05-04T13:15:00+00:00
       note = """


### PR DESCRIPTION
- [x] Use the timestamp from the last added LOGBOOK note to update the `lastmod` field.
- [x] Updates to `lastmod` and `date` fields should happen only based on activity in the "toplevel" LOGBOOK drawer.