### PR TITLE
perf: Better way to auto-inject bibliography heading

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -2909,7 +2909,7 @@ property list variable.
 :PROPERTIES:
 :CUSTOM_ID: org-hugo-citations-plist
 :END:
-This property list recognizes these properties:
+This property list recognizes this property:
 
 - :bibliography-section-heading :: /(string)/ Heading to insert before
   the bibliography section.  The default value is "References".
@@ -2932,15 +2932,6 @@ This property list recognizes these properties:
   (with-eval-after-load 'ox-hugo
     (plist-put org-hugo-citations-plist :bibliography-section-heading ""))
   #+end_src
-- :bibliography-section-regexp :: /(string)/ Regular expression to
-  find the beginning of the bibliography section.  The default value
-  is a regular expression that matches the ~<div
-  class="csl-bib-body">~ HTML element exported by ~citeproc.el~.
-
-  #+begin_note
-  The default regular expression applies to bibliography insertion
-  done by Org Cite or [[* Org Ref Citations][Org Ref]] because both use ~citeproc.el~ for that.
-  #+end_note
 **** Example
 Minimal example with ~org-cite~ citations:
 

--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -2977,14 +2977,6 @@ that."
         (org-ref-process-buffer 'html)))
     (add-to-list 'org-export-before-parsing-hook #'my/org-ref-process-buffer--html)))
 #+end_src
-**** Auto-inserting /Bibliography/ heading
-A Markdown heading named "References" will be auto-inserted above
-the ~org-ref~ ~[[bibliography:..]]~ link, which is typically present
-at the end of a post.
-
-This feature is controlled by the
-{{{relref(~org-hugo-citations-plist~,org-cite-citations/#org-hugo-citations-plist)}}}
-property list variable.
 **** Example
 Minimal example with ~org-ref~ citations:
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -869,11 +869,7 @@ arguments of the ORIG-FUN.
 
 This advice retains the `:hl_lines', `linenos' and
 `:front_matter_extra' parameters, if added to any source block.
-This parameter is used in `org-hugo-src-block'.
-
-This advice is added to the ORIG-FUN only while an ox-hugo export
-is in progress.  See `org-hugo--before-export-function' and
-`org-hugo--after-1-export-function'."
+This parameter is used in `org-hugo-src-block'."
   (let* ((param-keys-to-be-retained '(:hl_lines :linenos :front_matter_extra))
          (info (car args))
          (parameters (nth 2 info))
@@ -948,7 +944,11 @@ See `org-link-parameters' for details about PATH, DESC and FORMAT."
       (format "[%s](%s \"%s\")" desc link title))))
 
 (defun org-hugo--org-cite-export-bibliography (orig-fun &rest args)
-  "Insert a heading before the exported bibliography."
+  "Insert a heading before the exported bibliography.
+
+ORIG-FUN is the original function `org-cite-export-bibliography'
+that this function is designed to advice using `:around'.  ARGS
+are the arguments of the ORIG-FUN."
   (let ((bib (apply orig-fun args)))
     (when (org-string-nw-p bib)
       ;; Auto-inject Bibliography heading.
@@ -969,6 +969,10 @@ This function is called in the very beginning of
 `org-hugo-export-to-md' and `org-hugo-export-as-md'.
 
 SUBTREEP is non-nil for subtree-based exports.
+
+This function is used to advise few functions.  Those advices are
+effective only while an ox-hugo export is in progress because
+they get removed later in `org-hugo--after-1-export-function'.
 
 This is an internal function."
   (unless subtreep

--- a/test/site/content/posts/citation-org-ref.md
+++ b/test/site/content/posts/citation-org-ref.md
@@ -9,8 +9,6 @@ draft = false
 
 (<a href="#citeproc_bib_item_1">Org et al., 2021</a>)
 
-## References
-
 <style>.csl-entry{text-indent: -1.5em; margin-left: 1.5em;}</style><div class="csl-bib-body">
   <div class="csl-entry"><a id="citeproc_bib_item_1"></a>org, m., Syntax, C., List, M., &#38; Effort, T. (2021). Elegant citations with org-mode. <i>Journal of Plain Text Formats</i>, <i>42</i>(1), 2–3.</div>
 </div>

--- a/test/site/content/posts/org-cite-basic-example.md
+++ b/test/site/content/posts/org-cite-basic-example.md
@@ -51,4 +51,6 @@ Below Org snippet:
 
 exports to:
 
+## References
+
 org, mode and Syntax, Citation and List, Mailing and Effort, Time (2021). _Elegant Citations with Org-Mode_, Journal of Plain Text Formats.


### PR DESCRIPTION
Earlier method wasn't elegant because it relied on an empirically
derived regexp. The reason for this change was that this regexp was
falsely matching a <style> elsewhere in one of my blog posts (Nim
notes), and it caused a regex out of stack error 😒 

By advising `org-cite-export-bibliography` directly, we will always be
able to perfectly inject the heading before the bibliography. 

As a side-effect, 

1. This approach now is able to inject the heading for non-CSS i.e. basic style bibliography as well.
2. ❗ but! now the auto heading insertion will stop for org-ref citations.