### PR TITLE
fix: Change inline src block output to work around CommonMark issue

### DIFF
--- a/doc/ox-hugo-export-gh-doc.el
+++ b/doc/ox-hugo-export-gh-doc.el
@@ -1,11 +1,9 @@
-;; Time-stamp: <2017-10-11 04:28:38 kmodi>
-
 ;; Export Org document to GitHub documents like README.org,
 ;; CONTRIBUTING.org.
 
 (defvar ox-hugo-git-root (progn
                            (require 'vc-git)
-                           (file-truename (vc-git-root "."))))
+                           (file-truename (vc-git-root default-directory))))
 
 (defun ox-hugo-export-gh-doc ()
   "Export `ox-hugo' Org documentation to documentation on GitHub repo."

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2456,8 +2456,9 @@ Escape Hugo shortcodes if present in this element's value."
                 (org-element-property :value inline-src-block)
                 lang)))
     (org-element-put-property inline-src-block :value code)
-    (format "<code class=\"inline-src language-%s\" data-lang=\"%s\">%s</code>"
-            lang lang code)))
+    (format "<span class=\"inline-src language-%s\" data-lang=\"%s\">%s</span>"
+            lang lang
+            (org-md-verbatim inline-src-block nil nil))))
 
 ;;;; Keyword
 (defun org-hugo-keyword (keyword contents info)

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -98,13 +98,13 @@ Emacs installation.  If Emacs is installed using
       ;; (message (list-load-path-shadows :stringp))
       )))
 
-(defvar ox-hugo-tmp-dir (let ((dir (file-name-as-directory (getenv "OX_HUGO_TMP_DIR"))))
-                          (unless dir
-                            (setq dir
-                                  (let* ((dir-1 (file-name-as-directory (expand-file-name user-login-name temporary-file-directory)))
-                                         (dir-2 (file-name-as-directory (expand-file-name "ox-hugo-dev" dir-1))))
-                                    dir-2)))
-                          (setq dir (file-name-as-directory dir))
+(defvar ox-hugo-tmp-dir (let ((dir (file-name-as-directory
+                                    (or (getenv "OX_HUGO_TMP_DIR")
+                                        (expand-file-name
+                                         "ox-hugo-dev"
+                                         (file-name-as-directory
+                                          (expand-file-name
+                                           user-login-name temporary-file-directory)))))))
                           (make-directory dir :parents)
                           dir))
 (when ox-hugo-test-setup-verbose

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2170,11 +2170,11 @@ src_emacs-lisp[:exports none]{(message "Hello 4")} {{{results(=Hello 4=)}}}
 CSS used here:
 #+begin_src html :noweb-ref inline_src_css
 <style>
-    code.inline-src.language-nim::before {
+  .inline-src.language-nim code::before {
         color: initial;
         content: "｢";
     }
-    code.inline-src.language-nim::after {
+  .inline-src.language-nim code::after {
         color: initial;
         content: "｣";
     }
@@ -2183,16 +2183,20 @@ CSS used here:
 
 #+begin_export html
 <style>
-    code.inline-src.language-nim::before {
+    .inline-src.language-nim code::before {
         color: initial;
         content: "｢";
     }
-    code.inline-src.language-nim::after {
+    .inline-src.language-nim code::after {
         color: initial;
         content: "｣";
     }
 </style>
 #+end_export
+
+{{{oxhugoissue(640)}}} -- Test that straight quotes in inline src
+blocks don't get rendered as curved quotes by Hugo/Goldmark's
+Typographer.
 
 In Nim, src_nim[:exports code]{echo "hello"} will print
 {{{results(/hello/)}}}.

--- a/test/site/content/posts/inline-code-blocks.md
+++ b/test/site/content/posts/inline-code-blocks.md
@@ -31,7 +31,7 @@ src_emacs-lisp[:exports results]{(message "Hello 1")}
 src_emacs-lisp[:exports code]{(message "Hello 2")}
 ```
 
-<code class="inline-src language-emacs-lisp" data-lang="emacs-lisp">(message "Hello 2")</code>
+<span class="inline-src language-emacs-lisp" data-lang="emacs-lisp">`(message "Hello 2")`</span>
 
 
 ## Both code and results {#both-code-and-results}
@@ -40,7 +40,7 @@ src_emacs-lisp[:exports code]{(message "Hello 2")}
 src_emacs-lisp[:exports both]{(message "Hello 3")}
 ```
 
-<code class="inline-src language-emacs-lisp" data-lang="emacs-lisp">(message "Hello 3")</code> `Hello 3`
+<span class="inline-src language-emacs-lisp" data-lang="emacs-lisp">`(message "Hello 3")`</span> `Hello 3`
 
 
 ## None! {#none}
@@ -53,13 +53,13 @@ src_emacs-lisp[:exports none]{(message "Hello 4")}
 ## Escape Hugo shortcodes {#escape-hugo-shortcodes}
 
 md
-: <code class="inline-src language-md" data-lang="md">{{</* some_shortcode "foo" */>}}</code>
+: <span class="inline-src language-md" data-lang="md">`{{</* some_shortcode "foo" */>}}`</span>
 
 org
-: <code class="inline-src language-org" data-lang="org">{{%/* some_shortcode "foo" */%}}</code>
+: <span class="inline-src language-org" data-lang="org">`{{%/* some_shortcode "foo" */%}}`</span>
 
 go-html-template
-: <code class="inline-src language-go-html-template" data-lang="go-html-template">{{</* some_shortcode "foo" */>}}</code>
+: <span class="inline-src language-go-html-template" data-lang="go-html-template">`{{</* some_shortcode "foo" */>}}`</span>
 
 
 ## Using custom CSS for inline src blocks {#using-custom-css-for-inline-src-blocks}
@@ -70,11 +70,11 @@ CSS used here:
 
 ```html
 <style>
-    code.inline-src.language-nim::before {
+  .inline-src.language-nim code::before {
         color: initial;
         content: "｢";
     }
-    code.inline-src.language-nim::after {
+  .inline-src.language-nim code::after {
         color: initial;
         content: "｣";
     }
@@ -82,15 +82,19 @@ CSS used here:
 ```
 
 <style>
-    code.inline-src.language-nim::before {
+    .inline-src.language-nim code::before {
         color: initial;
         content: "｢";
     }
-    code.inline-src.language-nim::after {
+    .inline-src.language-nim code::after {
         color: initial;
         content: "｣";
     }
 </style>
 
-In Nim, <code class="inline-src language-nim" data-lang="nim">echo "hello"</code> will print
+`ox-hugo` Issue #[640](https://github.com/kaushalmodi/ox-hugo/issues/640) -- Test that straight quotes in inline src
+blocks don't get rendered as curved quotes by Hugo/Goldmark's
+Typographer.
+
+In Nim, <span class="inline-src language-nim" data-lang="nim">`echo "hello"`</span> will print
 _hello_.


### PR DESCRIPTION
- Before: Inline src block classes were in the HTML code element
- Now: The inline src block classes are in HTLM span tags wrapping
  Markdown `verbatim` block.

Fixes https://github.com/kaushalmodi/ox-hugo/issues/640.

