### PR TITLE
Fix auto menu weight calculation during "all subtrees" exports

### DIFF
--- a/doc/ox-hugo-export-gh-doc.el
+++ b/doc/ox-hugo-export-gh-doc.el
@@ -1,11 +1,9 @@
-;; Time-stamp: <2017-10-11 04:28:38 kmodi>
-
 ;; Export Org document to GitHub documents like README.org,
 ;; CONTRIBUTING.org.
 
 (defvar ox-hugo-git-root (progn
                            (require 'vc-git)
-                           (file-truename (vc-git-root "."))))
+                           (file-truename (vc-git-root default-directory))))
 
 (defun ox-hugo-export-gh-doc ()
   "Export `ox-hugo' Org documentation to documentation on GitHub repo."

--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -98,13 +98,13 @@ Emacs installation.  If Emacs is installed using
       ;; (message (list-load-path-shadows :stringp))
       )))
 
-(defvar ox-hugo-tmp-dir (let ((dir (file-name-as-directory (getenv "OX_HUGO_TMP_DIR"))))
-                          (unless dir
-                            (setq dir
-                                  (let* ((dir-1 (file-name-as-directory (expand-file-name user-login-name temporary-file-directory)))
-                                         (dir-2 (file-name-as-directory (expand-file-name "ox-hugo-dev" dir-1))))
-                                    dir-2)))
-                          (setq dir (file-name-as-directory dir))
+(defvar ox-hugo-tmp-dir (let ((dir (file-name-as-directory
+                                    (or (getenv "OX_HUGO_TMP_DIR")
+                                        (expand-file-name
+                                         "ox-hugo-dev"
+                                         (file-name-as-directory
+                                          (expand-file-name
+                                           user-login-name temporary-file-directory)))))))
                           (make-directory dir :parents)
                           dir))
 (when ox-hugo-test-setup-verbose


### PR DESCRIPTION
The fix is to correct the order of when the subtree post's menu weight is calculated.

1. First the subtree post's location is found in the original buffer and weight calculated based off that.
2. Then the buffer is pre-processed and export is done using that.

Fixes https://github.com/kaushalmodi/ox-hugo/issues/642.