### PR TITLE
fix: Remove the blank line inserted between code blocks and captions

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -752,8 +752,11 @@ to this rule:
      current item.
 
   3. In an item, if a paragraph is immediately followed by an src
-     or example block (or vice-versa), don't add a blank line
-     between those elements."
+     or example block, don't add a blank line after the paragraph.
+
+  4. In an item, if an src or example block doesn't have a caption
+     and is immediately followed by a paragraph, don't add a blank
+     line after that src or example block."
   (org-element-map tree (remq 'item org-element-all-elements) ;Exception 1 in the doc-string
     (lambda (el)
       (let ((post-blank (cond
@@ -771,9 +774,14 @@ to this rule:
                                (let ((next-el (org-export-get-next-element el info)))
                                  (memq (org-element-type next-el) '(src-block example-block))))
                           0)
-                         ;; Exception 3 in the doc-string (src-block -> paragraph).
+                         ;; Exception 4 in the doc-string (caption-less src-block -> paragraph).
+                         ;; If an src or example block has a caption,
+                         ;; that caption will be wrapped in an HTML
+                         ;; div block. In that case, we *do* need to
+                         ;; leave a blank line after the div block (CommonMark).
                          ((and (memq (org-element-type el) '(src-block example-block))
                                (eq (org-element-type (org-element-property :parent el)) 'item)
+                               (null (org-element-property :caption el)) ;<-- "no caption" check
                                (let ((next-el (org-export-get-next-element el info)))
                                  (memq (org-element-type next-el) '(paragraph))))
                           0)

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -134,7 +134,7 @@ tag needs to be `python'."
 ;;; Define Back-End
 
 (org-export-define-derived-backend 'blackfriday 'md
-  :filters-alist '((:filter-parse-tree . org-md-separate-elements))
+  :filters-alist '((:filter-parse-tree . org-blackfriday-separate-elements))
   ;; Do not clutter the *Org Exporter Dispatch* menu.
   ;; :menu-entry
   ;; '(?b "Export to Blackfriday Flavored Markdown"
@@ -729,6 +729,57 @@ This function is mostly a copy of
   (let* ((org-str (org-element-interpret-data (org-element-contents el)))
          (html-str (org-export-string-as org-str 'html :body-only)))
     html-str))
+
+
+
+;;; Filter Functions
+
+;; This function is adapted from `org-md-separate-elements'.
+(defun org-blackfriday-separate-elements (tree _backend info)
+  "Fix blank lines between elements.
+
+TREE is the parse tree being exported.
+
+INFO is a plist used as a communication channel.
+
+Enforce a blank line between elements.  There are 3 exceptions
+to this rule:
+
+  1. Preserve blank lines between sibling items in a plain list,
+
+  2. In an item, remove any blank line before the very first
+     paragraph and the next sub-list when the latter ends the
+     current item.
+
+  3. In an item, if a paragraph is immediately followed by an
+     src or example block, don't add a blank line after that
+     paragraph."
+  (org-element-map tree (remq 'item org-element-all-elements) ;Exception 1 in the doc-string
+    (lambda (el)
+      (let ((post-blank (cond
+                         ;; Exception 2 in the doc-string.
+                         ((and (eq (org-element-type el) 'paragraph)
+                               (eq (org-element-type (org-element-property :parent el)) 'item)
+                               (org-export-first-sibling-p el info)
+                               (let ((next-el (org-export-get-next-element el info)))
+                                 (and (eq (org-element-type next-el) 'plain-list)
+                                      (not (org-export-get-next-element next-el info)))))
+                          0)
+                         ;; Exception 3 in the doc-string.
+                         ((and (eq (org-element-type el) 'paragraph)
+                               (eq (org-element-type (org-element-property :parent el)) 'item)
+                               (let ((next-el (org-export-get-next-element el info)))
+                                 (memq (org-element-type next-el) '(src-block example-block))))
+                          0)
+                         (t
+                          1))))
+        (org-element-put-property el :post-blank post-blank)
+        ;; (message "[org-blackfriday-separate-elements DBG] %S post-blank: %d"
+        ;;          (org-element-type el)
+        ;;          (org-element-property :post-blank el))
+        )))
+  ;; Return updated tree.
+  tree)
 
 
 

--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -751,9 +751,9 @@ to this rule:
      paragraph and the next sub-list when the latter ends the
      current item.
 
-  3. In an item, if a paragraph is immediately followed by an
-     src or example block, don't add a blank line after that
-     paragraph."
+  3. In an item, if a paragraph is immediately followed by an src
+     or example block (or vice-versa), don't add a blank line
+     between those elements."
   (org-element-map tree (remq 'item org-element-all-elements) ;Exception 1 in the doc-string
     (lambda (el)
       (let ((post-blank (cond
@@ -765,11 +765,17 @@ to this rule:
                                  (and (eq (org-element-type next-el) 'plain-list)
                                       (not (org-export-get-next-element next-el info)))))
                           0)
-                         ;; Exception 3 in the doc-string.
+                         ;; Exception 3 in the doc-string (paragraph -> src-block).
                          ((and (eq (org-element-type el) 'paragraph)
                                (eq (org-element-type (org-element-property :parent el)) 'item)
                                (let ((next-el (org-export-get-next-element el info)))
                                  (memq (org-element-type next-el) '(src-block example-block))))
+                          0)
+                         ;; Exception 3 in the doc-string (src-block -> paragraph).
+                         ((and (memq (org-element-type el) '(src-block example-block))
+                               (eq (org-element-type (org-element-property :parent el)) 'item)
+                               (let ((next-el (org-export-get-next-element el info)))
+                                 (memq (org-element-type next-el) '(paragraph))))
                           0)
                          (t
                           1))))

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -3436,7 +3436,7 @@ their Hugo site's config."
                                     (caption-str
                                      (org-html-convert-special-strings ;Interpret em-dash, en-dash, etc.
                                       (org-export-data-with-backend caption 'html info))))
-                               (format (concat "\n\n<div class=\"src-block-caption\">\n"
+                               (format (concat "\n<div class=\"src-block-caption\">\n"
                                                "  <span class=\"src-block-number\">%s:</span>\n"
                                                "  %s\n"
                                                "</div>")

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -1746,20 +1746,26 @@ code block does not have Markdown syntax lists.
 -----
 {{{oxhugoissue(645)}}}
 
-1. item one
-2. This paragraph is followed by a source block *with* caption.
+1. paragraph -> src block with caption -> paragraph -> src block
    #+name: code__foo
    #+caption: Foo
    #+begin_src emacs-lisp
    (message "hey")
    #+end_src
-
-
-1. item one
-2. This paragraph is followed by a source block without caption.
+   sandwiched paragraph
    #+begin_src emacs-lisp
    (message "hey")
    #+end_src
+   last paragraph
+2. paragraph -> src block *without* caption -> paragraph -> src block
+   #+begin_src emacs-lisp
+   (message "hey")
+   #+end_src
+   sandwiched paragraph
+   #+begin_src emacs-lisp
+   (message "hey")
+   #+end_src
+   last paragraph
 **** Source block with list syntax but not in a list
 :PROPERTIES:
 :EXPORT_DATE: 2017-08-01

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -1731,6 +1731,9 @@ Another such example, but with space before a hyphen in source block:
 :EXPORT_DATE: 2017-08-01
 :EXPORT_FILE_NAME: list-has-src-block-but-no-list-syntax
 :END:
+#+begin_description
+Test source blocks inside list.
+#+end_description
 This case is not affected by /Blackfriday/ [[https://github.com/russross/blackfriday/issues/239][Issue #239]] as the fenced
 code block does not have Markdown syntax lists.
 - List item 1
@@ -1740,6 +1743,23 @@ code block does not have Markdown syntax lists.
   =def=
   #+end_src
 - List item 2
+-----
+{{{oxhugoissue(645)}}}
+
+1. item one
+2. This paragraph is followed by a source block *with* caption.
+   #+name: code__foo
+   #+caption: Foo
+   #+begin_src emacs-lisp
+   (message "hey")
+   #+end_src
+
+
+1. item one
+2. This paragraph is followed by a source block without caption.
+   #+begin_src emacs-lisp
+   (message "hey")
+   #+end_src
 **** Source block with list syntax but not in a list
 :PROPERTIES:
 :EXPORT_DATE: 2017-08-01

--- a/test/site/content/posts/code-fenced-src-blocks-default.md
+++ b/test/site/content/posts/code-fenced-src-blocks-default.md
@@ -11,7 +11,6 @@ Here are few variables that you might like to change in the `local.mk`:
 
 `prefix`
 : Org installation directory
-
     ```makefile
     prefix = /dir/where/you/want/to/install/org # Default: /usr/share
     ```
@@ -24,7 +23,6 @@ Here are few variables that you might like to change in the `local.mk`:
 : Org Info installation directory. I like to keep the
     Info file for development version of Org in a separate
     directory.
-
     ```makefile
     infodir = $(prefix)/org/info # Default: $(prefix)/info
     ```
@@ -32,7 +30,6 @@ Here are few variables that you might like to change in the `local.mk`:
 `ORG_MAKE_DOC`
 : Types of Org documentation you'd like to build by
     default.
-
     ```makefile
     # Define below you only need info documentation, the default includes html and pdf
     ORG_MAKE_DOC = info pdf card # html
@@ -42,7 +39,6 @@ Here are few variables that you might like to change in the `local.mk`:
 : Packages from the `contrib/` directory that
     you'd like to build along with Org. Below are the ones on my
     _must-have_ list.
-
     ```makefile
     # Define if you want to include some (or all) files from contrib/lisp
     # just the filename please (no path prefix, no .el suffix), maybe with globbing

--- a/test/site/content/posts/code-fenced-src-blocks-default.md
+++ b/test/site/content/posts/code-fenced-src-blocks-default.md
@@ -14,7 +14,6 @@ Here are few variables that you might like to change in the `local.mk`:
     ```makefile
     prefix = /dir/where/you/want/to/install/org # Default: /usr/share
     ```
-
     The `.el` files will go to `$(prefix)/emacs/site-lisp/org` by
                 default. If you'd like to change that, you can tweak the
                 `lispdir` variable.

--- a/test/site/content/posts/code-fenced-src-blocks.md
+++ b/test/site/content/posts/code-fenced-src-blocks.md
@@ -12,7 +12,6 @@ Here are few variables that you might like to change in the `local.mk`:
 
 `prefix`
 : Org installation directory
-
     ```makefile
     prefix = /dir/where/you/want/to/install/org # Default: /usr/share
     ```
@@ -25,7 +24,6 @@ Here are few variables that you might like to change in the `local.mk`:
 : Org Info installation directory. I like to keep the
     Info file for development version of Org in a separate
     directory.
-
     ```makefile
     infodir = $(prefix)/org/info # Default: $(prefix)/info
     ```
@@ -33,7 +31,6 @@ Here are few variables that you might like to change in the `local.mk`:
 `ORG_MAKE_DOC`
 : Types of Org documentation you'd like to build by
     default.
-
     ```makefile
     # Define below you only need info documentation, the default includes html and pdf
     ORG_MAKE_DOC = info pdf card # html
@@ -43,7 +40,6 @@ Here are few variables that you might like to change in the `local.mk`:
 : Packages from the `contrib/` directory that
     you'd like to build along with Org. Below are the ones on my
     _must-have_ list.
-
     ```makefile
     # Define if you want to include some (or all) files from contrib/lisp
     # just the filename please (no path prefix, no .el suffix), maybe with globbing

--- a/test/site/content/posts/code-fenced-src-blocks.md
+++ b/test/site/content/posts/code-fenced-src-blocks.md
@@ -15,7 +15,6 @@ Here are few variables that you might like to change in the `local.mk`:
     ```makefile
     prefix = /dir/where/you/want/to/install/org # Default: /usr/share
     ```
-
     The `.el` files will go to `$(prefix)/emacs/site-lisp/org` by
                 default. If you'd like to change that, you can tweak the
                 `lispdir` variable.

--- a/test/site/content/posts/highlight-shortcode-src-blocks.md
+++ b/test/site/content/posts/highlight-shortcode-src-blocks.md
@@ -18,7 +18,6 @@ Here are few variables that you might like to change in the `local.mk`:
 
 `prefix`
 : Org installation directory
-
     {{< highlight makefile >}}
     prefix = /dir/where/you/want/to/install/org # Default: /usr/share
     {{< /highlight >}}
@@ -31,7 +30,6 @@ Here are few variables that you might like to change in the `local.mk`:
 : Org Info installation directory. I like to keep the
     Info file for development version of Org in a separate
     directory.
-
     {{< highlight makefile >}}
     infodir = $(prefix)/org/info # Default: $(prefix)/info
     {{< /highlight >}}
@@ -39,7 +37,6 @@ Here are few variables that you might like to change in the `local.mk`:
 `ORG_MAKE_DOC`
 : Types of Org documentation you'd like to build by
     default.
-
     {{< highlight makefile >}}
     # Define below you only need info documentation, the default includes html and pdf
     ORG_MAKE_DOC = info pdf card # html
@@ -49,7 +46,6 @@ Here are few variables that you might like to change in the `local.mk`:
 : Packages from the `contrib/` directory that
     you'd like to build along with Org. Below are the ones on my
     _must-have_ list.
-
     {{< highlight makefile >}}
     # Define if you want to include some (or all) files from contrib/lisp
     # just the filename please (no path prefix, no .el suffix), maybe with globbing

--- a/test/site/content/posts/highlight-shortcode-src-blocks.md
+++ b/test/site/content/posts/highlight-shortcode-src-blocks.md
@@ -21,7 +21,6 @@ Here are few variables that you might like to change in the `local.mk`:
     {{< highlight makefile >}}
     prefix = /dir/where/you/want/to/install/org # Default: /usr/share
     {{< /highlight >}}
-
     The `.el` files will go to `$(prefix)/emacs/site-lisp/org` by
                 default. If you'd like to change that, you can tweak the
                 `lispdir` variable.

--- a/test/site/content/posts/inlined-svg.md
+++ b/test/site/content/posts/inlined-svg.md
@@ -65,7 +65,6 @@ style="stroke:#A80036;stroke-width:1.0;"/></g></svg>
 class A
 url of A is [[https://example.org/]]
 ```
-
 <div class="src-block-caption">
   <span class="src-block-number">Code Snippet 1:</span>
   My class diagram

--- a/test/site/content/posts/links-to-source-blocks.md
+++ b/test/site/content/posts/links-to-source-blocks.md
@@ -52,7 +52,6 @@ that the link jump is evident):
 ````emacs-lisp
 (message "Hello")
 ````
-
 <div class="src-block-caption">
   <span class="src-block-number"><a href="#code-snippet--hello">Code Snippet 1</a>:</span>
   Hello
@@ -116,7 +115,6 @@ blandit in.
 ````emacs-lisp
 (message "Hello again")
 ````
-
 <div class="src-block-caption">
   <span class="src-block-number"><a href="#code-snippet--helloagain">Code Snippet 2</a>:</span>
   Hello Again

--- a/test/site/content/posts/list-has-example-block-with-list-syntax.md
+++ b/test/site/content/posts/list-has-example-block-with-list-syntax.md
@@ -12,13 +12,11 @@ lists. `ox-hugo` provides a hack to get around that bug.
 Below is an example of such a case:
 
 -   List item 1
-
     ```text
     ​- List item 1.1 in code block
     ​- List item 1.2 in code block
     ```
 -   List item 2
-
     ```text
     ​+ List item 2.1 in code block
     ​+ List item 2.2 in code block
@@ -29,13 +27,11 @@ Another such example, but with spaces before the hyphens in example
 blocks:
 
 -   List item 1
-
     ```text
     ​- List item 1.1 in code block
     ​- List item 1.2 in code block
     ```
 -   List item 2
-
     ```text
     ​+ List item 2.1 in code block
     ​+ List item 2.2 in code block

--- a/test/site/content/posts/list-has-src-block-but-no-list-syntax.md
+++ b/test/site/content/posts/list-has-src-block-but-no-list-syntax.md
@@ -1,5 +1,6 @@
 +++
 title = "Source block without list syntax in a list"
+description = "Test source blocks inside list."
 date = 2017-08-01
 tags = ["src-block", "lists", "hyphen"]
 draft = false
@@ -9,10 +10,32 @@ This case is not affected by _Blackfriday_ [Issue #239](https://github.com/russr
 code block does not have Markdown syntax lists.
 
 -   List item 1
-
     ```md
     *abc*
     /def/
     =def=
     ```
 -   List item 2
+
+---
+
+`ox-hugo` Issue #[645](https://github.com/kaushalmodi/ox-hugo/issues/645)
+
+1.  item one
+2.  This paragraph is followed by a source block **with** caption.
+    <a id="code-snippet--foo"></a>
+    ```emacs-lisp
+    (message "hey")
+    ```
+    <div class="src-block-caption">
+      <span class="src-block-number"><a href="#code-snippet--foo">Code Snippet 1</a>:</span>
+      Foo
+    </div>
+
+<!--listend-->
+
+1.  item one
+2.  This paragraph is followed by a source block without caption.
+    ```emacs-lisp
+    (message "hey")
+    ```

--- a/test/site/content/posts/list-has-src-block-but-no-list-syntax.md
+++ b/test/site/content/posts/list-has-src-block-but-no-list-syntax.md
@@ -21,8 +21,7 @@ code block does not have Markdown syntax lists.
 
 `ox-hugo` Issue #[645](https://github.com/kaushalmodi/ox-hugo/issues/645)
 
-1.  item one
-2.  This paragraph is followed by a source block **with** caption.
+1.  paragraph -&gt; src block with caption -&gt; paragraph -&gt; src block
     <a id="code-snippet--foo"></a>
     ```emacs-lisp
     (message "hey")
@@ -32,10 +31,17 @@ code block does not have Markdown syntax lists.
       Foo
     </div>
 
-<!--listend-->
-
-1.  item one
-2.  This paragraph is followed by a source block without caption.
+    sandwiched paragraph
     ```emacs-lisp
     (message "hey")
     ```
+    last paragraph
+2.  paragraph -&gt; src block **without** caption -&gt; paragraph -&gt; src block
+    ```emacs-lisp
+    (message "hey")
+    ```
+    sandwiched paragraph
+    ```emacs-lisp
+    (message "hey")
+    ```
+    last paragraph

--- a/test/site/content/posts/list-has-src-block-with-list-syntax.md
+++ b/test/site/content/posts/list-has-src-block-with-list-syntax.md
@@ -13,13 +13,11 @@ lists. `ox-hugo` provides a hack to get around that bug.
 Below is an example of such a case:
 
 -   List item 1
-
     ```md
     ​- List item 1.1 in code block
     ​- List item 1.2 in code block
     ```
 -   List item 2
-
     ```md
     ​+ List item 2.1 in code block
     ​+ List item 2.2 in code block
@@ -29,13 +27,11 @@ Below is an example of such a case:
 Another such example, but with space before a hyphen in source block:
 
 1.  First item
-
     ```yaml
     ports:
       foo: bar
     ```
 2.  Second item
-
     ```yaml
     ports:
     ​ - port: 80

--- a/test/site/content/posts/paragraphs-in-lists.md
+++ b/test/site/content/posts/paragraphs-in-lists.md
@@ -9,7 +9,6 @@ draft = false
 
     Just indent the content to be even with the text of the bullet
     point, rather than the bullet itself.
-
     ```shell
     ls -l
     ```

--- a/test/site/content/posts/prep.md
+++ b/test/site/content/posts/prep.md
@@ -7,7 +7,6 @@ draft = false
 1.  Be the root directory for this Hugo site (the directory containing
     `config.toml`).
 2.  Run
-
     ```text
     hugo server --port 1111
     ```

--- a/test/site/content/posts/shortcode-src-blocks.md
+++ b/test/site/content/posts/shortcode-src-blocks.md
@@ -11,7 +11,6 @@ Here are few variables that you might like to change in the `local.mk`:
     {{< highlight makefile >}}
     prefix = /dir/where/you/want/to/install/org # Default: /usr/share
     {{< /highlight >}}
-
     The `.el` files will go to `$(prefix)/emacs/site-lisp/org` by
                  default. If you'd like to change that, you can tweak the
                  `lispdir` variable.

--- a/test/site/content/posts/shortcode-src-blocks.md
+++ b/test/site/content/posts/shortcode-src-blocks.md
@@ -8,7 +8,6 @@ Here are few variables that you might like to change in the `local.mk`:
 
 `prefix`
 : Org installation directory
-
     {{< highlight makefile >}}
     prefix = /dir/where/you/want/to/install/org # Default: /usr/share
     {{< /highlight >}}
@@ -21,7 +20,6 @@ Here are few variables that you might like to change in the `local.mk`:
 : Org Info installation directory. I like to keep the
     Info file for development version of Org in a separate
     directory.
-
     {{< highlight makefile >}}
     infodir = $(prefix)/org/info # Default: $(prefix)/info
     {{< /highlight >}}
@@ -29,7 +27,6 @@ Here are few variables that you might like to change in the `local.mk`:
 `ORG_MAKE_DOC`
 : Types of Org documentation you'd like to build by
     default.
-
     {{< highlight makefile >}}
     # Define below you only need info documentation, the default includes html and pdf
     ORG_MAKE_DOC = info pdf card # html
@@ -39,7 +36,6 @@ Here are few variables that you might like to change in the `local.mk`:
 : Packages from the `contrib/` directory that
     you'd like to build along with Org. Below are the ones on my
     _must-have_ list.
-
     {{< highlight makefile >}}
     # Define if you want to include some (or all) files from contrib/lisp
     # just the filename please (no path prefix, no .el suffix), maybe with globbing

--- a/test/site/content/posts/source-block-caption.md
+++ b/test/site/content/posts/source-block-caption.md
@@ -7,7 +7,6 @@ draft = false
 ```makefile
 prefix = /dir/where/you/want/to/install/org # Default: /usr/share
 ```
-
 <div class="src-block-caption">
   <span class="src-block-number">Code Snippet 1:</span>
   Prefix value in <code>local.mk</code>
@@ -16,7 +15,6 @@ prefix = /dir/where/you/want/to/install/org # Default: /usr/share
 ```emacs-lisp
 (message "hello")
 ```
-
 <div class="src-block-caption">
   <span class="src-block-number">Code Snippet 2:</span>
   Hello &#x2014; Caption with em-dash &#x2013; and &#x2013; en-dash

--- a/test/site/content/posts/source-block-indented.md
+++ b/test/site/content/posts/source-block-indented.md
@@ -25,29 +25,24 @@ Some content.
 Reference: `hugo` Issue #[4006](https://github.com/gohugoio/hugo/issues/4006)
 
 -   List item 1
-
     ```emacs-lisp
     (message "I am in list at level-1 indentation")
     ```
 
     -   List item 1.1
-
         ```emacs-lisp
         (message "I am in list at level-2 indentation")
         ```
 
         -   List item 1.1.1
-
             ```emacs-lisp
             (message "I am in list at level-3 indentation")
             ```
     -   List item 2.1
-
         ```emacs-lisp
         (message "I am in list back at level-2 indentation")
         ```
 -   List item 2
-
     ```emacs-lisp
     (message "I am in list back at level-1 indentation")
     ```
@@ -96,29 +91,24 @@ there.
 </div>
 
 -   List item 1
-
     ```emacs-lisp { linenos=true, linenostart=1 }
     (message "I am in list at level-1 indentation")
     ```
 
     -   List item 1.1
-
         ```emacs-lisp { linenos=true, linenostart=1 }
         (message "I am in list at level-2 indentation")
         ```
 
         -   List item 1.1.1
-
             ```emacs-lisp { linenos=true, linenostart=1 }
             (message "I am in list at level-3 indentation")
             ```
     -   List item 2.1
-
         ```emacs-lisp { linenos=true, linenostart=1 }
         (message "I am in list back at level-2 indentation")
         ```
 -   List item 2
-
     ```emacs-lisp { linenos=true, linenostart=1 }
     (message "I am in list back at level-1 indentation")
     ```

--- a/test/site/content/posts/src-and-example-blocks-in-lists.md
+++ b/test/site/content/posts/src-and-example-blocks-in-lists.md
@@ -8,13 +8,11 @@ draft = false
 [Ref](https://discourse.gohugo.io/t/blackfriday-not-handling-lists-and-code-blocks-the-right-way/19932)
 
 -   list item 1
-
     ```nim
     echo "hello from list item 1"
     ```
 
     -   list item 1.1
-
         ```text
         echo "hello from list item 1.1"
         ```
@@ -24,7 +22,6 @@ draft = false
         ```
 
         -   list item 1.2.1
-
             ```nim
             echo "hello from list item 1.2.1"
             ```
@@ -34,7 +31,6 @@ draft = false
             ```
 
             -   list item 1.2.2.1
-
                 ```text
                 echo "hello from list item 1.2.2.1"
                 ```
@@ -43,7 +39,6 @@ draft = false
     echo "there's not text before this src block in this list item"
     ```
 -   list item 3
-
     ```text
     echo "hello from list item 3"
     ```

--- a/test/site/content/singles/links-to-org-elements.md
+++ b/test/site/content/singles/links-to-org-elements.md
@@ -62,7 +62,6 @@ that the link jump is evident):
 ````emacs-lisp
 (message "Hello")
 ````
-
 <div class="src-block-caption">
   <span class="src-block-number"><a href="#code-snippet--hello">Programmlisting 1</a>:</span>
   Hello
@@ -126,7 +125,6 @@ blandit in.
 ````emacs-lisp
 (message "Hello again")
 ````
-
 <div class="src-block-caption">
   <span class="src-block-number"><a href="#code-snippet--helloagain">Programmlisting 2</a>:</span>
   Hello Again


### PR DESCRIPTION
- [x] Remove blank lines between code blocks and their captions - https://github.com/kaushalmodi/ox-hugo/pull/646/commits/71cb5f25737c6794927273554efdac1026fd676b

    This change is part of the fix for
https://github.com/kaushalmodi/ox-hugo/issues/645. The good thing is
that there's no functional change in how Hugo/GoldMark (tested on Hugo
v0.99.1) render these Markdown files after the change.

    So, to the user, it will be just a cosmetic change, that now there are
no blank lines between code blocks and their captions.
- [x] Inside lists, remove blank line after paragraph when followed by a code block. - https://github.com/kaushalmodi/ox-hugo/pull/646/commits/9471c21fc033c8d7ab874f5f648521486c08a3f2
- [x] Inside lists, remove blank line after code block when followed by a paragraph. - https://github.com/kaushalmodi/ox-hugo/pull/646/commits/ace25a665006e23f254ecf6f4490948687916139
- [x] OK.. "remove blank line after code block when followed by a paragraph" do this only if the src or example block does not have a caption!

Fixes https://github.com/kaushalmodi/ox-hugo/issues/645.