### PR TITLE
fix: Escape Hugo shortcodes in description front-matter

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -3595,7 +3595,7 @@ INFO is a plist holding export options."
         contents)
        ((string= block-type "description")
         ;; Overwrite the value of the `:description' key in `info'.
-        (plist-put info :description contents)
+        (plist-put info :description (org-hugo--escape-hugo-shortcode contents "md"))
         nil)
        ;; https://emacs.stackexchange.com/a/28685/115
        ((cl-member block-type paired-shortcodes

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -1995,12 +1995,15 @@ there.
 :EXPORT_FILE_NAME: source-block-md-with-hugo-shortcodes
 :EXPORT_HUGO_CODE_FENCE: t
 :END:
+#+begin_description
+Test verbatim use of Hugo shortcodes in content.
+#+end_description
 *** Shortcodes escaped
 The =figure= shortcodes in the two Markdown source code blocks below
 should *not* be expanded.. they should be visible verbatim.
 
-- {{< .. >}} --- [[https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown][Shortcodes without Markdown]]
-- {{% .. %}} --- [[https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown][Shortcodes with Markdown]]
+- src_md[:exports code]{{{< .. >}}} --- [[https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown][Shortcodes without Markdown]]
+- src_md[:exports code]{{{% .. %}}} --- [[https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown][Shortcodes with Markdown]]
 **** Code block using code fences
 #+begin_src md
 {{< figure src="https://ox-hugo.scripter.co/test/images/org-mode-unicorn-logo.png" >}}
@@ -6463,7 +6466,7 @@ instead.
 This test tests the following:
 - Pandoc leave the HTML ~span~ tags as-is.
 - Pandoc does not escape the ~<~ in the ~figure~ shortcodes with
-  captions (in general: ~{{< ..>}}~ shortcodes that could wrap across
+  captions (in general: ~{{< .. >}}~ shortcodes that could wrap across
   lines).
 - While Pandoc auto-wraps the re-written Markdown, it also wraps the
   ~{{< .. >}}~ shortcodes. The test checks that such "wrapped

--- a/test/site/content/posts/citations-with-captions/index.md
+++ b/test/site/content/posts/citations-with-captions/index.md
@@ -5,10 +5,10 @@ description = """
 
   -   Pandoc leave the HTML `span` tags as-is.
   -   Pandoc does not escape the `<` in the `figure` shortcodes with
-      captions (in general: `{{< ..>}}` shortcodes that could wrap across
+      captions (in general: `{{</* .. */>}}` shortcodes that could wrap across
       lines).
   -   While Pandoc auto-wraps the re-written Markdown, it also wraps the
-      `{{< .. >}}` shortcodes. The test checks that such "wrapped
+      `{{</* .. */>}}` shortcodes. The test checks that such "wrapped
       shortcodes" get unwrapped.
   """
 date = 2018-08-19

--- a/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
+++ b/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
@@ -1,5 +1,6 @@
 +++
 title = "Markdown source block with Hugo shortcodes"
+description = "Test verbatim use of Hugo shortcodes in content."
 tags = ["src-block", "shortcode"]
 draft = false
 +++
@@ -9,8 +10,8 @@ draft = false
 The `figure` shortcodes in the two Markdown source code blocks below
 should **not** be expanded.. they should be visible verbatim.
 
--   {{&lt; .. &gt;}} --- [Shortcodes without Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown)
--   {&lbrace;% .. %&rbrace;} --- [Shortcodes with Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown)
+-   <span class="inline-src language-md" data-lang="md">`{{</* .. */>}}`</span> --- [Shortcodes without Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown)
+-   <span class="inline-src language-md" data-lang="md">`{{%/* .. */%}}`</span> --- [Shortcodes with Markdown](https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown)
 
 
 ### Code block using code fences {#code-block-using-code-fences}

--- a/test/site/go.mod
+++ b/test/site/go.mod
@@ -2,4 +2,4 @@ module github.com/kaushalmodi/ox-hugo/test/site
 
 go 1.16
 
-require github.com/kaushalmodi/hugo-bare-min-theme v0.5.0 // indirect
+require github.com/kaushalmodi/hugo-bare-min-theme v0.6.0 // indirect

--- a/test/site/go.sum
+++ b/test/site/go.sum
@@ -1,6 +1,6 @@
 github.com/julmot/mark.js v0.0.0-20210820195258-8b57fccf976b/go.mod h1:aAyDyl2EhNPiZbFqqURsAmxYwwTHslrIxZErXMO3pJQ=
-github.com/kaushalmodi/hugo-bare-min-theme v0.5.0 h1:N85P1c/e/xAm4vboMoIh74kD+zHzh/nY+9/ucHoS4zM=
-github.com/kaushalmodi/hugo-bare-min-theme v0.5.0/go.mod h1:F3dhvekisR/Hg6lj/Ha+MBriwKcXGNmef+hzGGE+82E=
+github.com/kaushalmodi/hugo-bare-min-theme v0.6.0 h1:A0fF5Es5wg5gygWRuslZCgk+Vsi9HhzeP6k0LzGFFFM=
+github.com/kaushalmodi/hugo-bare-min-theme v0.6.0/go.mod h1:F3dhvekisR/Hg6lj/Ha+MBriwKcXGNmef+hzGGE+82E=
 github.com/kaushalmodi/hugo-debugprint v0.1.0/go.mod h1:vusrDLlGE+4Uc1b4PgM0dI8lJCEqC1o7NjFr8WIfkaQ=
 github.com/kaushalmodi/hugo-search-fuse-js v0.4.1/go.mod h1:Wr6gbPat+KW6wReh/hDBykKIWn296FsEkuhojJvHHxw=
 github.com/krisk/Fuse v3.2.1+incompatible/go.mod h1:3moWv8rDjwoKic9nwiPLgZjldkbdTAbtzJHCu/Vsj4A=


### PR DESCRIPTION
The description front-matter will most likely be parsed as Markdown
string using $.Page.RenderString, and we do not want literal strings
like "{{< .. >}}" in there be interpreted as Hugo shortcode calls.

Shortcodes are now rendered by RenderString starting Hugo v0.100.0:
https://github.com/gohugoio/hugo/releases/tag/v0.100.0.