### PR TITLE
feat: Export links to manual pages of GNU software like tar too

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -674,6 +674,77 @@ bibliography heading auto-injection is not done."
   :group 'org-export-hugo
   :type '(plist :key-type symbol :value-type string))
 
+(defcustom org-hugo-info-gnu-software '("3dldf" "8sync"
+                                        "a2ps" "acct" "acm" "adns" "alive" "anubis" "apl"
+                                        "archimedes" "aris" "artanis" "aspell" "auctex" "autoconf" "autoconf-archive"
+                                        "autogen" "automake" "avl"
+                                        "ballandpaddle" "barcode" "bash" "bayonne" "bazaar" "bc" "behistun"
+                                        "bfd" "binutils" "bison" "bool" "bpel2owfn"
+                                        "c-graph" "ccaudio" "ccd2cue" "ccide" "ccrtp" "ccscript" "cflow"
+                                        "cgicc" "chess" "cim" "classpath" "classpathx" "clisp" "combine"
+                                        "commoncpp" "complexity" "config" "consensus" "coreutils" "cpio" "cppi"
+                                        "cssc" "cursynth"
+                                        "dap" "datamash" "dc" "ddd" "ddrescue" "dejagnu" "denemo"
+                                        "dia" "dico" "diction" "diffutils" "direvent" "djgpp" "dominion"
+                                        "dr-geo"
+                                        "easejs" "ed" "edma" "electric" "emacs" "emacs-muse" "emms"
+                                        "enscript" "epsilon"
+                                        "fdisk" "ferret" "findutils" "fisicalab" "foliot" "fontopia" "fontutils"
+                                        "freedink" "freefont" "freeipmi" "freetalk" "fribidi"
+                                        "g-golf" "gama" "garpd" "gawk" "gcal" "gcc" "gcide"
+                                        "gcl" "gcompris" "gdb" "gdbm" "gengen" "gengetopt" "gettext"
+                                        "gforth" "ggradebook" "ghostscript" "gift" "gimp" "glean" "global"
+                                        "glpk" "glue" "gmediaserver" "gmp" "gnash" "gnat" "gnats"
+                                        "gnatsweb" "gnowsys" "gnu-c-manual" "gnu-crypto" "gnu-pw-mgr" "gnuae" "gnuastro"
+                                        "gnubatch" "gnubg" "gnubiff" "gnubik" "gnucap" "gnucash" "gnucobol"
+                                        "gnucomm" "gnudos" "gnufm" "gnugo" "gnuit" "gnujdoc" "gnujump"
+                                        "gnukart" "gnulib" "gnumach" "gnumed" "gnumeric" "gnump3d" "gnun"
+                                        "gnunet" "gnupg" "gnupod" "gnuprologjava" "gnuradio" "gnurobots" "gnuschool"
+                                        "gnushogi" "gnusound" "gnuspeech" "gnuspool" "gnustandards" "gnustep" "gnutls"
+                                        "gnutrition" "gnuzilla" "goptical" "gorm" "gpaint" "gperf" "gprolog"
+                                        "grabcomics" "greg" "grep" "gretl" "groff" "grub" "gsasl"
+                                        "gsegrafix" "gsl" "gslip" "gsrc" "gss" "gtick" "gtypist"
+                                        "guile" "guile-cv" "guile-dbi" "guile-gnome" "guile-ncurses" "guile-opengl"
+                                        "guile-rpc" "guile-sdl" "guix" "gurgle" "gv" "gvpe" "gwl" "gxmessage"
+                                        "gzip"
+                                        "halifax" "health" "hello" "help2man" "hp2xx" "html-info" "httptunnel"
+                                        "hurd" "hyperbole"
+                                        "icecat" "idutils" "ignuit" "indent" "inetutils" "inklingreader" "intlfonts"
+                                        "jacal" "jami" "java-getopt" "jel" "jitter" "jtw" "jwhois"
+                                        "kawa" "kopi"
+                                        "leg" "less" "libc" "libcdio" "libdbh" "liberty-eiffel" "libextractor"
+                                        "libffcall" "libgcrypt" "libiconv" "libidn" "libjit" "libmatheval"
+                                        "libmicrohttpd" "libredwg" "librejs" "libsigsegv" "libtasn1" "libtool"
+                                        "libunistring" "libxmi" "lightning" "lilypond" "lims" "linux-libre" "liquidwar6"
+                                        "lispintro" "lrzsz" "lsh"
+                                        "m4" "macchanger" "mailman" "mailutils" "make" "marst" "maverik"
+                                        "mc" "mcron" "mcsim" "mdk" "mediagoblin" "melting" "mempool"
+                                        "mes" "metaexchange" "metahtml" "metalogic-inference" "mifluz" "mig" "miscfiles"
+                                        "mit-scheme" "moe" "motti" "mpc" "mpfr" "mpria" "mtools"
+                                        "nana" "nano" "nano-archimedes" "ncurses" "nettle" "network"
+                                        "ocrad" "octave" "oleo" "oo-browser" "orgadoc" "osip"
+                                        "panorama" "parallel" "parted" "pascal" "patch" "paxutils" "pcb"
+                                        "pem" "pexec" "pies" "pipo" "plotutils" "poke" "polyxmass"
+                                        "powerguru" "proxyknife" "pspp" "psychosynth" "pth" "pythonwebkit"
+                                        "qexo" "quickthreads"
+                                        "r" "radius" "rcs" "readline" "recutils" "reftex" "remotecontrol"
+                                        "rottlog" "rpge" "rush"
+                                        "sather" "scm" "screen" "sed" "serveez" "sharutils" "shepherd"
+                                        "shishi" "shmm" "shtool" "sipwitch" "slib" "smalltalk" "social"
+                                        "solfege" "spacechart" "spell" "sqltutor" "src-highlite" "ssw" "stalkerfs"
+                                        "stow" "stump" "superopt" "swbis" "sysutils"
+                                        "taler" "talkfilters" "tar" "termcap" "termutils" "teseq" "teximpatient"
+                                        "texinfo" "texmacs" "time" "tramp" "trans-coord" "trueprint"
+                                        "unifont" "units" "unrtf" "userv" "uucp"
+                                        "vc-dwim" "vcdimager" "vera" "vmgen"
+                                        "wb" "wdiff" "websocket4j" "webstump" "wget" "which" "womb"
+                                        "xaos" "xboard" "xlogmaster" "xmlat" "xnee" "xorriso"
+                                        "zile")
+  "List of GNU software for Info manual links.
+The software list is taken from https://www.gnu.org/software/."
+  :group 'org-export-hugo
+  :type '(repeat string))
+
 
 
 ;;; Define Back-End
@@ -936,6 +1007,12 @@ See `org-link-parameters' for details about PATH, DESC and FORMAT."
                       (let ((manual-url (if (string= (downcase manual) "org")
                                             "https://orgmode.org/manual"
                                           (format "https://www.gnu.org/software/emacs/manual/html_node/%s" manual)))
+                            (node-url (if (string= node "Top")
+                                          "index.html"
+                                        (concat (org-info--expand-node-name node) ".html"))))
+                        (format "%s/%s" manual-url node-url)))
+                     ((member manual org-hugo-info-gnu-software)
+                      (let ((manual-url (format "https://www.gnu.org/software/%s/manual/html_node" manual))
                             (node-url (if (string= node "Top")
                                           "index.html"
                                         (concat (org-info--expand-node-name node) ".html"))))

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -3886,6 +3886,7 @@ Test links to Info manual nodes.
 - Link to an Emacs Info manual node: [[info:emacs#Point]] (same link but
   with a custom description: [[info:emacs#Point][🛈 Emacs: Point]])
 - Link to an Emacs Lisp Info manual node: [[info:elisp#Lambda Expressions]]
+- Link to a GNU software (~tar~) Info manual node: [[info:tar#Old Options]]
 * Equations                                                       :equations:
 ** MathJax                                                          :mathjax:
 *** Inline equations

--- a/test/site/content/posts/links-to-info-manual-nodes.md
+++ b/test/site/content/posts/links-to-info-manual-nodes.md
@@ -10,3 +10,4 @@ draft = false
 -   Link to an Emacs Info manual node: [Emacs Info: Point](https://www.gnu.org/software/emacs/manual/html_node/emacs/Point.html "Emacs Lisp: (info \"(emacs) Point\")") (same link but
     with a custom description: [🛈 Emacs: Point](https://www.gnu.org/software/emacs/manual/html_node/emacs/Point.html "Emacs Lisp: (info \"(emacs) Point\")"))
 -   Link to an Emacs Lisp Info manual node: [Elisp Info: Lambda Expressions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Lambda-Expressions.html "Emacs Lisp: (info \"(elisp) Lambda Expressions\")")
+-   Link to a GNU software (`tar`) Info manual node: [Tar Info: Old Options](https://www.gnu.org/software/tar/manual/html_node/Old-Options.html "Emacs Lisp: (info \"(tar) Old Options\")")


### PR DESCRIPTION
New custom variable `org-hugo-info-gnu-software`. It contains a list
of GNU software taken from https://www.gnu.org/software/.