### PR TITLE
Remove needless quote

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -457,7 +457,7 @@ This option can also be set with the OPTIONS keyword,
 e.g. \"num:onlytoc\", \"num:nil\", \"num:t\" or \"num:3\"."
   :group 'org-export-hugo
   :type '(choice
-          (const :tag "Don't number only in body" 'onlytoc)
+          (const :tag "Don't number only in body" onlytoc)
           (const :tag "Don't number any heading" nil)
           (const :tag "Number all headings" t)
           (integer :tag "Number to level")))


### PR DESCRIPTION
This fixes the following byte-compile warning.

```
ox-hugo.el:443:12: Warning: defcustom for
    ‘org-hugo-export-with-section-numbers’ has syntactically odd type
    ‘'(choice (const :tag Don't number only in body 'onlytoc) (const :tag
    Don't number any heading nil) (const :tag Number all headings t) (integer
    :tag Number to level))’
```