### PR TITLE
Cease stripping the final newline in generated Markdown

### DIFF
--- a/ox-blackfriday.el
+++ b/ox-blackfriday.el
@@ -894,8 +894,8 @@ holding export options."
         (setq toc-string (concat toc-string
                                  (org-blackfriday-format-toc heading info)
                                  "\n"))))
-    (org-trim (concat toc-string toc-tail contents "\n"
-                      (org-blackfriday-footnote-section info)))))
+    (concat toc-string toc-tail contents "\n"
+            (org-blackfriday-footnote-section info))))
 
 ;;;; Italic
 (defun org-blackfriday-italic (_italic contents _info)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2523,13 +2523,13 @@ holding export options."
                     " \\2" contents)))
 
     ;; (message "[org-hugo-inner-template DBG] toc-level: %s" toc-level)
-    (org-trim (concat
-               toc
-               contents
-               ;; Make sure CONTENTS is separated from table of contents
-               ;; and footnotes with at least a blank line.
-               "\n"
-               (org-blackfriday-footnote-section info (org-hugo--lang-cjk-p info))))))
+    (concat
+     toc
+     contents
+     ;; Make sure CONTENTS is separated from table of contents
+     ;; and footnotes with at least a blank line.
+     "\n"
+     (org-blackfriday-footnote-section info (org-hugo--lang-cjk-p info)))))
 
 ;;;; Inline Src Block
 (defun org-hugo-inline-src-block (inline-src-block _contents _info)


### PR DESCRIPTION
This change moves the code closer to `org-md-inner-template`, which has similar logic but doesn't call `org-trim`.

* ox-hugo.el (org-hugo-inner-template): Remove call to `org-trim` to address github issue #671.  Users no longer need to set `require-final-newline` to `t` to get a final newline, and users with that set to `ask` no longer get prompted on every save.
* ox-blackfriday.el (org-blackfriday-inner-template): ditto.