### PR TITLE
feat: Toggle ommission of subheading content

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -745,6 +745,17 @@ The software list is taken from https://www.gnu.org/software/."
   :group 'org-export-hugo
   :type '(repeat string))
 
+(defcustom org-hugo-omit-subheadings nil
+  "When non-nil, omit subheadings with their own pages.
+
+Normally, each heading includes its subheadings' content along
+with its own. When this variable is non-nil, those subheadings
+that have their own pages (as indicated by the presence of the
+`:EXPORT_FILE_NAME' property), will have their content omitted
+from the parent heading's page."
+  :group 'org-export-hugo
+  :type 'boolean)
+;;;###autoload (put 'org-hugo-exclude-subheadings 'safe-local-variable 'booleanp)
 
 
 ;;; Define Back-End
@@ -2141,6 +2152,7 @@ a communication channel."
                   ;; of that preceding list.
                   bullet " " heading tags-fmtd "\n\n"
                   (and contents (replace-regexp-in-string "^" "    " contents)))))
+       ((and org-hugo-omit-subheadings (org-hugo--export-file-name-p heading)) "")
        (t
         (let* ((anchor (format "{#%s}" (org-hugo--get-anchor heading info))) ;https://gohugo.io/extras/crossreferences/
                (heading-title (org-hugo--heading-title style level loffset title
@@ -2182,6 +2194,10 @@ Else, no HTML element is wrapped around the HEADING."
            (if (= 1 (org-export-get-relative-level heading info))
                (plist-get info :html-container)
              "div"))))
+
+(defun org-hugo--export-file-name-p (heading)
+  "Determine if a heading has the `:EXPORT_FILE_NAME' property."
+  (org-export-get-node-property :EXPORT_FILE_NAME heading nil))
 
 ;;;###autoload
 (defun org-hugo-slug (str &optional allow-double-hyphens)


### PR DESCRIPTION
Previously, when a heading was rendered, each of its subheadings' output was included in the output. With this change, a customizable variable is added that, if set, will omit those subheadings that have the :EXPORT_FILE_NAME property set from the output of their parent.

This can be handy for non-blogging sites, where the content is still hierarchical, but doesn't lend itself to the blogging format where a parent page includes the content of each of its children (like a year index page, month index page, etc.)

At the rist of being annoyingly verbose, before this change, if you had a post structure like this (in pseudo-org-mode format):

    * Post A
      :EXPORT_FILE_NAME: post-a

      Some text.

    ** Post B
       :EXPORT_FILE_NAME: post-b

       Text that relates to Post B.

    ** Post C

       General text, but no :EXPORT_FILE_NAME.

When rendered into HTML at the URL of /posts/post-a/, one would see:

    Post A

    Some text.

    Post B

    Text that relates to Post B.

    Post C

    General text, but no :EXPORT_FILE_NAME.

    …

After this change (and when the variable is set):

    Post A

    Some text.

    Post C

    General text, but no :EXPORT_FILE_NAME.

    …

The premise is that Post B will have its own page (as indicated by the :EXPORT_FILE_NAME property) and so doesn't or shouldn't be included in the content of Post A.