### PR TITLE
fix: Use loaddefs-generate if available (Emacs 29+)

### DIFF
--- a/test/setup-ox-hugo.el
+++ b/test/setup-ox-hugo.el
@@ -155,9 +155,11 @@ Emacs installation.  If Emacs is installed using
       (setq package-archives (delq (assoc "nongnu" package-archives) package-archives))
 
       ;; Generate/update and load the autoloads for ox-hugo.el and co.
-      (let ((generated-autoload-file ox-hugo-autoloads-file))
-        (update-directory-autoloads ox-hugo-site-git-root)
-        (load-file ox-hugo-autoloads-file))
+      (if (fboundp #'loaddefs-generate) ;Emacs 29+
+          (loaddefs-generate ox-hugo-site-git-root ox-hugo-autoloads-file)
+        (let ((generated-autoload-file ox-hugo-autoloads-file)) ;Emacs 28.x and older
+          (update-directory-autoloads ox-hugo-site-git-root)))
+      (load-file ox-hugo-autoloads-file)
 
       ;; Load emacs packages and activate them.
       ;; Don't delete this line.


### PR DESCRIPTION
Ref:
https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?id=d6831d1b0a18882d688a842721dd1592884a06e2#n487

Fixes https://github.com/kaushalmodi/ox-hugo/issues/667.

---

From the NEWS file updates for Emacs 29:

```
---
** The autoload.el library is now obsolete.
It is superseded by the loaddefs-gen.el library.

+++
** "loaddefs.el" generation has been reimplemented.
The various "loaddefs.el" files in the Emacs tree (which contain
information about autoloads, built-in packages and package prefixes)
used to be generated by functions in autoloads.el.  These are now
generated by loaddefs-gen.el instead.  This leads to functionally
equivalent "loaddef.el" files, but they do not use exactly the same
syntax, so using 'M-x update-file-autoloads' no longer works.  (This
didn't work well in most files in the past, either, but it will now
signal an error in any file.)
```