### PR TITLE
fix: Escape Hugo shortcode markers in emacs-lisp src blocks as well

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -1242,15 +1242,15 @@ contents according to the current heading."
 (defun org-hugo--escape-hugo-shortcode (code lang)
   "Escape Hugo shortcodes if present in CODE string.
 
-The escaping is enabled only if LANG is \"md\", \"org\" or
-\"go-html-template\".
+The escaping is enabled only if LANG is \"md\", \"org\",
+\"go-html-template\" or \"emacs-lisp\".
 
  - Shortcode with Markdown    : {{% foo %}} -> {{%/* foo */%}}
 
  - Shortcode without Markdown : {{< foo >}} -> {{</* foo */>}}
 
 Return the escaped/unescaped string."
-  (if (member lang '("md" "org" "go-html-template"))
+  (if (member lang '("md" "org" "go-html-template" "emacs-lisp"))
       (replace-regexp-in-string
        "\\({{<\\)\\([^}][^}]*\\)\\(>}}\\)" "\\1/*\\2*/\\3"
        (replace-regexp-in-string

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -2020,6 +2020,26 @@ numbering.
 #+begin_src org
 ,#+macro: relref @@hugo:[@@ $1 @@hugo:]({{< relref "$2" >}})@@
 #+end_src
+**** Shortcode escaped in Emacs-Lisp source blocks
+{{{oxhugoissue(680)}}}
+
+#+begin_src emacs-lisp
+;; Follow Hugo links
+(defun org-hugo-follow (link)
+  "Follow Hugo link shortcodes"
+  (org-link-open-as-file
+   (string-trim "{{% ref test.org %}}" "{{% ref " "%}}")))
+
+;; New link type for Org-Hugo internal links
+(org-link-set-parameters
+ "hugo"
+ :complete (lambda ()
+             (concat "{{% ref */"
+                     (file-name-nondirectory
+                      (read-file-name "File: "))
+                     " %}}"))
+ :follow #'org-hugo-follow)
+#+end_src
 *** Shortcodes *not* escaped
 The =figure= shortcode in the below example block *should* be
 expanded.. you should be seeing a little unicorn below.

--- a/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
+++ b/test/site/content/posts/source-block-md-with-hugo-shortcodes.md
@@ -40,6 +40,29 @@ numbering.
 ```
 
 
+### Shortcode escaped in Emacs-Lisp source blocks {#shortcode-escaped-in-emacs-lisp-source-blocks}
+
+`ox-hugo` Issue #[680](https://github.com/kaushalmodi/ox-hugo/issues/680)
+
+```emacs-lisp
+;; Follow Hugo links
+(defun org-hugo-follow (link)
+  "Follow Hugo link shortcodes"
+  (org-link-open-as-file
+   (string-trim "{{%/* ref test.org */%}}" "{{%/* ref " "*/%}}")))
+
+;; New link type for Org-Hugo internal links
+(org-link-set-parameters
+ "hugo"
+ :complete (lambda ()
+             (concat "{{%/* ref */"
+                     (file-name-nondirectory
+                      (read-file-name "File: "))
+                     " */%}}"))
+ :follow #'org-hugo-follow)
+```
+
+
 ## Shortcodes **not** escaped {#shortcodes-not-escaped}
 
 The `figure` shortcode in the below example block **should** be


### PR DESCRIPTION
Fixes https://github.com/kaushalmodi/ox-hugo/issues/680.