### PR TITLE
fix: Pass on the info to `org-export-custom-protocol-maybe`

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2744,7 +2744,7 @@ and rewrite link paths to make blogging more seamless."
     ;; (message "[org-hugo-link DBG] link type: %s" type)
     (cond
      ;; Link type is handled by a special function.
-     ((org-export-custom-protocol-maybe link desc 'md))
+     ((org-export-custom-protocol-maybe link desc 'md info))
      ((member type '("custom-id" "id"
                      "fuzzy")) ;<<target>>, #+name, heading links
       (let ((destination (if (string= type "fuzzy")


### PR DESCRIPTION
This is necessary for exporting of custom link protocols to work. This issue was originally reported in
https://github.com/tecosaur/org-glossary/issues/9.

Fixes https://github.com/kaushalmodi/ox-hugo/issues/702.