### PR TITLE
fix: properly escape dot in directory-files regex, fixes false matches

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4879,7 +4879,7 @@ The optional argument NOERROR is passed to
     ;; Auto-update `org-id-locations' if it's nil or empty hash table
     ;; to avoid broken [[id:..]] type links.
     (when (or (eq org-id-locations nil) (zerop (hash-table-count org-id-locations)))
-      (org-id-update-id-locations (directory-files "." :full "\.org\$" :nosort) :silent))
+      (org-id-update-id-locations (directory-files "." :full "\\.org$" :nosort) :silent))
 
     (org-hugo--cleanup)
 


### PR DESCRIPTION
It appears that the original regex took `\.` as a single dot (any character) rather than a literal dot.

I assume it's because single backslashes are dropped in emacs strings if the character following needs no escape as part of a string. However that's desired in the regex.

See 
https://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-for-Strings.html

------

In my case, it matched a `./beorg` subdir causing a further error during the export process -- `not a regular file`.