### PR TITLE
HTML container improvements

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -4303,6 +4303,11 @@ sub-tree is exported as a heading surrounding with ~<section>~ and
 ~</section>~. By default, that ~section~ tag has the class
 "outline-NUM" where /NUM/ is the level of that heading in that post.
 
+By default, if ~HTML_CONTAINER~ is inherited (for example, set at the
+file level), it is only applied to top-level sections. Deeper sections
+get wrapped in ~div~ tags. If you would like the same container to be
+applied throughout, set ~HTML_CONTAINER_NESTED~ to ~t~.
+
 Additionally, if it has the property ~EXPORT_HTML_CONTAINER_CLASS:
 foo~, the "foo" class gets added to that container tag as well.
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2151,8 +2151,9 @@ a communication channel."
               (let* ((container-class (or (org-element-property :HTML_CONTAINER_CLASS heading)
                                           (org-element-property :EXPORT_HTML_CONTAINER_CLASS heading)
                                           (plist-get info :html-container-class)))
-                     (container-class-str (when (org-string-nw-p container-class)
-                                            (concat " " container-class))))
+                     (container-class-str (if (org-string-nw-p container-class)
+                                              (concat " " container-class)
+                                            container-class)))
                 (format (concat "<%s class=\"outline-%d%s\">\n"
                                 "%s%s\n"
                                 "</%s>")

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -822,6 +822,7 @@ The software list is taken from https://www.gnu.org/software/."
                    (:bibliography "BIBLIOGRAPHY" nil nil newline) ;Used in ox-hugo-pandoc-cite
                    (:html-container "HTML_CONTAINER" nil org-hugo-container-element)
                    (:html-container-class "HTML_CONTAINER_CLASS" nil "")
+                   (:html-container-nested "HTML_CONTAINER_NESTED" nil nil)
 
                    ;; Front-matter variables
                    ;; https://gohugo.io/content-management/front-matter/#front-matter-variables
@@ -2180,7 +2181,8 @@ Else, no HTML element is wrapped around the HEADING."
   (or (org-element-property :HTML_CONTAINER heading) ;property of the immediate heading
       (org-element-property :EXPORT_HTML_CONTAINER heading) ;property of the immediate heading
       (and (org-string-nw-p (plist-get info :html-container)) ;inherited :html-container: property if any
-           (if (= 1 (org-export-get-relative-level heading info))
+           (if (or (plist-get info :html-container-nested)
+                   (= 1 (org-export-get-relative-level heading info)))
                (plist-get info :html-container)
              "div"))))
 

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -540,6 +540,14 @@ This heading is wrapped in an ~aside~ tag with classes ~outline-1~ and
 :END:
 This heading is wrapped in a ~blockquote~ tag with classes ~outline-2~
 and ~baz~.
+*** HTML Container without class
+:PROPERTIES:
+:EXPORT_FILE_NAME: html-container-without-class
+:END:
+**** Top level heading 1
+This heading is wrapped in a ~section~ tag with class ~outline-1~.
+***** Sub-heading 1.1
+This heading is wrapped in a ~div~ tag with class ~outline-2~.
 ** Export with planning info                                       :planning:
 :PROPERTIES:
 :EXPORT_FILE_NAME: planning-info

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -548,6 +548,15 @@ and ~baz~.
 This heading is wrapped in a ~section~ tag with class ~outline-1~.
 ***** Sub-heading 1.1
 This heading is wrapped in a ~div~ tag with class ~outline-2~.
+*** HTML Container nested
+:PROPERTIES:
+:EXPORT_FILE_NAME: html-container-nested
+:EXPORT_HTML_CONTAINER_NESTED: t
+:END:
+**** Top level heading 1
+This heading is wrapped in a ~section~ tag with class ~outline-1~.
+***** Sub-heading 1.1
+This heading is wrapped in a ~section~ tag with class ~outline-2~.
 ** Export with planning info                                       :planning:
 :PROPERTIES:
 :EXPORT_FILE_NAME: planning-info

--- a/test/site/content/posts/html-container-nested.md
+++ b/test/site/content/posts/html-container-nested.md
@@ -1,0 +1,21 @@
++++
+title = "HTML Container nested"
+tags = ["headings", "container", "html"]
+draft = false
++++
+
+<section class="outline-1">
+
+## Top level heading 1 {#top-level-heading-1}
+
+This heading is wrapped in a `section` tag with class `outline-1`.
+
+<section class="outline-2">
+
+### Sub-heading 1.1 {#sub-heading-1-dot-1}
+
+This heading is wrapped in a `section` tag with class `outline-2`.
+
+</section>
+
+</section>

--- a/test/site/content/posts/html-container-without-class.md
+++ b/test/site/content/posts/html-container-without-class.md
@@ -1,0 +1,21 @@
++++
+title = "HTML Container without class"
+tags = ["headings", "container", "html"]
+draft = false
++++
+
+<section class="outline-1">
+
+## Top level heading 1 {#top-level-heading-1}
+
+This heading is wrapped in a `section` tag with class `outline-1`.
+
+<div class="outline-2">
+
+### Sub-heading 1.1 {#sub-heading-1-dot-1}
+
+This heading is wrapped in a `div` tag with class `outline-2`.
+
+</div>
+
+</section>


### PR DESCRIPTION
Hope you don't mind two changes in one PR here.

First one is a bugfix. I found if I didn't set `EXPORT_CONTAINER_CLASS` I got class names like "outline-1nil".

Second one enables the use of "nested" elements (like sections). I'm not sure what the intention was with having it fall back to "div" at lower levels, but I found it convenient to add `#+html_container: section` to the top of my file and have all (sub)sections wrapper in `section`.