### PR TITLE
Enhancement: Allow customizing code block syntax highlighting with header arguments

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -1386,6 +1386,22 @@ The Org source for the below is similar to the above, except that the
 =-n= switch is also added to enable the line numbers.
 
 #+include: "../test/site/content-org/all-posts.org::#source-blocks-with-highlighting-with-linenums-not-starting-from-1" :only-contents t
+**** Setting =style= for exported code blocks
+Instead of using the syntax highlighting theme specified in
+~markup.highlight.style~ (which defaults to =monokai=), the syntax style
+can be specified for an exported code block by passing the
+=:syntax-style= header argument.
+This is particularly useful when you would like to "override" the
+default style for a type of source block; for example, one could set
+#+begin_src org
+#+property: header-args:diff :syntax-style "paraiso-dark"
+#+end_src
+to use the =paraiso-dark= theme for ~diff~ code blocks without affecting
+the syntax highlighting of other types of code blocks.
+
+=:syntax-style= should a valid Chroma syntax highlighting style; a list
+of all styles supported by Hugo can be found at the [[https://gohugo.io/quick-reference/syntax-highlighting-styles/][syntax
+highlighting styles]] page on the Hugo docs.
 **** Hiding source block caption numbers
 The "Code Snippet <number>:" part of the source block captions can be
 hidden by adding this to the CSS:

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -958,10 +958,10 @@ ORIG-FUN is the original function `org-babel-exp-code' that this
 function is designed to advice using `:around'.  ARGS are the
 arguments of the ORIG-FUN.
 
-This advice retains the `:hl_lines', `linenos' and
+This advice retains the `:hl_lines', `linenos', `syntax-style' and
 `:front_matter_extra' parameters, if added to any source block.
 This parameter is used in `org-hugo-src-block'."
-  (let* ((param-keys-to-be-retained '(:hl_lines :linenos :front_matter_extra))
+  (let* ((param-keys-to-be-retained '(:hl_lines :linenos :syntax-style :front_matter_extra))
          (info (car args))
          (parameters (nth 2 info))
          (ox-hugo-params-str (let ((str ""))
@@ -3503,6 +3503,7 @@ their Hugo site's config."
                          (if (numberp hl-lines-param)
                              (number-to-string hl-lines-param)
                            hl-lines-param)))
+             (syntax-style (cdr (assoc :syntax-style parameters)))
              (code-refs-and-anchor (org-hugo--get-coderef-anchor-prefix src-block))
              (code-refs (let ((code-refs1 (car code-refs-and-anchor)))
                           (when code-refs1
@@ -3591,6 +3592,11 @@ their Hugo site's config."
           (if (org-string-nw-p code-attr-str)
               (setq code-attr-str (format "%s, hl_lines=%s" code-attr-str hl-lines))
             (setq code-attr-str (format "hl_lines=%s" hl-lines))))
+
+        (when syntax-style
+          (if (org-string-nw-p code-attr-str)
+              (setq code-attr-str (format "%s, style=%s" code-attr-str syntax-style))
+            (setq code-attr-str (format "style=%s" syntax-style))))
 
         (when code-refs
           (let* ((anchor-prefix (cdr code-refs-and-anchor))


### PR DESCRIPTION
This PR extends the code block header arguments understood by ox-hugo to include `:syntax-style`, which allows customizing the syntax highlighting `style` for an exported code block.

This makes it easy to use different styles for different source languages and gives more granular control over syntax highlighting without relying on maintaining a custom Chroma syntax CSS file.

The motivating use case for myself was to add syntax highlighting to diff source blocks, which the modus-vivendi Chroma theme does not currently support; another potentially compelling use case is making different source languages on the same page more visually distinct.

I'm unfamiliar with the style guidelines of this project, so please feel free to be particularly nitpicky when reviewing my changes. Thank you for maintaining ox-hugo!