### PR TITLE
Fix org-roam file-level ID links in subtree export mode

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4672,7 +4672,10 @@ links."
 
                     ;; Change the link if it points to a valid
                     ;; destination outside the subtree.
-                    (unless (equal source-path destination-path)
+                    (unless (or  (equal source-path destination-path)
+                                 (and (string= type "id")
+                                      (org-id-find-id-file
+                                       (org-element-property :path el))))
                       (let ((link-desc (org-element-contents el)))
                         ;; (message "[ox-hugo pre process DBG] link desc: %s" link-desc)
 


### PR DESCRIPTION
# Summary

fix #764 

- Fix org-roam file-level ID links generating
incorrect anchors in subtree export mode
- Allow org-roam file-level ID links to use the
same processing logic as file export mode
- Maintain backward compatibility for other link
types

# Changes

Modified org-hugo--get-pre-processed-buffer to exclude org-roam file-level ID links from preprocessing conversion. org-roam file-level ID links are now:

1. Kept as id type instead of being converted to
file type
2. Processed by existing org-hugo-link logic that
 correctly handles cross-file ID references
3. Generate proper Hugo relref shortcodes like
{{< relref "target-file.md" >}}

