### PR TITLE
Respect `org-id-locations-file`

### DIFF
--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4908,7 +4908,8 @@ The optional argument NOERROR is passed to
 
     ;; Auto-update `org-id-locations' if it's nil or empty hash table
     ;; to avoid broken [[id:..]] type links.
-    (when (or (eq org-id-locations nil) (zerop (hash-table-count org-id-locations)))
+    (unless org-id-locations (org-id-locations-load))
+    (when (or (null org-id-locations) (zerop (hash-table-count org-id-locations)))
       (org-id-update-id-locations (directory-files "." :full "\\.org$" :nosort) :silent))
 
     (org-hugo--cleanup)


### PR DESCRIPTION
I’ve noticed that `org-id-update-id-locations` takes a long time (there are nearly 800 org files in sibling folders), yet all my
org IDs are stored in `org-id-locations-file`, so it shouldn’t need to load every file to update ID locations.

The correct approach should follow `org-id-find-id-file`: first try running `org-id-locations-load`, and only then proceed with
other actions.