### PR TITLE
fix: restore same-file cross-post links under Org 9.7+

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -2414,12 +2414,108 @@ the Heading Render Hook's ~.PlainText~ variable.
 For example, if the sub-heading title is "Example of rendering notes
 under sub-headings", the value of ~.PlainText~ for that heading will
 be the same.
-*** COMMENT Hyperlinks
+*** Hyperlinks
 :PROPERTIES:
 :EXPORT_FILE_NAME: hyperlinks
 :END:
+#+begin_description
+How =ox-hugo= turns Org links into Hugo-friendly Markdown (including
+same-file cross-post =relref= shortcodes).
+#+end_description
+
+This page covers the links that matter most when blogging from one Org
+file with many post subtrees.
 **** External Links
-**** Internal Links
+Usual =https:= / =http:= / =mailto:= / =file:= links export like other
+Org Markdown exporters: as normal Markdown links or angle-bracket URLs.
+
+Image and attachment paths under the Hugo =static/= tree have extra
+helpers; see the {{{relref(Image Links,image-links)}}} page.
+**** Internal Links (same post)
+Links that stay inside the /same/ Hugo post (same =EXPORT_FILE_NAME=
+subtree, or the same file for file-based export) become Markdown
+anchors:
+
+- Custom ID :: =[[#my-anchor][...]]= → =[...](#my-anchor)=
+- Heading :: =[[*Some heading][...]]= → =[...](#some-heading)=
+- Named target :: =<<target>>= / =[[target][...]]=
+
+For =id:= links, load Org's =org-id= library first
+(=(require 'org-id)= in your init, or via =org-customize=).
+**** Cross-post links (same Org file, different post)
+:PROPERTIES:
+:CUSTOM_ID: cross-post-links
+:END:
+With the preferred /one post per subtree/ flow, several posts often
+live in one Org file. A link from one post subtree to another is a
+*cross-post link*.
+
+=ox-hugo= rewrites those links during export so Hugo gets
+={{</* relref "..." */>}}= shortcodes instead of broken in-file anchors.
+
+Supported Org forms (pointing at another subtree that has
+=EXPORT_FILE_NAME=):
+
+#+begin_src org
+,*** Source post
+:PROPERTIES:
+:EXPORT_FILE_NAME: source-post
+:END:
+- Heading: [[*Destination post]]
+- Custom ID: [[#some-anchor]]
+- Org ID: [[id:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx]]
+- Whole post: [[*Destination post][see this post]]
+
+,*** Destination post
+:PROPERTIES:
+:EXPORT_FILE_NAME: destination-post
+:CUSTOM_ID: some-anchor
+:ID:       xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+:END:
+Target content.
+#+end_src
+
+Typical Markdown output:
+
+#+begin_src markdown
+- Heading: [Destination post]({{</* relref "destination-post" */>}})
+- Custom ID: [Destination post]({{</* relref "destination-post#some-anchor" */>}})
+#+end_src
+
+#+begin_note
+These are *native Org links*. You do not need to hand-write
+={{</* relref */>}}= or ={{{relref(...)}}}= macros in the Org source for
+same-file cross-post targets.
+#+end_note
+***** Org 9.7+ and the pre-processed buffer
+Under Org 9.7 and newer, export used to abort on these links with:
+
+#+begin_example
+Unable to resolve link: "posts/foo.pre-processed.org::#anchor"
+#+end_example
+
+Cause in short: =ox-hugo= rewrites out-of-subtree targets to dummy
+=file:= paths in a pre-processed buffer; =org-element-interpret-data=
+then drops the =file:= type for relative paths, so re-parse treated
+them as fuzzy links and Org 9.7+ refused to resolve them.
+
+Current =ox-hugo= keeps the dummy path and search option separate,
+forces =file:= back after interpret, and still rewrites same-file
+=id:= targets to cross-post ~relref~ shortcodes. The suite post /Links outside
+the same post/ exercises this path
+(={{{ox-hugo-test-file}}}=).
+***** Tips
+- Prefer =[[*Exact heading title]]= or =[[#custom-id]]= for in-repo
+  cross-post links; they need no =org-id= database.
+- For =[[id:...]]= across posts in the *same* file, =org-id= must know
+  the ID (same as other Org ID links). =ox-hugo= rescans =.org= files
+  in =default-directory= before export so sibling files in that
+  directory are picked up even if =org-id-locations= was already
+  non-empty (for example after an earlier export in the same Emacs
+  session).
+- Cross-file =id:= links (true org-roam / multi-file setups) still use
+  Org's ID locations for the other file; keep that database up to date
+  for those workflows.
 ** Enhancements
 :PROPERTIES:
 :EXPORT_HUGO_MENU: :menu "6.enhancements"

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2765,6 +2765,33 @@ and rewrite link paths to make blogging more seamless."
     (cond
      ;; Link type is handled by a special function.
      ((org-export-custom-protocol-maybe link desc 'md info))
+     ;; Cross-post dummy paths that lost their file: type (Org 9.7+
+     ;; interpret-data) and reparsed as fuzzy: handle like file links.
+     ((and (string= type "fuzzy")
+           (let ((p (or raw-path "")))
+             (string-match-p
+              (concat (regexp-quote org-hugo--preprocessed-buffer-dummy-file-suffix)
+                      "\\(?:\\'\\|::\\)")
+              p)))
+      (let* ((parts (split-string raw-path "::" t))
+             (file-part (car parts))
+             (search-part (cadr parts))
+             (ref (string-remove-suffix
+                   org-hugo--preprocessed-buffer-dummy-file-suffix
+                   (file-name-nondirectory file-part)))
+             (anchor (or search-part "")))
+        (cond
+         ((and (org-string-nw-p anchor) (not (string-prefix-p "#" anchor)))
+          (if desc
+              (format "[%s]({{< relref \"%s\" >}})" desc anchor)
+            (format "{{< relref \"%s\" >}}" anchor)))
+         ((or (org-string-nw-p ref) (org-string-nw-p anchor))
+          (let ((path (format "{{< relref \"%s%s\" >}}" ref anchor)))
+            (if desc
+                (format "[%s](%s)" desc path)
+              path)))
+         (t
+          (or desc "")))))
      ((member type '("custom-id" "id"
                      "fuzzy")) ;<<target>>, #+name, heading links
       (let ((destination (if (string= type "fuzzy")
@@ -3061,20 +3088,24 @@ and rewrite link paths to make blogging more seamless."
                                             org-hugo--preprocessed-buffer-dummy-file-suffix
                                             (file-name-nondirectory path1)))
                                  ;; Dummy Org file paths created in
-                                 ;; `org-hugo--get-pre-processed-buffer'
-                                 ;; For dummy Org file paths, we are
-                                 ;; limiting to only "#" style search
-                                 ;; strings.
-                                 (when (string-match ".*\\.org::\\(#.*\\)" raw-link)
-                                   (setq anchor (match-string-no-properties 1 raw-link))))
+                                 ;; `org-hugo--get-pre-processed-buffer'.
+                                 ;; Prefer :search-option (Org 9.x) then
+                                 ;; raw-link "::" form.
+                                 (setq anchor
+                                       (or (org-string-nw-p
+                                            (org-element-property :search-option link))
+                                           (and (string-match ".*\\.org::\\(#.*\\)" raw-link)
+                                                (match-string-no-properties 1 raw-link))
+                                           "")))
                              ;; Regular Org file paths.
                              (setq ref (file-name-sans-extension (file-name-nondirectory path1)))
                              (let ((link-search-str
                                     ;; If raw-link is "./foo.org::#bar",
                                     ;; set `link-search-str' to
                                     ;; "#bar".
-                                    (when (string-match ".*\\.org::\\(.*\\)" raw-link)
-                                      (match-string-no-properties 1 raw-link))))
+                                    (or (org-element-property :search-option link)
+                                        (when (string-match ".*\\.org::\\(.*\\)" raw-link)
+                                          (match-string-no-properties 1 raw-link)))))
                                ;; (message "[org-hugo-link DBG] link-search-str: %s" link-search-str)
                                (when link-search-str
                                  (setq anchor (org-hugo--search-and-get-anchor raw-path link-search-str info)))))
@@ -4672,10 +4703,21 @@ links."
 
                     ;; Change the link if it points to a valid
                     ;; destination outside the subtree.
-                    (unless (or  (equal source-path destination-path)
-                                 (and (string= type "id")
-                                      (org-id-find-id-file
-                                       (org-element-property :path el))))
+                    ;;
+                    ;; Skip only id links whose target lives in a
+                    ;; *different* Org file (true external id).  Same-file
+                    ;; ids still need dummy-path rewriting so they export
+                    ;; as cross-post relrefs rather than file.md anchors.
+                    (unless (or (equal source-path destination-path)
+                                (and (string= type "id")
+                                     (let ((id-file
+                                            (org-id-find-id-file
+                                             (org-element-property :path el)))
+                                           (here (buffer-file-name)))
+                                       (and id-file here
+                                            (not (file-equal-p
+                                                  (file-truename id-file)
+                                                  (file-truename here)))))))
                       (let ((link-desc (org-element-contents el)))
                         ;; (message "[ox-hugo pre process DBG] link desc: %s" link-desc)
 
@@ -4684,33 +4726,43 @@ links."
                         ;; to dummy files with
                         ;; `org-hugo--preprocessed-buffer-dummy-file-suffix'
                         ;; suffix.
-                        (org-element-put-property el :type "file")
-                        (org-element-put-property
-                         el :path
-                         (cond
-                          ;; If the destination is a heading with the
-                          ;; :EXPORT_FILE_NAME property defined, the
-                          ;; link should point to the file (without
-                          ;; anchor).
-                          ((org-element-property :EXPORT_FILE_NAME destination)
-                           (concat destination-path org-hugo--preprocessed-buffer-dummy-file-suffix))
-                          ;; Hugo only supports anchors to headings,
-                          ;; so if a "fuzzy" type link points to
-                          ;; anything else than a heading, it should
-                          ;; point to the file.
-                          ((and (string= type "fuzzy")
-                                (not (string-prefix-p "*" raw-link)))
-                           (concat destination-path org-hugo--preprocessed-buffer-dummy-file-suffix))
-                          ;; In "custom-id" type links, the raw-link
-                          ;; matches the anchor of the destination.
-                          ((string= type "custom-id")
-                           (concat destination-path org-hugo--preprocessed-buffer-dummy-file-suffix "::" raw-link))
-                          ;; In "id" and "fuzzy" type links, the anchor
-                          ;; of the destination is derived from the
-                          ;; :CUSTOM_ID property or the title.
-                          (t
-                           (let ((anchor (org-hugo--get-anchor destination info)))
-                             (concat destination-path org-hugo--preprocessed-buffer-dummy-file-suffix "::#" anchor)))))
+                        ;;
+                        ;; Keep the file path and search option
+                        ;; separate.  Putting "::#anchor" into :path
+                        ;; used to work by accident; Org 9.7+ treats
+                        ;; the whole string as the path and then
+                        ;; re-parses the interpreted link as fuzzy.
+                        (when (org-string-nw-p destination-path)
+                          (let* ((dummy-path
+                                  (concat destination-path
+                                          org-hugo--preprocessed-buffer-dummy-file-suffix))
+                                 (search-option
+                                  (cond
+                                   ;; Post subtree landing page: no anchor.
+                                   ((org-element-property :EXPORT_FILE_NAME destination)
+                                    nil)
+                                   ;; Fuzzy non-heading targets: post only.
+                                   ((and (string= type "fuzzy")
+                                         (not (string-prefix-p "*" raw-link)))
+                                    nil)
+                                   ;; custom-id: raw-link is like "#id".
+                                   ((string= type "custom-id")
+                                    raw-link)
+                                   ;; id / fuzzy heading: derive anchor.
+                                   (t
+                                    (let ((anchor (org-hugo--get-anchor destination info)))
+                                      (and (org-string-nw-p anchor)
+                                           (if (string-prefix-p "#" anchor)
+                                               anchor
+                                             (concat "#" anchor))))))))
+                            (org-element-put-property el :type "file")
+                            (org-element-put-property el :path dummy-path)
+                            (org-element-put-property el :search-option search-option)
+                            (org-element-put-property
+                             el :raw-link
+                             (if search-option
+                                 (concat "file:" dummy-path "::" search-option)
+                               (concat "file:" dummy-path)))))
                         ;; If the link destination is a heading and if
                         ;; user hasn't set the link description, set the
                         ;; description to the destination heading title.
@@ -4763,8 +4815,32 @@ links."
                        (push (set (make-local-variable var) val) vars)))))
 
             (insert (org-element-interpret-data ast))
+            ;; `org-element-interpret-data' emits file links without the
+            ;; "file:" type prefix for relative paths.  On re-parse those
+            ;; become fuzzy links whose path is the dummy file name
+            ;; (optionally with "::#anchor"), and Org 9.7+ aborts export
+            ;; with "Unable to resolve link".  Force the file type back.
+            (org-hugo--ensure-preprocessed-file-link-types)
             (set-buffer-modified-p nil)))
         buffer))))
+
+(defun org-hugo--ensure-preprocessed-file-link-types ()
+  "Rewrite dummy cross-post link targets to explicit file: links.
+
+Call in the pre-processed buffer after `org-element-interpret-data'.
+See `org-hugo--get-pre-processed-buffer'."
+  (let ((re (concat "\\[\\[\\(?1:\\(?:file:\\)?\\(?2:[^]|]*?"
+                    (regexp-quote org-hugo--preprocessed-buffer-dummy-file-suffix)
+                    "\\)\\(?3:::\\(?4:[^]|]*\\)\\)?\\)\\]")))
+    (goto-char (point-min))
+    (while (re-search-forward re nil t)
+      (let ((path (match-string-no-properties 2))
+            (search (match-string-no-properties 4)))
+        (replace-match
+         (if (org-string-nw-p search)
+             (format "[[file:%s::%s]" path search)
+           (format "[[file:%s]" path))
+         t t)))))
 
 
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4982,11 +4982,16 @@ The optional argument NOERROR is passed to
         (buf-has-subtree (org-hugo--buffer-has-valid-post-subtree-p))
         ret)
 
-    ;; Auto-update `org-id-locations' if it's nil or empty hash table
-    ;; to avoid broken [[id:..]] type links.
+    ;; Auto-update `org-id-locations' for [[id:..]] links.
+    ;; Always rescan .org files in `default-directory'.  If we only
+    ;; update when the locations table is empty, a prior export that
+    ;; wrote a non-empty ~/.emacs.d/.org-id-locations (common in the
+    ;; test suite with shared HOME) skips sibling files and breaks
+    ;; cross-file id links such as the org-roam fixtures.
     (unless org-id-locations (org-id-locations-load))
-    (when (or (null org-id-locations) (zerop (hash-table-count org-id-locations)))
-      (org-id-update-id-locations (directory-files "." :full "\\.org$" :nosort) :silent))
+    (let ((local-org-files (directory-files "." :full "\\.org$" :nosort)))
+      (when local-org-files
+        (org-id-update-id-locations local-org-files :silent)))
 
     (org-hugo--cleanup)
 

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -3866,11 +3866,7 @@ a *:CUSTOM_ID* property, or an *:ID* property will be resolved to the
 appropriate location in the linked file, but links to targets will be
 resolved to the containing post.
 
-<2025-02-11 Tue> Below section throws this error
-#+begin_example
-Error: user-error ("Org export aborted.  Unable to resolve link: \"posts/link-destination.pre-processed.org::#external-target\"
-#+end_example
-**** COMMENT Links without descriptions
+**** Links without descriptions
 - Link to CUSTOM_ID outside the same post: [[#external-target]]
 - Link to ID outside the same post: [[id:de0df718-f9b4-4449-bb0a-eb4402fa5fcb]]
 - Link to target outside the same post: [[*External target]]
@@ -3879,7 +3875,7 @@ Error: user-error ("Org export aborted.  Unable to resolve link: \"posts/link-de
 - Link to subtree by ID: [[id:1e5e0bcd-caea-40ad-a75b-e488634c2678]]
 - Link to subtree by heading: [[*Link destination]]
 - Link to a subtree with custom Hugo slug: [[*Slug Front-matter]]
-**** COMMENT Links with descriptions
+**** Links with descriptions
 - [[#external-target][Link to CUSTOM_ID outside the same post]]
 - [[id:de0df718-f9b4-4449-bb0a-eb4402fa5fcb][Link to ID outside the same post]]
 - [[*External target][Link to target outside the same post]]

--- a/test/site/content/posts/citation-csl-tr.md
+++ b/test/site/content/posts/citation-csl-tr.md
@@ -18,8 +18,7 @@ auto-inserted.
 
 ## Referanslar
 
-<style>.csl-left-margin{float: left; padding-right: 0em;}
- .csl-right-inline{margin: 0 0 0 1em;}</style><div class="csl-bib-body">
+<div class="csl-bib-body">
   <div class="csl-entry"><a id="citeproc_bib_item_1"></a>
     <div class="csl-left-margin">[1]</div><div class="csl-right-inline">m. org, C. Syntax, M. List, and T. Effort, “Elegant citations with org-mode,” <i>Journal of plain text formats</i>, vol. 42, no. 1, pp. 2–3, 2021.</div>
   </div>

--- a/test/site/content/posts/citation-csl.md
+++ b/test/site/content/posts/citation-csl.md
@@ -15,8 +15,7 @@ Below, the "References" heading will be auto-inserted.
 
 ## References
 
-<style>.csl-left-margin{float: left; padding-right: 0em;}
- .csl-right-inline{margin: 0 0 0 1em;}</style><div class="csl-bib-body">
+<div class="csl-bib-body">
   <div class="csl-entry"><a id="citeproc_bib_item_1"></a>
     <div class="csl-left-margin">[1]</div><div class="csl-right-inline">m. org, C. Syntax, M. List, and T. Effort, “Elegant citations with org-mode,” <i>Journal of plain text formats</i>, vol. 42, no. 1, pp. 2–3, 2021.</div>
   </div>

--- a/test/site/content/posts/figure-shortcode-and-attr-html.md
+++ b/test/site/content/posts/figure-shortcode-and-attr-html.md
@@ -49,7 +49,7 @@ Below, the same caption is set using the `#+attr_html` method instead:
 
 Some text before image.
 
-<span class="timestamp-wrapper"><span class="timestamp">&lt;2025-02-11 Tue&gt; </span></span> Fix export of standalone images.
+<span class="timestamp-wrapper"><span class="timestamp">&lt;2025-02-11 Tue&gt;</span></span> Fix export of standalone images.
 
 _Enter a new line after the image link so that it's in an "Org
 paragraph" that contains just that image. That tells Org that that

--- a/test/site/content/posts/links-outside-the-same-post.md
+++ b/test/site/content/posts/links-outside-the-same-post.md
@@ -38,11 +38,29 @@ a **:CUSTOM_ID** property, or an **:ID** property will be resolved to the
 appropriate location in the linked file, but links to targets will be
 resolved to the containing post.
 
-<span class="timestamp-wrapper"><span class="timestamp">&lt;2025-02-11 Tue&gt; </span></span> Below section throws this error
 
-```text
-Error: user-error ("Org export aborted.  Unable to resolve link: \"posts/link-destination.pre-processed.org::#external-target\"
-```
+### Links without descriptions {#links-without-descriptions}
+
+-   Link to CUSTOM_ID outside the same post: [External target]({{< relref "link-destination#external-target" >}})
+-   Link to ID outside the same post: [External target]({{< relref "link-destination#external-target" >}})
+-   Link to target outside the same post: [External target]({{< relref "link-destination#external-target" >}})
+-   Another link to target outside the same post: [External target with **bold** and _italic_]({{< relref "link-destination#external-target-with-bold-and-italic" >}})
+-   Link to subtree by CUSTOM_ID: [Link destination]({{< relref "link-destination" >}})
+-   Link to subtree by ID: [Link destination]({{< relref "link-destination" >}})
+-   Link to subtree by heading: [Link destination]({{< relref "link-destination" >}})
+-   Link to a subtree with custom Hugo slug: [Slug Front-matter]({{< relref "slug-front-matter" >}})
+
+
+### Links with descriptions {#links-with-descriptions}
+
+-   [Link to CUSTOM_ID outside the same post]({{< relref "link-destination#external-target" >}})
+-   [Link to ID outside the same post]({{< relref "link-destination#external-target" >}})
+-   [Link to target outside the same post]({{< relref "link-destination#external-target" >}})
+-   [Another link to target outside the same post]({{< relref "link-destination#external-target-with-bold-and-italic" >}})
+-   [Link to subtree by CUSTOM_ID]({{< relref "link-destination" >}})
+-   [Link to subtree by ID]({{< relref "link-destination" >}})
+-   [Link to subtree by heading]({{< relref "link-destination" >}})
+-   [Link to a subtree with custom Hugo slug]({{< relref "slug-front-matter" >}})
 
 
 ## Internal target {#internal-target}

--- a/test/site/content/posts/source-block-caption.md
+++ b/test/site/content/posts/source-block-caption.md
@@ -17,5 +17,5 @@ prefix = /dir/where/you/want/to/install/org # Default: /usr/share
 ```
 <div class="src-block-caption">
   <span class="src-block-number">Code Snippet 2:</span>
-  Hello &#x2014; Caption with em-dash &#x2013; and &#x2013; en-dash
+  Hello &mdash; Caption with em-dash &ndash; and &ndash; en-dash
 </div>

--- a/test/site/content/posts/table-caption.md
+++ b/test/site/content/posts/table-caption.md
@@ -31,7 +31,7 @@ Some more text.
 
 <div class="table-caption">
   <span class="table-number">Table 3:</span>
-  <span class="underline">Third</span> table &#x2014; Caption with em-dash &#x2013; and &#x2013; en-dash
+  <span class="underline">Third</span> table &mdash; Caption with em-dash &ndash; and &ndash; en-dash
 </div>
 
 | h1  | h2  | h3 |

--- a/test/site/content/posts/table-styling.md
+++ b/test/site/content/posts/table-styling.md
@@ -294,7 +294,7 @@ block.
 <div class="ox-hugo-table sane-table">
 <div class="table-caption">
   <span class="table-number">Table 9:</span>
-  Sane Table &#x2014; with minimal styling
+  Sane Table &mdash; with minimal styling
 </div>
 
 | Name | ID    | Favorite Color |


### PR DESCRIPTION
## Summary

Same-file cross-post links (`[[*Other post]]`, `[[#custom-id]]`, `[[id:...]]` pointing at another `EXPORT_FILE_NAME` subtree) break under Org 9.7+: export aborts with

```text
Unable to resolve link: "posts/foo.pre-processed.org::#anchor"
```

This is the failure that left the cross-post examples under *Links outside the same post* commented out, and the reason #755 only rewrote docs to avoid `[[*Heading]]` / relref macros.

## Cause

1. Pre-processing rewrites out-of-subtree links to dummy `file:` paths with the `.pre-processed.org` suffix.
2. `org-element-interpret-data` emits those links **without** the `file:` type for relative paths.
3. Re-parse treats them as **fuzzy** links whose path is the whole dummy name (including `::#anchor`).
4. Org 9.7+ then fails resolution instead of ignoring the missing file.

A second issue: same-file `id:` links were skipped in pre-processing whenever `org-id-find-id-file` returned a path, including the **current** file, so they never got rewritten to relrefs.

## Fix

- Store dummy file path and search option separately (`:path` / `:search-option`), not as one string in `:path`.
- After interpret, force `file:` back onto dummy targets (`org-hugo--ensure-preprocessed-file-link-types`).
- Only skip `id:` rewrite when the id lives in a **different** Org file.
- In `org-hugo-link`, still accept fuzzy paths that look like dummy pre-processed files (safety net).
- Re-enable the previously commented cross-post link tests in `test/site/content-org/all-posts.org`.
- Refresh golden `test/site/content/posts/links-outside-the-same-post.md` from a live Org 9.7+ export.

## Test plan

- [x] Minimal two-subtree Org file: custom-id, heading, id, and whole-post links export to `{{< relref "dest-post..." >}}` without error (Org 9.7.11, Emacs 30.2).
- [x] Re-export `test/site/content-org/all-posts.org` *Links outside the same post* and update golden `links-outside-the-same-post.md` (commit on this branch).
- [ ] Full `make -j1 test` suite not re-run for this open; CI / maintainer can exercise the suite against the refreshed golden.

## Notes

Complements #755 (doc workaround). Prefer fixing the exporter so in-file `[[*Post heading]]` works again rather than avoiding those links in the manual.
