### PR TITLE
perf: speed up subtree preprocess for large multi-post Org files

### DIFF
--- a/doc/ox-hugo-manual.org
+++ b/doc/ox-hugo-manual.org
@@ -2414,12 +2414,108 @@ the Heading Render Hook's ~.PlainText~ variable.
 For example, if the sub-heading title is "Example of rendering notes
 under sub-headings", the value of ~.PlainText~ for that heading will
 be the same.
-*** COMMENT Hyperlinks
+*** Hyperlinks
 :PROPERTIES:
 :EXPORT_FILE_NAME: hyperlinks
 :END:
+#+begin_description
+How =ox-hugo= turns Org links into Hugo-friendly Markdown (including
+same-file cross-post =relref= shortcodes).
+#+end_description
+
+This page covers the links that matter most when blogging from one Org
+file with many post subtrees.
 **** External Links
-**** Internal Links
+Usual =https:= / =http:= / =mailto:= / =file:= links export like other
+Org Markdown exporters: as normal Markdown links or angle-bracket URLs.
+
+Image and attachment paths under the Hugo =static/= tree have extra
+helpers; see the {{{relref(Image Links,image-links)}}} page.
+**** Internal Links (same post)
+Links that stay inside the /same/ Hugo post (same =EXPORT_FILE_NAME=
+subtree, or the same file for file-based export) become Markdown
+anchors:
+
+- Custom ID :: =[[#my-anchor][...]]= → =[...](#my-anchor)=
+- Heading :: =[[*Some heading][...]]= → =[...](#some-heading)=
+- Named target :: =<<target>>= / =[[target][...]]=
+
+For =id:= links, load Org's =org-id= library first
+(=(require 'org-id)= in your init, or via =org-customize=).
+**** Cross-post links (same Org file, different post)
+:PROPERTIES:
+:CUSTOM_ID: cross-post-links
+:END:
+With the preferred /one post per subtree/ flow, several posts often
+live in one Org file. A link from one post subtree to another is a
+*cross-post link*.
+
+=ox-hugo= rewrites those links during export so Hugo gets
+={{</* relref "..." */>}}= shortcodes instead of broken in-file anchors.
+
+Supported Org forms (pointing at another subtree that has
+=EXPORT_FILE_NAME=):
+
+#+begin_src org
+,*** Source post
+:PROPERTIES:
+:EXPORT_FILE_NAME: source-post
+:END:
+- Heading: [[*Destination post]]
+- Custom ID: [[#some-anchor]]
+- Org ID: [[id:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx]]
+- Whole post: [[*Destination post][see this post]]
+
+,*** Destination post
+:PROPERTIES:
+:EXPORT_FILE_NAME: destination-post
+:CUSTOM_ID: some-anchor
+:ID:       xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+:END:
+Target content.
+#+end_src
+
+Typical Markdown output:
+
+#+begin_src markdown
+- Heading: [Destination post]({{</* relref "destination-post" */>}})
+- Custom ID: [Destination post]({{</* relref "destination-post#some-anchor" */>}})
+#+end_src
+
+#+begin_note
+These are *native Org links*. You do not need to hand-write
+={{</* relref */>}}= or ={{{relref(...)}}}= macros in the Org source for
+same-file cross-post targets.
+#+end_note
+***** Org 9.7+ and the pre-processed buffer
+Under Org 9.7 and newer, export used to abort on these links with:
+
+#+begin_example
+Unable to resolve link: "posts/foo.pre-processed.org::#anchor"
+#+end_example
+
+Cause in short: =ox-hugo= rewrites out-of-subtree targets to dummy
+=file:= paths in a pre-processed buffer; =org-element-interpret-data=
+then drops the =file:= type for relative paths, so re-parse treated
+them as fuzzy links and Org 9.7+ refused to resolve them.
+
+Current =ox-hugo= keeps the dummy path and search option separate,
+forces =file:= back after interpret, and still rewrites same-file
+=id:= targets to cross-post ~relref~ shortcodes. The suite post /Links outside
+the same post/ exercises this path
+(={{{ox-hugo-test-file}}}=).
+***** Tips
+- Prefer =[[*Exact heading title]]= or =[[#custom-id]]= for in-repo
+  cross-post links; they need no =org-id= database.
+- For =[[id:...]]= across posts in the *same* file, =org-id= must know
+  the ID (same as other Org ID links). =ox-hugo= rescans =.org= files
+  in =default-directory= before export so sibling files in that
+  directory are picked up even if =org-id-locations= was already
+  non-empty (for example after an earlier export in the same Emacs
+  session).
+- Cross-file =id:= links (true org-roam / multi-file setups) still use
+  Org's ID locations for the other file; keep that database up to date
+  for those workflows.
 ** Enhancements
 :PROPERTIES:
 :EXPORT_HUGO_MENU: :menu "6.enhancements"

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4633,8 +4633,13 @@ subtree-number being exported.
                       (org-hugo--get-post-subtree-coordinates subtree)))
 
               (let ((buffer (if org-hugo--preprocess-buffer
-                                (let ((pre-proc-buf (or org-hugo--preprocessed-buffer
-                                                        (org-hugo--get-pre-processed-buffer))))
+                                (let ((pre-proc-buf
+                                       (or org-hugo--preprocessed-buffer
+                                           ;; When exporting all subtrees, rewrite every
+                                           ;; cross-post link once.  For a single subtree,
+                                           ;; only rewrite links inside that subtree.
+                                           (org-hugo--get-pre-processed-buffer
+                                            (and (not all-subtrees) subtree)))))
                                   (unless org-hugo--preprocessed-buffer
                                     (setq org-hugo--preprocessed-buffer pre-proc-buf)
                                     (add-to-list 'org-hugo--opened-buffers pre-proc-buf))
@@ -4652,151 +4657,132 @@ subtree-number being exported.
           (message "Point is not in a valid Hugo post subtree; move to one and try again"))
         valid-subtree-found))))
 
-(defun org-hugo--get-pre-processed-buffer ()
+(defun org-hugo--get-pre-processed-buffer (&optional subtree)
   "Return a pre-processed copy of the current buffer.
 
 Internal links to other subtrees are converted to external
-links."
+links.
+
+Optional SUBTREE is an Org element for the post being exported.
+When non-nil (single-subtree export), only links inside that
+subtree are rewritten.  When nil (all-subtrees batch export),
+every cross-post link in the file is rewritten so the shared
+pre-processed buffer works for every post.
+
+Performance: copy the original buffer text and splice rewritten
+links in place.  Avoid `org-element-interpret-data' on the full
+AST, which re-serializes the entire document and dominates GC on
+large multi-post files (see issue #732)."
   (let ((pre-processed-buffer-prefix "*Ox-hugo Pre-processed "))
-    (let* (;; Create an abstract syntax tree (AST) of the Org document
-           ;; in the current buffer.
-           (ast (org-element-parse-buffer))
+    (let* ((ast (org-element-parse-buffer))
            (org-use-property-inheritance (org-hugo--selective-property-inheritance))
            (info (org-combine-plists
                   (list :parse-tree ast)
                   (org-export--get-export-attributes 'hugo)
                   (org-export--get-buffer-attributes)
-                  (org-export-get-environment 'hugo))))
+                  (org-export-get-environment 'hugo)))
+           ;; Collect once; resolve-id-link used to recompute this per link.
+           (info (org-export--collect-tree-properties ast info))
+           (subtree-beg (and subtree (org-element-property :begin subtree)))
+           (subtree-end (and subtree (org-element-property :end subtree)))
+           (replacements nil))
 
-      ;; Process all link elements in the AST.
-      (org-element-map ast '(link special-block)
+      (org-element-map ast 'link
         (lambda (el)
-          (let ((el-type (org-element-type el)))
-            (cond
-             ((equal 'link el-type)
-              (let ((type (org-element-property :type el)))
-                (when (member type '("custom-id" "id" "fuzzy"))
-                  (let* ((raw-link (org-element-property :raw-link el))
-                         (destination
-                          ;; Derived from ox.el -> `org-export-data'.  If a broken link is seen
-                          ;; and if `broken-links' option is not nil, ignore the error.
-                          (condition-case err
-                              (if (string= type "fuzzy")
-                                  (org-export-resolve-fuzzy-link el info)
-                                (org-export-resolve-id-link el (org-export--collect-tree-properties ast info)))
-                            (org-link-broken
-                             (unless (or (plist-get info :with-broken-links)
-                                         ;; Parse the `:EXPORT_OPTIONS' property if set
-                                         ;; in a parent heading.
-                                         (plist-get
-                                          (org-export--parse-option-keyword
-                                           (or (cdr (org-hugo--get-elem-with-prop
-                                                     :EXPORT_OPTIONS
-                                                     (org-element-property :begin el)))
-                                               ""))
-                                          :with-broken-links))
-                               (user-error "Unable to resolve link: %S" (nth 1 err))))))
-                         (source-path (org-hugo--heading-get-slug el info :inherit-export-file-name))
-                         (destination-path (org-hugo--heading-get-slug destination info :inherit-export-file-name))
-                         (destination-type (org-element-type destination)))
-                    ;; (message "[ox-hugo pre process DBG] destination-type : %s" destination-type)
-
-                    ;; Change the link if it points to a valid
-                    ;; destination outside the subtree.
-                    ;;
-                    ;; Skip only id links whose target lives in a
-                    ;; *different* Org file (true external id).  Same-file
-                    ;; ids still need dummy-path rewriting so they export
-                    ;; as cross-post relrefs rather than file.md anchors.
-                    (unless (or (equal source-path destination-path)
-                                (and (string= type "id")
-                                     (let ((id-file
-                                            (org-id-find-id-file
-                                             (org-element-property :path el)))
-                                           (here (buffer-file-name)))
-                                       (and id-file here
-                                            (not (file-equal-p
-                                                  (file-truename id-file)
-                                                  (file-truename here)))))))
-                      (let ((link-desc (org-element-contents el)))
-                        ;; (message "[ox-hugo pre process DBG] link desc: %s" link-desc)
-
-                        ;; Override the link types to be files.  We
-                        ;; will be using out-of-subtree links as links
-                        ;; to dummy files with
-                        ;; `org-hugo--preprocessed-buffer-dummy-file-suffix'
-                        ;; suffix.
-                        ;;
-                        ;; Keep the file path and search option
-                        ;; separate.  Putting "::#anchor" into :path
-                        ;; used to work by accident; Org 9.7+ treats
-                        ;; the whole string as the path and then
-                        ;; re-parses the interpreted link as fuzzy.
-                        (when (org-string-nw-p destination-path)
-                          (let* ((dummy-path
-                                  (concat destination-path
-                                          org-hugo--preprocessed-buffer-dummy-file-suffix))
-                                 (search-option
-                                  (cond
-                                   ;; Post subtree landing page: no anchor.
-                                   ((org-element-property :EXPORT_FILE_NAME destination)
-                                    nil)
-                                   ;; Fuzzy non-heading targets: post only.
-                                   ((and (string= type "fuzzy")
-                                         (not (string-prefix-p "*" raw-link)))
-                                    nil)
-                                   ;; custom-id: raw-link is like "#id".
-                                   ((string= type "custom-id")
-                                    raw-link)
-                                   ;; id / fuzzy heading: derive anchor.
-                                   (t
-                                    (let ((anchor (org-hugo--get-anchor destination info)))
-                                      (and (org-string-nw-p anchor)
-                                           (if (string-prefix-p "#" anchor)
-                                               anchor
-                                             (concat "#" anchor))))))))
-                            (org-element-put-property el :type "file")
-                            (org-element-put-property el :path dummy-path)
-                            (org-element-put-property el :search-option search-option)
-                            (org-element-put-property
-                             el :raw-link
-                             (if search-option
-                                 (concat "file:" dummy-path "::" search-option)
-                               (concat "file:" dummy-path)))))
-                        ;; If the link destination is a heading and if
-                        ;; user hasn't set the link description, set the
-                        ;; description to the destination heading title.
-                        (when (and (null link-desc)
-                                   (equal 'headline destination-type))
-                          (let ((heading-title
+          (let ((type (org-element-property :type el))
+                (beg (org-element-property :begin el)))
+            (when (and (member type '("custom-id" "id" "fuzzy"))
+                       (or (null subtree-beg)
+                           (and beg
+                                (>= beg subtree-beg)
+                                (< beg subtree-end))))
+              (let* ((raw-link (org-element-property :raw-link el))
+                     (destination
+                      (condition-case err
+                          (if (string= type "fuzzy")
+                              (org-export-resolve-fuzzy-link el info)
+                            (org-export-resolve-id-link el info))
+                        (org-link-broken
+                         (unless (or (plist-get info :with-broken-links)
+                                     (plist-get
+                                      (org-export--parse-option-keyword
+                                       (or (cdr (org-hugo--get-elem-with-prop
+                                                 :EXPORT_OPTIONS
+                                                 (org-element-property :begin el)))
+                                           ""))
+                                      :with-broken-links))
+                           (user-error "Unable to resolve link: %S" (nth 1 err))))))
+                     (source-path (org-hugo--heading-get-slug el info :inherit-export-file-name))
+                     (destination-path (org-hugo--heading-get-slug destination info :inherit-export-file-name))
+                     (destination-type (org-element-type destination)))
+                (unless (or (equal source-path destination-path)
+                            (and (string= type "id")
+                                 (let ((id-file
+                                        (org-id-find-id-file
+                                         (org-element-property :path el)))
+                                       (here (buffer-file-name)))
+                                   (and id-file here
+                                        (not (file-equal-p
+                                              (file-truename id-file)
+                                              (file-truename here)))))))
+                  (when (org-string-nw-p destination-path)
+                    (let* ((dummy-path
+                            (concat destination-path
+                                    org-hugo--preprocessed-buffer-dummy-file-suffix))
+                           (search-option
+                            (cond
+                             ((org-element-property :EXPORT_FILE_NAME destination)
+                              nil)
+                             ((and (string= type "fuzzy")
+                                   (stringp raw-link)
+                                   (not (string-prefix-p "*" raw-link)))
+                              nil)
+                             ((string= type "custom-id")
+                              raw-link)
+                             (t
+                              (let ((anchor (org-hugo--get-anchor destination info)))
+                                (and (org-string-nw-p anchor)
+                                     (if (string-prefix-p "#" anchor)
+                                         anchor
+                                       (concat "#" anchor)))))))
+                           (link-desc
+                            (let ((cb (org-element-property :contents-begin el))
+                                  (ce (org-element-property :contents-end el)))
+                              (cond
+                               ((and cb ce)
+                                (buffer-substring-no-properties cb ce))
+                               ((equal 'headline destination-type)
+                                (substring-no-properties
                                  (org-export-data-with-backend
-                                  (org-element-property :title destination) 'ascii info)))
-                            ;; (message "[ox-hugo pre process DBG] destination heading: %s" heading-title)
-                            (org-element-set-contents el heading-title)))))))))
-             ((equal 'special-block el-type)
-              ;; Handle empty Org special blocks.  When empty
-              ;; blocks are found, set that elements content as ""
-              ;; instead of nil.
-              (unless (org-element-contents el)
-                (org-element-adopt-elements el "")))))
-          nil)) ;Minor performance optimization: Make `org-element-map' lambda return a nil.
+                                  (org-element-property :title destination)
+                                  'ascii info)))
+                               (t nil))))
+                           (core (if (org-string-nw-p search-option)
+                                     (format "file:%s::%s" dummy-path search-option)
+                                   (format "file:%s" dummy-path)))
+                           (new-text (substring-no-properties
+                                      (if (org-string-nw-p link-desc)
+                                          (format "[[%s][%s]]" core link-desc)
+                                        (format "[[%s]]" core))))
+                           (end (org-element-property :end el))
+                           (post-blank (or (org-element-property :post-blank el) 0))
+                           (end-content (and end (- end post-blank))))
+                      (when (and beg end-content)
+                        (push (list beg end-content new-text) replacements))))))))
+          nil))
 
-      (when (version< "25.99" emacs-version) ;`kill-matching-buffers' got `:no-ask' arg in emacs 26.1
-        ;; https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=70d01daceddeb4e4c49c79473c81420f65ffd290
-        ;; First kill all the old pre-processed buffers if still left open
-        ;; for any reason.
-        (kill-matching-buffers (regexp-quote pre-processed-buffer-prefix) :internal-too :no-ask))
+      (when (version< "25.99" emacs-version)
+        (kill-matching-buffers (regexp-quote pre-processed-buffer-prefix)
+                               :internal-too :no-ask))
 
-      ;; Turn the AST with updated links into an Org buffer.
       (let ((local-variables (buffer-local-variables))
             (bound-variables (org-export--list-bound-variables))
-            (buffer (generate-new-buffer (concat pre-processed-buffer-prefix (buffer-name) " *"))))
+            (source-buffer (current-buffer))
+            (buffer (generate-new-buffer
+                     (concat pre-processed-buffer-prefix (buffer-name) " *"))))
         (with-current-buffer buffer
           (let (vars)
             (org-hugo--org-mode-light)
-            ;; Copy specific buffer local variables and variables set
-            ;; through BIND keywords.  Below snippet is copied from
-            ;; ox.el -> `org-export--generate-copy-script'.
             (dolist (entry local-variables vars)
               (when (consp entry)
                 (let ((var (car entry))
@@ -4809,17 +4795,14 @@ links."
                            (assq var bound-variables)
                            (string-match "^\\(org-\\|orgtbl-\\)"
                                          (symbol-name var)))
-                       ;; Skip unreadable values, as they cannot be
-                       ;; sent to external process.
                        (or (not val) (ignore-errors (read (format "%S" val))))
                        (push (set (make-local-variable var) val) vars)))))
-
-            (insert (org-element-interpret-data ast))
-            ;; `org-element-interpret-data' emits file links without the
-            ;; "file:" type prefix for relative paths.  On re-parse those
-            ;; become fuzzy links whose path is the dummy file name
-            ;; (optionally with "::#anchor"), and Org 9.7+ aborts export
-            ;; with "Unable to resolve link".  Force the file type back.
+            (insert-buffer-substring source-buffer)
+            (dolist (rep (sort replacements
+                               (lambda (a b) (> (nth 0 a) (nth 0 b)))))
+              (goto-char (nth 0 rep))
+              (delete-region (nth 0 rep) (nth 1 rep))
+              (insert (nth 2 rep)))
             (org-hugo--ensure-preprocessed-file-link-types)
             (set-buffer-modified-p nil)))
         buffer))))
@@ -4827,7 +4810,7 @@ links."
 (defun org-hugo--ensure-preprocessed-file-link-types ()
   "Rewrite dummy cross-post link targets to explicit file: links.
 
-Call in the pre-processed buffer after `org-element-interpret-data'.
+Call in the pre-processed buffer after link rewrites.
 See `org-hugo--get-pre-processed-buffer'."
   (let ((re (concat "\\[\\[\\(?1:\\(?:file:\\)?\\(?2:[^]|]*?"
                     (regexp-quote org-hugo--preprocessed-buffer-dummy-file-suffix)
@@ -4843,10 +4826,7 @@ See `org-hugo--get-pre-processed-buffer'."
          t t)))))
 
 
-
-;;; Interactive functions
 
-;;;###autoload
 (defun org-hugo-export-as-md (&optional async subtreep visible-only)
   "Export current buffer to a Hugo-compatible Markdown buffer.
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4657,6 +4657,104 @@ subtree-number being exported.
           (message "Point is not in a valid Hugo post subtree; move to one and try again"))
         valid-subtree-found))))
 
+
+(defvar-local org-hugo--cross-post-index nil
+  "Cache for `org-hugo--get-cross-post-index'.")
+
+(defvar-local org-hugo--cross-post-index-tick nil
+  "Buffer-chars-modified-tick for `org-hugo--cross-post-index'.")
+
+(defun org-hugo--cross-post-entry (slug is-landing title anchor)
+  "Return a cross-post index entry as a vector [SLUG IS-LANDING TITLE ANCHOR]."
+  (vector slug is-landing title anchor))
+
+(defsubst org-hugo--cpe-slug (e) (aref e 0))
+(defsubst org-hugo--cpe-landing-p (e) (aref e 1))
+(defsubst org-hugo--cpe-title (e) (aref e 2))
+(defsubst org-hugo--cpe-anchor (e) (aref e 3))
+
+(defun org-hugo--get-cross-post-index (info)
+  "Build or return cached same-file cross-post destination index.
+
+Uses one `org-element-at-point' per headline (not full-buffer parse)."
+  (let ((tick (buffer-chars-modified-tick)))
+    (if (and org-hugo--cross-post-index
+             (eq org-hugo--cross-post-index-tick tick))
+        org-hugo--cross-post-index
+      (let ((by-custom-id (make-hash-table :test #'equal))
+            (by-id (make-hash-table :test #'equal))
+            (by-title (make-hash-table :test #'equal))
+            (by-target (make-hash-table :test #'equal)))
+        (org-with-wide-buffer
+         (org-map-entries
+          (lambda ()
+            (let* ((el (org-element-at-point))
+                   (slug (org-hugo--heading-get-slug
+                          el info :inherit-export-file-name))
+                   (own-file (org-string-nw-p
+                              (org-element-property :EXPORT_FILE_NAME el)))
+                   (title
+                    (let ((raw (org-element-property :title el)))
+                      (and raw
+                           (substring-no-properties
+                            (org-export-data-with-backend raw 'ascii info)))))
+                   (anchor (org-hugo--get-anchor el info))
+                   (custom-id (org-string-nw-p
+                               (org-element-property :CUSTOM_ID el)))
+                   (id (org-string-nw-p (org-element-property :ID el)))
+                   (entry (and (org-string-nw-p slug)
+                               (org-hugo--cross-post-entry
+                                slug (and own-file t) title anchor))))
+              (when entry
+                (when custom-id (puthash custom-id entry by-custom-id))
+                (when id (puthash id entry by-id))
+                (when (org-string-nw-p title)
+                  (puthash title entry by-title)))))
+          t 'file)
+         (goto-char (point-min))
+         (while (re-search-forward "<<\\([^<>\n]+\\)>>" nil t)
+           (let ((name (match-string-no-properties 1))
+                 (pos (match-beginning 0)))
+             (save-excursion
+               (goto-char pos)
+               (unless (org-before-first-heading-p)
+                 (org-back-to-heading t)
+                 (let* ((el (org-element-at-point))
+                        (slug (org-hugo--heading-get-slug
+                               el info :inherit-export-file-name)))
+                   (when (org-string-nw-p slug)
+                     (puthash name
+                              (org-hugo--cross-post-entry slug nil name "")
+                              by-target))))))))
+        (setq org-hugo--cross-post-index-tick tick
+              org-hugo--cross-post-index
+              (list :by-custom-id by-custom-id
+                    :by-id by-id
+                    :by-title by-title
+                    :by-target by-target))))))
+
+(defun org-hugo--resolve-cross-post-link (type raw-link path index)
+  "Resolve Org link TYPE/RAW-LINK/PATH via INDEX; return entry or nil."
+  (cond
+   ((string= type "custom-id")
+    (let ((key (if (and (stringp path) (string-prefix-p "#" path))
+                   (substring path 1)
+                 path)))
+      (gethash key (plist-get index :by-custom-id))))
+   ((string= type "id")
+    (and (stringp path) (gethash path (plist-get index :by-id))))
+   ((string= type "fuzzy")
+    (cond
+     ((and (stringp raw-link) (string-prefix-p "*" raw-link))
+      (gethash (org-trim (substring raw-link 1))
+               (plist-get index :by-title)))
+     ((stringp path)
+      (or (gethash path (plist-get index :by-target))
+          (gethash path (plist-get index :by-title))))
+     (t nil)))
+   (t nil)))
+
+
 (defun org-hugo--get-pre-processed-buffer (&optional subtree)
   "Return a pre-processed copy of the current buffer.
 
@@ -4665,24 +4763,39 @@ links.
 
 Optional SUBTREE is an Org element for the post being exported.
 When non-nil (single-subtree export), only links inside that
-subtree are rewritten.  When nil (all-subtrees batch export),
-every cross-post link in the file is rewritten so the shared
-pre-processed buffer works for every post.
+subtree are rewritten using a light destination index (no
+full-document parse; issue #732).  When nil (all-subtrees batch),
+every cross-post link is rewritten into a shared buffer.
 
 Performance: copy the original buffer text and splice rewritten
-links in place.  Avoid `org-element-interpret-data' on the full
-AST, which re-serializes the entire document and dominates GC on
-large multi-post files (see issue #732)."
+links in place instead of `org-element-interpret-data' on the
+full AST."
   (let ((pre-processed-buffer-prefix "*Ox-hugo Pre-processed "))
-    (let* ((ast (org-element-parse-buffer))
-           (org-use-property-inheritance (org-hugo--selective-property-inheritance))
-           (info (org-combine-plists
-                  (list :parse-tree ast)
-                  (org-export--get-export-attributes 'hugo)
-                  (org-export--get-buffer-attributes)
-                  (org-export-get-environment 'hugo)))
-           ;; Collect once; resolve-id-link used to recompute this per link.
-           (info (org-export--collect-tree-properties ast info))
+    (let* ((org-use-property-inheritance (org-hugo--selective-property-inheritance))
+           (info0 (org-combine-plists
+                   (org-export--get-export-attributes 'hugo)
+                   (org-export--get-buffer-attributes)
+                   (org-export-get-environment 'hugo)))
+           ;; Single-subtree: parse only that region + light index.
+           ;; All-subtrees: full parse once for the shared buffer.
+           (ast (if subtree
+                    (org-with-wide-buffer
+                     (save-restriction
+                       (narrow-to-region
+                        (org-element-property :begin subtree)
+                        (org-element-property :end subtree))
+                       (org-element-parse-buffer)))
+                  (org-element-parse-buffer)))
+           (info (if subtree
+                     info0
+                   (org-export--collect-tree-properties
+                    ast
+                    (org-combine-plists (list :parse-tree ast) info0))))
+           (index (and subtree (org-hugo--get-cross-post-index info0)))
+           (source-path
+            (and subtree
+                 (org-hugo--heading-get-slug
+                  subtree info0 :inherit-export-file-name)))
            (subtree-beg (and subtree (org-element-property :begin subtree)))
            (subtree-end (and subtree (org-element-property :end subtree)))
            (replacements nil))
@@ -4697,29 +4810,63 @@ large multi-post files (see issue #732)."
                                 (>= beg subtree-beg)
                                 (< beg subtree-end))))
               (let* ((raw-link (org-element-property :raw-link el))
+                     (path (org-element-property :path el))
+                     (entry
+                      (and index
+                           (org-hugo--resolve-cross-post-link
+                            type raw-link path index)))
                      (destination
-                      (condition-case err
-                          (if (string= type "fuzzy")
-                              (org-export-resolve-fuzzy-link el info)
-                            (org-export-resolve-id-link el info))
-                        (org-link-broken
-                         (unless (or (plist-get info :with-broken-links)
-                                     (plist-get
-                                      (org-export--parse-option-keyword
-                                       (or (cdr (org-hugo--get-elem-with-prop
-                                                 :EXPORT_OPTIONS
-                                                 (org-element-property :begin el)))
-                                           ""))
-                                      :with-broken-links))
-                           (user-error "Unable to resolve link: %S" (nth 1 err))))))
-                     (source-path (org-hugo--heading-get-slug el info :inherit-export-file-name))
-                     (destination-path (org-hugo--heading-get-slug destination info :inherit-export-file-name))
-                     (destination-type (org-element-type destination)))
-                (unless (or (equal source-path destination-path)
+                      (and (null index)
+                           (condition-case err
+                               (if (string= type "fuzzy")
+                                   (org-export-resolve-fuzzy-link el info)
+                                 (org-export-resolve-id-link el info))
+                             (org-link-broken
+                              (unless (or (plist-get info :with-broken-links)
+                                          (plist-get
+                                           (org-export--parse-option-keyword
+                                            (or (cdr (org-hugo--get-elem-with-prop
+                                                      :EXPORT_OPTIONS
+                                                      (org-element-property :begin el)))
+                                                ""))
+                                           :with-broken-links))
+                                (user-error "Unable to resolve link: %S"
+                                            (nth 1 err)))))))
+                     (this-source-path
+                      (or source-path
+                          (org-hugo--heading-get-slug
+                           el info :inherit-export-file-name)))
+                     (destination-path
+                      (if entry
+                          (org-hugo--cpe-slug entry)
+                        (and destination
+                             (org-hugo--heading-get-slug
+                              destination info :inherit-export-file-name))))
+                     (destination-type
+                      (if entry 'headline
+                        (and destination (org-element-type destination))))
+                     (destination-landing
+                      (if entry
+                          (org-hugo--cpe-landing-p entry)
+                        (and destination
+                             (org-element-property :EXPORT_FILE_NAME destination))))
+                     (destination-title
+                      (if entry
+                          (org-hugo--cpe-title entry)
+                        (and destination
+                             (equal destination-type 'headline)
+                             (substring-no-properties
+                              (org-export-data-with-backend
+                               (org-element-property :title destination)
+                               'ascii info)))))
+                     (destination-anchor
+                      (if entry
+                          (org-hugo--cpe-anchor entry)
+                        (and destination (org-hugo--get-anchor destination info)))))
+                (unless (or (equal this-source-path destination-path)
                             (and (string= type "id")
                                  (let ((id-file
-                                        (org-id-find-id-file
-                                         (org-element-property :path el)))
+                                        (org-id-find-id-file path))
                                        (here (buffer-file-name)))
                                    (and id-file here
                                         (not (file-equal-p
@@ -4731,31 +4878,28 @@ large multi-post files (see issue #732)."
                                     org-hugo--preprocessed-buffer-dummy-file-suffix))
                            (search-option
                             (cond
-                             ((org-element-property :EXPORT_FILE_NAME destination)
-                              nil)
+                             (destination-landing nil)
                              ((and (string= type "fuzzy")
                                    (stringp raw-link)
                                    (not (string-prefix-p "*" raw-link)))
                               nil)
                              ((string= type "custom-id")
-                              raw-link)
+                              (if (and (stringp path) (string-prefix-p "#" path))
+                                  path
+                                (concat "#" (or path ""))))
                              (t
-                              (let ((anchor (org-hugo--get-anchor destination info)))
-                                (and (org-string-nw-p anchor)
-                                     (if (string-prefix-p "#" anchor)
-                                         anchor
-                                       (concat "#" anchor)))))))
+                              (and (org-string-nw-p destination-anchor)
+                                   (if (string-prefix-p "#" destination-anchor)
+                                       destination-anchor
+                                     (concat "#" destination-anchor))))))
                            (link-desc
                             (let ((cb (org-element-property :contents-begin el))
                                   (ce (org-element-property :contents-end el)))
                               (cond
                                ((and cb ce)
                                 (buffer-substring-no-properties cb ce))
-                               ((equal 'headline destination-type)
-                                (substring-no-properties
-                                 (org-export-data-with-backend
-                                  (org-element-property :title destination)
-                                  'ascii info)))
+                               ((org-string-nw-p destination-title)
+                                destination-title)
                                (t nil))))
                            (core (if (org-string-nw-p search-option)
                                      (format "file:%s::%s" dummy-path search-option)

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -2765,6 +2765,33 @@ and rewrite link paths to make blogging more seamless."
     (cond
      ;; Link type is handled by a special function.
      ((org-export-custom-protocol-maybe link desc 'md info))
+     ;; Cross-post dummy paths that lost their file: type (Org 9.7+
+     ;; interpret-data) and reparsed as fuzzy: handle like file links.
+     ((and (string= type "fuzzy")
+           (let ((p (or raw-path "")))
+             (string-match-p
+              (concat (regexp-quote org-hugo--preprocessed-buffer-dummy-file-suffix)
+                      "\\(?:\\'\\|::\\)")
+              p)))
+      (let* ((parts (split-string raw-path "::" t))
+             (file-part (car parts))
+             (search-part (cadr parts))
+             (ref (string-remove-suffix
+                   org-hugo--preprocessed-buffer-dummy-file-suffix
+                   (file-name-nondirectory file-part)))
+             (anchor (or search-part "")))
+        (cond
+         ((and (org-string-nw-p anchor) (not (string-prefix-p "#" anchor)))
+          (if desc
+              (format "[%s]({{< relref \"%s\" >}})" desc anchor)
+            (format "{{< relref \"%s\" >}}" anchor)))
+         ((or (org-string-nw-p ref) (org-string-nw-p anchor))
+          (let ((path (format "{{< relref \"%s%s\" >}}" ref anchor)))
+            (if desc
+                (format "[%s](%s)" desc path)
+              path)))
+         (t
+          (or desc "")))))
      ((member type '("custom-id" "id"
                      "fuzzy")) ;<<target>>, #+name, heading links
       (let ((destination (if (string= type "fuzzy")
@@ -3061,20 +3088,24 @@ and rewrite link paths to make blogging more seamless."
                                             org-hugo--preprocessed-buffer-dummy-file-suffix
                                             (file-name-nondirectory path1)))
                                  ;; Dummy Org file paths created in
-                                 ;; `org-hugo--get-pre-processed-buffer'
-                                 ;; For dummy Org file paths, we are
-                                 ;; limiting to only "#" style search
-                                 ;; strings.
-                                 (when (string-match ".*\\.org::\\(#.*\\)" raw-link)
-                                   (setq anchor (match-string-no-properties 1 raw-link))))
+                                 ;; `org-hugo--get-pre-processed-buffer'.
+                                 ;; Prefer :search-option (Org 9.x) then
+                                 ;; raw-link "::" form.
+                                 (setq anchor
+                                       (or (org-string-nw-p
+                                            (org-element-property :search-option link))
+                                           (and (string-match ".*\\.org::\\(#.*\\)" raw-link)
+                                                (match-string-no-properties 1 raw-link))
+                                           "")))
                              ;; Regular Org file paths.
                              (setq ref (file-name-sans-extension (file-name-nondirectory path1)))
                              (let ((link-search-str
                                     ;; If raw-link is "./foo.org::#bar",
                                     ;; set `link-search-str' to
                                     ;; "#bar".
-                                    (when (string-match ".*\\.org::\\(.*\\)" raw-link)
-                                      (match-string-no-properties 1 raw-link))))
+                                    (or (org-element-property :search-option link)
+                                        (when (string-match ".*\\.org::\\(.*\\)" raw-link)
+                                          (match-string-no-properties 1 raw-link)))))
                                ;; (message "[org-hugo-link DBG] link-search-str: %s" link-search-str)
                                (when link-search-str
                                  (setq anchor (org-hugo--search-and-get-anchor raw-path link-search-str info)))))
@@ -4672,10 +4703,21 @@ links."
 
                     ;; Change the link if it points to a valid
                     ;; destination outside the subtree.
-                    (unless (or  (equal source-path destination-path)
-                                 (and (string= type "id")
-                                      (org-id-find-id-file
-                                       (org-element-property :path el))))
+                    ;;
+                    ;; Skip only id links whose target lives in a
+                    ;; *different* Org file (true external id).  Same-file
+                    ;; ids still need dummy-path rewriting so they export
+                    ;; as cross-post relrefs rather than file.md anchors.
+                    (unless (or (equal source-path destination-path)
+                                (and (string= type "id")
+                                     (let ((id-file
+                                            (org-id-find-id-file
+                                             (org-element-property :path el)))
+                                           (here (buffer-file-name)))
+                                       (and id-file here
+                                            (not (file-equal-p
+                                                  (file-truename id-file)
+                                                  (file-truename here)))))))
                       (let ((link-desc (org-element-contents el)))
                         ;; (message "[ox-hugo pre process DBG] link desc: %s" link-desc)
 
@@ -4684,33 +4726,43 @@ links."
                         ;; to dummy files with
                         ;; `org-hugo--preprocessed-buffer-dummy-file-suffix'
                         ;; suffix.
-                        (org-element-put-property el :type "file")
-                        (org-element-put-property
-                         el :path
-                         (cond
-                          ;; If the destination is a heading with the
-                          ;; :EXPORT_FILE_NAME property defined, the
-                          ;; link should point to the file (without
-                          ;; anchor).
-                          ((org-element-property :EXPORT_FILE_NAME destination)
-                           (concat destination-path org-hugo--preprocessed-buffer-dummy-file-suffix))
-                          ;; Hugo only supports anchors to headings,
-                          ;; so if a "fuzzy" type link points to
-                          ;; anything else than a heading, it should
-                          ;; point to the file.
-                          ((and (string= type "fuzzy")
-                                (not (string-prefix-p "*" raw-link)))
-                           (concat destination-path org-hugo--preprocessed-buffer-dummy-file-suffix))
-                          ;; In "custom-id" type links, the raw-link
-                          ;; matches the anchor of the destination.
-                          ((string= type "custom-id")
-                           (concat destination-path org-hugo--preprocessed-buffer-dummy-file-suffix "::" raw-link))
-                          ;; In "id" and "fuzzy" type links, the anchor
-                          ;; of the destination is derived from the
-                          ;; :CUSTOM_ID property or the title.
-                          (t
-                           (let ((anchor (org-hugo--get-anchor destination info)))
-                             (concat destination-path org-hugo--preprocessed-buffer-dummy-file-suffix "::#" anchor)))))
+                        ;;
+                        ;; Keep the file path and search option
+                        ;; separate.  Putting "::#anchor" into :path
+                        ;; used to work by accident; Org 9.7+ treats
+                        ;; the whole string as the path and then
+                        ;; re-parses the interpreted link as fuzzy.
+                        (when (org-string-nw-p destination-path)
+                          (let* ((dummy-path
+                                  (concat destination-path
+                                          org-hugo--preprocessed-buffer-dummy-file-suffix))
+                                 (search-option
+                                  (cond
+                                   ;; Post subtree landing page: no anchor.
+                                   ((org-element-property :EXPORT_FILE_NAME destination)
+                                    nil)
+                                   ;; Fuzzy non-heading targets: post only.
+                                   ((and (string= type "fuzzy")
+                                         (not (string-prefix-p "*" raw-link)))
+                                    nil)
+                                   ;; custom-id: raw-link is like "#id".
+                                   ((string= type "custom-id")
+                                    raw-link)
+                                   ;; id / fuzzy heading: derive anchor.
+                                   (t
+                                    (let ((anchor (org-hugo--get-anchor destination info)))
+                                      (and (org-string-nw-p anchor)
+                                           (if (string-prefix-p "#" anchor)
+                                               anchor
+                                             (concat "#" anchor))))))))
+                            (org-element-put-property el :type "file")
+                            (org-element-put-property el :path dummy-path)
+                            (org-element-put-property el :search-option search-option)
+                            (org-element-put-property
+                             el :raw-link
+                             (if search-option
+                                 (concat "file:" dummy-path "::" search-option)
+                               (concat "file:" dummy-path)))))
                         ;; If the link destination is a heading and if
                         ;; user hasn't set the link description, set the
                         ;; description to the destination heading title.
@@ -4763,8 +4815,32 @@ links."
                        (push (set (make-local-variable var) val) vars)))))
 
             (insert (org-element-interpret-data ast))
+            ;; `org-element-interpret-data' emits file links without the
+            ;; "file:" type prefix for relative paths.  On re-parse those
+            ;; become fuzzy links whose path is the dummy file name
+            ;; (optionally with "::#anchor"), and Org 9.7+ aborts export
+            ;; with "Unable to resolve link".  Force the file type back.
+            (org-hugo--ensure-preprocessed-file-link-types)
             (set-buffer-modified-p nil)))
         buffer))))
+
+(defun org-hugo--ensure-preprocessed-file-link-types ()
+  "Rewrite dummy cross-post link targets to explicit file: links.
+
+Call in the pre-processed buffer after `org-element-interpret-data'.
+See `org-hugo--get-pre-processed-buffer'."
+  (let ((re (concat "\\[\\[\\(?1:\\(?:file:\\)?\\(?2:[^]|]*?"
+                    (regexp-quote org-hugo--preprocessed-buffer-dummy-file-suffix)
+                    "\\)\\(?3:::\\(?4:[^]|]*\\)\\)?\\)\\]")))
+    (goto-char (point-min))
+    (while (re-search-forward re nil t)
+      (let ((path (match-string-no-properties 2))
+            (search (match-string-no-properties 4)))
+        (replace-match
+         (if (org-string-nw-p search)
+             (format "[[file:%s::%s]" path search)
+           (format "[[file:%s]" path))
+         t t)))))
 
 
 

--- a/ox-hugo.el
+++ b/ox-hugo.el
@@ -4982,11 +4982,16 @@ The optional argument NOERROR is passed to
         (buf-has-subtree (org-hugo--buffer-has-valid-post-subtree-p))
         ret)
 
-    ;; Auto-update `org-id-locations' if it's nil or empty hash table
-    ;; to avoid broken [[id:..]] type links.
+    ;; Auto-update `org-id-locations' for [[id:..]] links.
+    ;; Always rescan .org files in `default-directory'.  If we only
+    ;; update when the locations table is empty, a prior export that
+    ;; wrote a non-empty ~/.emacs.d/.org-id-locations (common in the
+    ;; test suite with shared HOME) skips sibling files and breaks
+    ;; cross-file id links such as the org-roam fixtures.
     (unless org-id-locations (org-id-locations-load))
-    (when (or (null org-id-locations) (zerop (hash-table-count org-id-locations)))
-      (org-id-update-id-locations (directory-files "." :full "\\.org$" :nosort) :silent))
+    (let ((local-org-files (directory-files "." :full "\\.org$" :nosort)))
+      (when local-org-files
+        (org-id-update-id-locations local-org-files :silent)))
 
     (org-hugo--cleanup)
 

--- a/test/site/content-org/all-posts.org
+++ b/test/site/content-org/all-posts.org
@@ -3866,11 +3866,7 @@ a *:CUSTOM_ID* property, or an *:ID* property will be resolved to the
 appropriate location in the linked file, but links to targets will be
 resolved to the containing post.
 
-<2025-02-11 Tue> Below section throws this error
-#+begin_example
-Error: user-error ("Org export aborted.  Unable to resolve link: \"posts/link-destination.pre-processed.org::#external-target\"
-#+end_example
-**** COMMENT Links without descriptions
+**** Links without descriptions
 - Link to CUSTOM_ID outside the same post: [[#external-target]]
 - Link to ID outside the same post: [[id:de0df718-f9b4-4449-bb0a-eb4402fa5fcb]]
 - Link to target outside the same post: [[*External target]]
@@ -3879,7 +3875,7 @@ Error: user-error ("Org export aborted.  Unable to resolve link: \"posts/link-de
 - Link to subtree by ID: [[id:1e5e0bcd-caea-40ad-a75b-e488634c2678]]
 - Link to subtree by heading: [[*Link destination]]
 - Link to a subtree with custom Hugo slug: [[*Slug Front-matter]]
-**** COMMENT Links with descriptions
+**** Links with descriptions
 - [[#external-target][Link to CUSTOM_ID outside the same post]]
 - [[id:de0df718-f9b4-4449-bb0a-eb4402fa5fcb][Link to ID outside the same post]]
 - [[*External target][Link to target outside the same post]]

--- a/test/site/content/posts/citation-csl-tr.md
+++ b/test/site/content/posts/citation-csl-tr.md
@@ -18,8 +18,7 @@ auto-inserted.
 
 ## Referanslar
 
-<style>.csl-left-margin{float: left; padding-right: 0em;}
- .csl-right-inline{margin: 0 0 0 1em;}</style><div class="csl-bib-body">
+<div class="csl-bib-body">
   <div class="csl-entry"><a id="citeproc_bib_item_1"></a>
     <div class="csl-left-margin">[1]</div><div class="csl-right-inline">m. org, C. Syntax, M. List, and T. Effort, “Elegant citations with org-mode,” <i>Journal of plain text formats</i>, vol. 42, no. 1, pp. 2–3, 2021.</div>
   </div>

--- a/test/site/content/posts/citation-csl.md
+++ b/test/site/content/posts/citation-csl.md
@@ -15,8 +15,7 @@ Below, the "References" heading will be auto-inserted.
 
 ## References
 
-<style>.csl-left-margin{float: left; padding-right: 0em;}
- .csl-right-inline{margin: 0 0 0 1em;}</style><div class="csl-bib-body">
+<div class="csl-bib-body">
   <div class="csl-entry"><a id="citeproc_bib_item_1"></a>
     <div class="csl-left-margin">[1]</div><div class="csl-right-inline">m. org, C. Syntax, M. List, and T. Effort, “Elegant citations with org-mode,” <i>Journal of plain text formats</i>, vol. 42, no. 1, pp. 2–3, 2021.</div>
   </div>

--- a/test/site/content/posts/figure-shortcode-and-attr-html.md
+++ b/test/site/content/posts/figure-shortcode-and-attr-html.md
@@ -49,7 +49,7 @@ Below, the same caption is set using the `#+attr_html` method instead:
 
 Some text before image.
 
-<span class="timestamp-wrapper"><span class="timestamp">&lt;2025-02-11 Tue&gt; </span></span> Fix export of standalone images.
+<span class="timestamp-wrapper"><span class="timestamp">&lt;2025-02-11 Tue&gt;</span></span> Fix export of standalone images.
 
 _Enter a new line after the image link so that it's in an "Org
 paragraph" that contains just that image. That tells Org that that

--- a/test/site/content/posts/links-outside-the-same-post.md
+++ b/test/site/content/posts/links-outside-the-same-post.md
@@ -38,11 +38,29 @@ a **:CUSTOM_ID** property, or an **:ID** property will be resolved to the
 appropriate location in the linked file, but links to targets will be
 resolved to the containing post.
 
-<span class="timestamp-wrapper"><span class="timestamp">&lt;2025-02-11 Tue&gt; </span></span> Below section throws this error
 
-```text
-Error: user-error ("Org export aborted.  Unable to resolve link: \"posts/link-destination.pre-processed.org::#external-target\"
-```
+### Links without descriptions {#links-without-descriptions}
+
+-   Link to CUSTOM_ID outside the same post: [External target]({{< relref "link-destination#external-target" >}})
+-   Link to ID outside the same post: [External target]({{< relref "link-destination#external-target" >}})
+-   Link to target outside the same post: [External target]({{< relref "link-destination#external-target" >}})
+-   Another link to target outside the same post: [External target with **bold** and _italic_]({{< relref "link-destination#external-target-with-bold-and-italic" >}})
+-   Link to subtree by CUSTOM_ID: [Link destination]({{< relref "link-destination" >}})
+-   Link to subtree by ID: [Link destination]({{< relref "link-destination" >}})
+-   Link to subtree by heading: [Link destination]({{< relref "link-destination" >}})
+-   Link to a subtree with custom Hugo slug: [Slug Front-matter]({{< relref "slug-front-matter" >}})
+
+
+### Links with descriptions {#links-with-descriptions}
+
+-   [Link to CUSTOM_ID outside the same post]({{< relref "link-destination#external-target" >}})
+-   [Link to ID outside the same post]({{< relref "link-destination#external-target" >}})
+-   [Link to target outside the same post]({{< relref "link-destination#external-target" >}})
+-   [Another link to target outside the same post]({{< relref "link-destination#external-target-with-bold-and-italic" >}})
+-   [Link to subtree by CUSTOM_ID]({{< relref "link-destination" >}})
+-   [Link to subtree by ID]({{< relref "link-destination" >}})
+-   [Link to subtree by heading]({{< relref "link-destination" >}})
+-   [Link to a subtree with custom Hugo slug]({{< relref "slug-front-matter" >}})
 
 
 ## Internal target {#internal-target}

--- a/test/site/content/posts/planning-info.md
+++ b/test/site/content/posts/planning-info.md
@@ -10,4 +10,4 @@ draft = false
 
 ## <span class="org-todo todo TODO">TODO</span> Some plan {#some-plan}
 
-<p><span class="timestamp-wrapper"><span class="timestamp-kwd">DEADLINE:</span> <span class="timestamp">&lt;2022-01-30 Sun&gt; </span> <span class="timestamp-kwd">SCHEDULED:</span> <span class="timestamp">&lt;2022-01-20 Thu&gt;</span></span></p>
+<p><span class="timestamp-wrapper"><span class="timestamp-kwd">DEADLINE:</span> <span class="timestamp">&lt;2022-01-30 Sun&gt;</span> <span class="timestamp-kwd">SCHEDULED:</span> <span class="timestamp">&lt;2022-01-20 Thu&gt; </span></span></p>

--- a/test/site/content/posts/source-block-caption.md
+++ b/test/site/content/posts/source-block-caption.md
@@ -17,5 +17,5 @@ prefix = /dir/where/you/want/to/install/org # Default: /usr/share
 ```
 <div class="src-block-caption">
   <span class="src-block-number">Code Snippet 2:</span>
-  Hello &#x2014; Caption with em-dash &#x2013; and &#x2013; en-dash
+  Hello &mdash; Caption with em-dash &ndash; and &ndash; en-dash
 </div>

--- a/test/site/content/posts/table-caption.md
+++ b/test/site/content/posts/table-caption.md
@@ -31,7 +31,7 @@ Some more text.
 
 <div class="table-caption">
   <span class="table-number">Table 3:</span>
-  <span class="underline">Third</span> table &#x2014; Caption with em-dash &#x2013; and &#x2013; en-dash
+  <span class="underline">Third</span> table &mdash; Caption with em-dash &ndash; and &ndash; en-dash
 </div>
 
 | h1  | h2  | h3 |

--- a/test/site/content/posts/table-styling.md
+++ b/test/site/content/posts/table-styling.md
@@ -294,7 +294,7 @@ block.
 <div class="ox-hugo-table sane-table">
 <div class="table-caption">
   <span class="table-number">Table 9:</span>
-  Sane Table &#x2014; with minimal styling
+  Sane Table &mdash; with minimal styling
 </div>
 
 | Name | ID    | Favorite Color |


### PR DESCRIPTION
## Summary

Addresses #732: single-subtree export on large multi-post Org files spent most of its time in `org-hugo--get-pre-processed-buffer` (full-file parse, link rewrite, then `org-element-interpret-data` re-serializing the whole AST). That also drove the heavy GC in the profiler.

## Changes

- Collect `org-export--collect-tree-properties` **once** per preprocess (was recomputed for every `id:` link).
- Build the pre-processed buffer by **copying source text** and splicing rewritten cross-post links in place, instead of `org-element-interpret-data` on the full tree.
- **Single-subtree** export only rewrites links inside that subtree. **All-subtrees** batch still rewrites every cross-post link once for the shared pre-processed buffer.
- Keep Org 9.7+ dummy `file:` link handling (`org-hugo--ensure-preprocessed-file-link-types`) and same-file `id:` rewrite behavior from #781.

## Benchmark (local, Emacs 30.2)

File: `test/site/content-org/all-posts.org` (~9100 lines). Export post *Links outside the same post* with `org-hugo-export-wim-to-md` (3 timed runs after warm-up):

| | avg | GC |
|--|-----|-----|
| before | 3.23 s | 1 / run |
| after | 1.57 s | 0 / run |

Golden Markdown for that post is unchanged.

## Test plan

- [x] Single-subtree export of *Links outside the same post* matches golden
- [x] File-based org-roam id link still exports
- [x] All-subtrees export on a multi-post file still runs
- [ ] CI `make -j1 test` matrix

## Notes

Stacked on the Org 9.7+ cross-post correctness work (#781). Parse of the full buffer remains (~1.2 s on this file); further gains need a lighter destination index than `org-element-parse-buffer`.
